### PR TITLE
fix: handle `PermissionError` in reading `libdir.is_dir()`

### DIFF
--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -21,22 +21,21 @@ def get_python_library() -> Path | None:
     multiarch = sysconfig.get_config_var("MULTIARCH")
     masd = sysconfig.get_config_var("multiarchsubdir")
 
-    try:
-        libdir_is_dir = libdir and ldlibrary and libdir.is_dir()
-    except PermissionError:
-        return None
-
-    if libdir_is_dir:
-        if multiarch:
-            if masd:
+    if libdir and ldlibrary:
+        try:
+            libdir_is_dir = libdir.is_dir()
+        except PermissionError:
+            return None
+        if libdir_is_dir:
+            if multiarch and masd:
                 if masd.startswith(os.sep):
                     masd = masd[len(os.sep) :]
                 libdir_masd = libdir / masd
                 if libdir_masd.is_dir():
                     libdir = libdir_masd
-        libpath = Path(libdir) / ldlibrary
-        if libpath.is_file():
-            return libpath
+            libpath = libdir / ldlibrary
+            if libpath.is_file():
+                return libpath
 
     framework_prefix = sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
     if framework_prefix and Path(framework_prefix).is_dir() and ldlibrary:

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -21,7 +21,12 @@ def get_python_library() -> Path | None:
     multiarch = sysconfig.get_config_var("MULTIARCH")
     masd = sysconfig.get_config_var("multiarchsubdir")
 
-    if libdir and ldlibrary and libdir.is_dir():
+    try:
+        libdir_is_dir = libdir.is_dir()
+    except PermissionError:
+        return None
+
+    if libdir and ldlibrary and libdir_is_dir:
         if multiarch:
             if masd:
                 if masd.startswith(os.sep):

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -22,11 +22,11 @@ def get_python_library() -> Path | None:
     masd = sysconfig.get_config_var("multiarchsubdir")
 
     try:
-        libdir_is_dir = libdir.is_dir()
+        libdir_is_dir = libdir and ldlibrary and libdir.is_dir()
     except PermissionError:
         return None
 
-    if libdir and ldlibrary and libdir_is_dir:
+    if libdir_is_dir:
         if multiarch:
             if masd:
                 if masd.startswith(os.sep):


### PR DESCRIPTION
`pyodide-build` fails with `scikit-build-core`, because `scikit-build-core` tries to `stat()` the `libdir` given by `sysconfig`. I'm not sure what the bug is here; should we be able to stat `LIBDIR` under `pyodide-build`? I suspect not if we're pretending to be the target environment, but I'm not certain. 

This is a very specific fix, and I suspect there's a nicer way of generalising this to the  class of "this isn't a conventional Python distribution" errors. However, this patch as-it-stands fixes `pyodide-build`, so it's a starting point for a proper fix.