### PR TITLE
feat: prettier logging with config setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+color = [
+    "rich",
+]
 test = [
     "build",
     "cattrs >=22.2.0",

--- a/src/scikit_build_core/pyproject/init.py
+++ b/src/scikit_build_core/pyproject/init.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import functools
+import logging
+
+__all__ = ["setup_logging"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@functools.lru_cache(1)
+def setup_logging(log_level: str) -> None:
+
+    try:
+        import rich.logging
+        import rich.traceback
+    except ModuleNotFoundError:
+        logging.basicConfig(level=log_level)
+        return
+
+    FORMAT = "%(message)s"
+    logging.basicConfig(
+        level=log_level,
+        format=FORMAT,
+        datefmt="[%X]",
+        handlers=[rich.logging.RichHandler(level=log_level, rich_tracebacks=True)],
+    )
+
+    rich.traceback.install()

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -10,6 +10,8 @@ import pathspec
 from pyproject_metadata import StandardMetadata
 
 from .._compat import tomllib
+from ..settings.skbuild_settings import read_settings
+from .init import setup_logging
 
 __all__: list[str] = ["build_sdist"]
 
@@ -23,6 +25,9 @@ def build_sdist(
     # pylint: disable-next=unused-argument
     config_settings: dict[str, list[str] | str] | None = None,
 ) -> str:
+    settings = read_settings(Path("pyproject.toml"), config_settings or {})
+    setup_logging(settings.logging.level)
+
     sdist_dir = Path(sdist_directory)
 
     with Path("pyproject.toml").open("rb") as f:

--- a/src/scikit_build_core/pyproject/wheel.py
+++ b/src/scikit_build_core/pyproject/wheel.py
@@ -13,6 +13,7 @@ from ..builder.builder import Builder
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMakeConfig
 from ..settings.skbuild_settings import read_settings
+from .init import setup_logging
 
 __all__: list[str] = ["build_wheel"]
 
@@ -30,6 +31,8 @@ def build_wheel(
     config_settings: dict[str, list[str] | str] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
+    settings = read_settings(Path("pyproject.toml"), config_settings or {})
+    setup_logging(settings.logging.level)
 
     # We don't support preparing metadata yet
     assert metadata_directory is None

--- a/src/scikit_build_core/settings/cmake_model.py
+++ b/src/scikit_build_core/settings/cmake_model.py
@@ -19,6 +19,12 @@ class CMakeSettings:
 
 
 @dataclasses.dataclass
+class LogggingSettings:
+    level: str = "WARNING"
+
+
+@dataclasses.dataclass
 class ScikitBuildSettings:
     cmake: CMakeSettings
     ninja: NinjaSettings
+    logging: LogggingSettings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def pep518_wheelhouse(tmpdir_factory):
             "pathspec",
             "pybind11",
             "pyproject-metadata",
+            "rich",
             "setuptools",
             "tomli",
             "typing-extensions",

--- a/tests/packages/simple_pyproject_ext/pyproject.toml
+++ b/tests/packages/simple_pyproject_ext/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
+    "scikit_build_core[color]",
     "pybind11",
 ]
 build-backend = "scikit_build_core.build"

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -15,11 +15,13 @@ def test_skbuild_settings_default(tmp_path):
 
     assert settings.cmake.minimum_version == "3.15"
     assert settings.ninja.minimum_version == "1.5"
+    assert settings.logging.level == "WARNING"
 
 
 def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_CMAKE_MINIMUM_VERSION", "3.16")
     monkeypatch.setenv("SKBUILD_NINJA_MINIMUM_VERSION", "1.1")
+    monkeypatch.setenv("SKBUILD_LOGGING_LEVEL", "DEBUG")
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -30,6 +32,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
 
     assert settings.cmake.minimum_version == "3.16"
     assert settings.ninja.minimum_version == "1.1"
+    assert settings.logging.level == "DEBUG"
 
 
 def test_skbuild_settings_config_settings(tmp_path):
@@ -39,12 +42,14 @@ def test_skbuild_settings_config_settings(tmp_path):
     config_settings = {
         "scikit-build.cmake.minimum-version": "3.17",
         "scikit-build.ninja.minimum-version": "1.2",
+        "scikit-build.logging.level": "INFO",
     }
 
     settings = read_settings(pyproject_toml, config_settings)
 
     assert settings.cmake.minimum_version == "3.17"
     assert settings.ninja.minimum_version == "1.2"
+    assert settings.logging.level == "INFO"
 
 
 def test_skbuild_settings_pyproject_toml(tmp_path):
@@ -55,6 +60,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path):
             [tool.scikit-build]
             cmake.minimum-version = "3.18"
             ninja.minimum-version = "1.3"
+            logging.level = "ERROR"
             """
         ),
         encoding="utf-8",
@@ -66,3 +72,4 @@ def test_skbuild_settings_pyproject_toml(tmp_path):
 
     assert settings.cmake.minimum_version == "3.18"
     assert settings.ninja.minimum_version == "1.3"
+    assert settings.logging.level == "ERROR"


### PR DESCRIPTION
Not supported in setuptools mode. Will take some thought there.

To test this or similar things, you can run:

```bash
pipx run build --wheel
PIP_FIND_LINKS="dist" pipx run build --wheel tests/packages/simple_pyproject_ext -o dist -C scikit-build.log-level=NOTSET
```