### PR TITLE
fix: simple example PyPy support workaround

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 10
+    after_n_builds: 13
 coverage:
   status:
     project:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C VERSION ${SKBUILD_PROJECT_VERSION})
 find_package(Python COMPONENTS Interpreter Development.Module)
 
 Python_add_library(_module MODULE src/module.c WITH_SOABI)
+set(Python_SOABI ${SKBUILD_SOABI})  # Required for PyPy support
 
 install(TARGETS _module DESTINATION ${SKBUILD_PROJECT_NAME})
 install(FILES src/simplest/__init__.py
@@ -99,11 +100,6 @@ Scikit-build-core will backport FindPython from CMake 3.24 to older versions of
 Python, and will handle PyPy for you if you are building from PyPy. You will
 need to install everything you want into the full final path inside site-modules
 (so you will usually prefix everything by the package name).
-
-> Warning: FindPython does not report the correct SOABI for PyPy due to the
-> SOABI being reported incorrectly. This will be fixed in the next release of
-> PyPy. And PyPy doesn't support skipping the SOABI to avoid clashes with
-> CPython. Pybind11's `pybind11_add_module` handles this correctly for you.
 
 More examples are in the
 [tests/packages](https://github.com/scikit-build/scikit-build-core/tree/main/tests/packages).

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,8 +34,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    # TODO: build seems to be muddling the order here without unbuffered
-    env = {"PIP_DISABLE_PIP_VERSION_CHECK": "1", "PYTHONUNBUFFERED": "1"}
+    env = {"PIP_DISABLE_PIP_VERSION_CHECK": "1"}
     session.install("-e.[test]")
     session.run("pytest", *session.posargs, env=env)
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -110,6 +110,13 @@ class Builder:
             cache_config[f"{prefix}_ROOT_DIR"] = sys.prefix
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
 
+        # Workaround for bug in PyPy and packaging that is not handled in CMake
+        # According to PEP 3149, SOABI and EXT_SUFFIX are interchangeable (and
+        # the latter is much more likely to be correct as it is used elsewhere)
+        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+        assert ext_suffix
+        cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
+
         self.config.init_cache(cache_config)
 
         # Adding CMake arguments set as environment variable

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.15...3.24)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C VERSION ${SKBUILD_PROJECT_VERSION})
 
 find_package(Python COMPONENTS COMPONENTS Interpreter Development.Module)
+set(Python_SOABI ${SKBUILD_SOABI})
 
 Python_add_library(_module MODULE src/module.c WITH_SOABI)
 

--- a/tests/test_simplest_c.py
+++ b/tests/test_simplest_c.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import pytest
@@ -11,10 +10,6 @@ SIMPLEST = DIR / "packages/simplest_c"
 
 @pytest.mark.compile
 @pytest.mark.configure
-@pytest.mark.skipif(
-    sys.implementation.name == "pypy",
-    reason="PyPy reports the wrong SOABI (fixed upstream)",
-)
 def test_pep517_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"
     dist.mkdir()


### PR DESCRIPTION
This is probably the best I can do unless this is fixed upstream. FindPython doesn't respect pre-set SOABI values, so it has to be added in user code.
