### PR TITLE
feat: cmake_source_dir from scikit-build classic

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -234,12 +234,10 @@ Experimental. Supports only a single module, may not support extra Python files.
 ```python
 from setuptools import setup
 
-from scikit_build_core.setuptools.extension import CMakeExtension
-
 setup(
     name="cmake_example",
     version="0.0.1",
-    cmake_extensions=[CMakeExtension("cmake_example")],
+    cmake_source_dir=".",
     zip_safe=False,
     extras_require={"test": ["pytest>=6.0"]},
     python_requires=">=3.7",
@@ -269,3 +267,13 @@ target_compile_definitions(cmake_example
 
 install(TARGETS cmake_example DESTINATION .)
 ```
+
+This is built on top of CMakeExtenion, which looks like this:
+
+```
+from scikit_build_core.setuptoools.extension import CMakeExtension
+...
+cmake_extensions=[CMakeExtension("cmake_example")],
+```
+
+Which should eventually support multiple extensions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ Examples = "https://github.com/scikit-build/scikit-build-core/tree/main/tests/pa
 
 [project.entry-points."distutils.setup_keywords"]
 cmake_extensions = "scikit_build_core.setuptools.extension:cmake_extensions"
+cmake_source_dir = "scikit_build_core.setuptools.extension:cmake_source_dir"
 
 [tool.hatch]
 build.exclude = ["extern"]

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -118,3 +118,16 @@ def cmake_extensions(
     dist.ext_modules = (dist.ext_modules or []) + value
 
     add_cmake_extension(dist)
+
+
+def cmake_source_dir(
+    dist: Distribution, attr: Literal["cmake_source_dir"], value: str
+) -> None:
+    assert attr == "cmake_source_dir"
+    assert Path(value).is_dir()
+    assert dist.cmake_extensions is None, "Combining cmake_source_dir= and cmake_extensions= is not allowed"  # type: ignore[attr-defined]
+    name = dist.get_name().replace("-", "_")  # type: ignore[attr-defined]
+
+    extensions = [CMakeExtension(name, value)]
+    dist.cmake_extensions = extensions  # type: ignore[attr-defined]
+    cmake_extensions(dist, "cmake_extensions", extensions)

--- a/tests/packages/simple_setuptools_ext/setup.py
+++ b/tests/packages/simple_setuptools_ext/setup.py
@@ -1,13 +1,9 @@
 from setuptools import setup
 
-from scikit_build_core.setuptools.extension import CMakeExtension
-
 setup(
     name="cmake-example",
     version="0.0.1",
-    cmake_extensions=[
-        CMakeExtension("cmake_example", define_macros=[("EXAMPLE_INFO", "42")])
-    ],
+    cmake_source_dir=".",
     zip_safe=False,
     extras_require={"test": ["pytest>=6.0"]},
     python_requires=">=3.7",


### PR DESCRIPTION
This adds support for `cmake_source_dir` from scikit-build classic.

Unlike scikit-build classic, this works on a vanilla `from setuptools import setup`, and it doesn't require an import of `scikit_build_core` at all.
