### PR TITLE
feat: support for setting python & abi tag (including limited API)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
     rev: v0.982
     hooks:
       - id: mypy
-        exclude: tests/packages/simplest_c/src/simplest/__init__.py
+        exclude: tests/packages/(simplest_c/src/simplest/__init__.py|.*/setup.py)
         files: ^(src|tests)
         args: []
         additional_dependencies:

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -58,6 +58,7 @@ class Builder:
         defines: Mapping[str, str],
         name: str | None = None,
         version: Version | None = None,
+        limited_abi: bool | None = None,
     ) -> None:
         cmake_defines = dict(defines)
         cmake_args: list[str] = []
@@ -111,7 +112,10 @@ class Builder:
             cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
 
-        if self.settings.py_abi_tag.endswith("-abi3"):
+        if limited_abi is None:
+            limited_abi = self.settings.py_abi_tag.endswith("-abi3")
+
+        if limited_abi:
             cache_config["SKBUILD_SOABI"] = (
                 "" if sys.platform.startswith("win") else "abi3"
             )

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -111,12 +111,17 @@ class Builder:
             cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
 
-        # Workaround for bug in PyPy and packaging that is not handled in CMake
-        # According to PEP 3149, SOABI and EXT_SUFFIX are interchangeable (and
-        # the latter is much more likely to be correct as it is used elsewhere)
-        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
-        assert ext_suffix
-        cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
+        if self.settings.abi_tag.startswith("cp"):
+            cache_config["SKBUILD_SOABI"] = (
+                "" if sys.platform.startswith("win") else "abi3"
+            )
+        else:
+            # Workaround for bug in PyPy and packaging that is not handled in CMake
+            # According to PEP 3149, SOABI and EXT_SUFFIX are interchangeable (and
+            # the latter is much more likely to be correct as it is used elsewhere)
+            ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+            assert ext_suffix
+            cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
 
         self.config.init_cache(cache_config)
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -111,7 +111,7 @@ class Builder:
             cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
 
-        if self.settings.abi_tag.startswith("cp"):
+        if self.settings.py_abi_tag.endswith("-abi3"):
             cache_config["SKBUILD_SOABI"] = (
                 "" if sys.platform.startswith("win") else "abi3"
             )

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -28,7 +28,7 @@ class WheelTag:
     # TODO: plats only used on macOS
     @classmethod
     def compute_best(
-        cls: type[Self], archs: Sequence[str] = (), abi_tag: str = ""
+        cls: type[Self], archs: Sequence[str] = (), py_abi_tag: str = ""
     ) -> Self:
         best_tag = next(packaging.tags.sys_tags())
         interp, abi, *plats = (best_tag.interpreter, best_tag.abi, best_tag.platform)
@@ -47,12 +47,9 @@ class WheelTag:
             else:
                 plats = [next(packaging.tags.mac_platforms((major, minor)))]
 
-        if abi_tag:
-            abi = "none" if abi_tag.startswith("py") else "abi3"
-            pyvers = abi_tag.split(".")
-            assert all(
-                x.startswith("py") or x.startswith("cp") for x in pyvers
-            ), "All abi_tag's must start with 'py' or 'cp.', or be empty"
+        if py_abi_tag:
+            pyver, abi = py_abi_tag.split("-")
+            pyvers = pyver.split(".")
 
         return cls(pyvers=pyvers, abis=[abi], archs=plats)
 

--- a/src/scikit_build_core/pyproject/wheel.py
+++ b/src/scikit_build_core/pyproject/wheel.py
@@ -71,7 +71,7 @@ def build_wheel(
             settings=settings,
             config=config,
         )
-        tags = WheelTag.compute_best(builder.get_archs(), settings.abi_tag)
+        tags = WheelTag.compute_best(builder.get_archs(), settings.py_abi_tag)
 
         defines: dict[str, str] = {}
         builder.configure(

--- a/src/scikit_build_core/pyproject/wheel.py
+++ b/src/scikit_build_core/pyproject/wheel.py
@@ -71,7 +71,7 @@ def build_wheel(
             settings=settings,
             config=config,
         )
-        tags = WheelTag.compute_best(builder.get_archs())
+        tags = WheelTag.compute_best(builder.get_archs(), settings.abi_tag)
 
         defines: dict[str, str] = {}
         builder.configure(

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -10,16 +10,21 @@ def __dir__() -> List[str]:
 
 @dataclasses.dataclass
 class NinjaSettings:
+    #: The minimum version of Ninja to use. If Ninja is older than this, it will
+    #: be upgraded via PyPI if possible. An empty string will disable this check.
     minimum_version: str = "1.5"
 
 
 @dataclasses.dataclass
 class CMakeSettings:
+    #: The minimum version of CMake to use. If CMake is older than this, it will
+    #: be upgraded via PyPI if possible. An empty string will disable this check.
     minimum_version: str = "3.15"
 
 
 @dataclasses.dataclass
 class LogggingSettings:
+    #: The logging level to display.
     level: str = "WARNING"
 
 
@@ -28,3 +33,11 @@ class ScikitBuildSettings:
     cmake: CMakeSettings
     ninja: NinjaSettings
     logging: LogggingSettings
+
+    #: The ABI version to target. The default (empty string) will use the default
+    #: ABI version for the Python version. You can also set this to "cp37" to
+    #: enable the CPython 3.7+ Stable ABI / Limited API. Or you can set it to
+    #: "py3" or "py2.py3" to ignore Python ABI compatibility. For the stable ABI,
+    #: the CMake variable SKBUILD_SOABI will be set to abi3 on Unix-like systems
+    #: (empty on Windows).
+    abi_tag: str = ""

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -34,10 +34,11 @@ class ScikitBuildSettings:
     ninja: NinjaSettings
     logging: LogggingSettings
 
-    #: The ABI version to target. The default (empty string) will use the default
-    #: ABI version for the Python version. You can also set this to "cp37" to
-    #: enable the CPython 3.7+ Stable ABI / Limited API. Or you can set it to
-    #: "py3" or "py2.py3" to ignore Python ABI compatibility. For the stable ABI,
-    #: the CMake variable SKBUILD_SOABI will be set to abi3 on Unix-like systems
-    #: (empty on Windows).
-    abi_tag: str = ""
+    #: The Python and ABI tags. The default (empty string) will use the default
+    #: Python version. You can also set this to "cp37-abi3" to enable the CPython
+    #: 3.7+ Stable ABI / Limited API. Or you can set it to "py3-none" or
+    #: "py2.py3-none" to ignore Python ABI compatibility. For the stable ABI, the
+    #: CMake variable SKBUILD_SOABI will be set to abi3 on Unix-like systems
+    #: (empty on Windows). FindPython doesn't have a way to target python3.dll instead
+    #: of python3N.dll, so this is harder to use on Windows.
+    py_abi_tag: str = ""

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -114,14 +114,15 @@ def cmake_extensions(
 
     # A rather hacky way to enable ABI3 without using non-public code in wheel
     settings = read_settings(Path("pyproject.toml"), {})
-    if settings.abi_tag.startswith("cp3"):
+    if settings.py_abi_tag:
         bdist_wheel = dist.get_command_class("bdist_wheel")  # type: ignore[no-untyped-call]
         if "abi3" not in bdist_wheel.__class__.__name__:
 
             class bdist_wheel_abi3(bdist_wheel):  # type: ignore[valid-type, misc]
                 def get_tag(self):
                     _, _, plat = bdist_wheel.get_tag(self)
-                    return settings.abi_tag, "abi3", plat
+                    py, abi = settings.py_abi_tag.split("-")
+                    return py, abi, plat
 
             dist.cmdclass["bdist_wheel"] = bdist_wheel_abi3
 

--- a/src/scikit_build_core/setuptools/extension.py
+++ b/src/scikit_build_core/setuptools/extension.py
@@ -89,6 +89,7 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
             defines=defines,
             name=dist.get_name(),
             version=dist.get_version(),
+            limited_abi=ext.py_limited_api,
         )
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level

--- a/tests/packages/abi3_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/abi3_pyproject_ext/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15...3.24)
+
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C VERSION ${SKBUILD_PROJECT_VERSION})
+
+find_package(Python COMPONENTS COMPONENTS Interpreter Development.Module)
+set(Python_SOABI ${SKBUILD_SOABI})
+
+Python_add_library(abi3_example MODULE abi3_example.c WITH_SOABI)
+
+install(TARGETS abi3_example DESTINATION .)

--- a/tests/packages/abi3_pyproject_ext/abi3_example.c
+++ b/tests/packages/abi3_pyproject_ext/abi3_example.c
@@ -1,0 +1,25 @@
+#define Py_LIMITED_API 0x03070000
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+float square(float x) { return x * x; }
+
+static PyObject *square_wrapper(PyObject *self, PyObject *args) {
+  float input, result;
+  if (!PyArg_ParseTuple(args, "f", &input)) {
+    return NULL;
+  }
+  result = square(input);
+  return PyFloat_FromDouble(result);
+}
+
+static PyMethodDef pysimple_methods[] = {
+    {"square", square_wrapper, METH_VARARGS, "Square function"},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef pysimple_module = {PyModuleDef_HEAD_INIT, "pysimple",
+                                             NULL, -1, pysimple_methods};
+
+PyMODINIT_FUNC PyInit_abi3_example(void) {
+  return PyModule_Create(&pysimple_module);
+}

--- a/tests/packages/abi3_pyproject_ext/pyproject.toml
+++ b/tests/packages/abi3_pyproject_ext/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "abi3-example"
+version = "0.0.1"
+
+[tool.scikit-build]
+abi-tag = "cp37"

--- a/tests/packages/abi3_pyproject_ext/pyproject.toml
+++ b/tests/packages/abi3_pyproject_ext/pyproject.toml
@@ -7,4 +7,4 @@ name = "abi3-example"
 version = "0.0.1"
 
 [tool.scikit-build]
-abi-tag = "cp37"
+py-abi-tag = "cp37-abi3"

--- a/tests/packages/abi3_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/abi3_setuptools_ext/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15...3.24)
+
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C VERSION ${SKBUILD_PROJECT_VERSION})
+
+find_package(Python COMPONENTS COMPONENTS Interpreter Development.Module)
+set(Python_SOABI ${SKBUILD_SOABI})
+
+Python_add_library(abi3_example MODULE abi3_example.c WITH_SOABI)
+
+install(TARGETS abi3_example DESTINATION .)

--- a/tests/packages/abi3_setuptools_ext/abi3_example.c
+++ b/tests/packages/abi3_setuptools_ext/abi3_example.c
@@ -1,0 +1,25 @@
+#define Py_LIMITED_API 0x03070000
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+float square(float x) { return x * x; }
+
+static PyObject *square_wrapper(PyObject *self, PyObject *args) {
+  float input, result;
+  if (!PyArg_ParseTuple(args, "f", &input)) {
+    return NULL;
+  }
+  result = square(input);
+  return PyFloat_FromDouble(result);
+}
+
+static PyMethodDef pysimple_methods[] = {
+    {"square", square_wrapper, METH_VARARGS, "Square function"},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef pysimple_module = {PyModuleDef_HEAD_INIT, "pysimple",
+                                             NULL, -1, pysimple_methods};
+
+PyMODINIT_FUNC PyInit_abi3_example(void) {
+  return PyModule_Create(&pysimple_module);
+}

--- a/tests/packages/abi3_setuptools_ext/pyproject.toml
+++ b/tests/packages/abi3_setuptools_ext/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.setuptools.build_meta"
+
+[tool.scikit-build]
+abi-tag = "cp37"

--- a/tests/packages/abi3_setuptools_ext/pyproject.toml
+++ b/tests/packages/abi3_setuptools_ext/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.setuptools.build_meta"
 
 [tool.scikit-build]
-abi-tag = "cp37"
+py-abi-tag = "cp37-abi3"

--- a/tests/packages/abi3_setuptools_ext/setup.py
+++ b/tests/packages/abi3_setuptools_ext/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name="abi3_example",
+    version="0.0.1",
+    cmake_source_dir=".",
+    zip_safe=False,
+    python_requires=">=3.7",
+)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -96,14 +96,14 @@ def test_wheel_tag_with_abi_darwin(monkeypatch):
     monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", "10.10")
     monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9", "", ""))
 
-    tags = WheelTag.compute_best(["x86_64"], abi_tag="cp39")
+    tags = WheelTag.compute_best(["x86_64"], py_abi_tag="cp39-abi3")
     assert str(tags) == "cp39-abi3-macosx_10_10_x86_64"
 
-    tags = WheelTag.compute_best(["x86_64"], abi_tag="cp37")
+    tags = WheelTag.compute_best(["x86_64"], py_abi_tag="cp37-abi3")
     assert str(tags) == "cp37-abi3-macosx_10_10_x86_64"
 
-    tags = WheelTag.compute_best(["x86_64"], abi_tag="py3")
+    tags = WheelTag.compute_best(["x86_64"], py_abi_tag="py3-none")
     assert str(tags) == "py3-none-macosx_10_10_x86_64"
 
-    tags = WheelTag.compute_best(["x86_64"], abi_tag="py2.py3")
+    tags = WheelTag.compute_best(["x86_64"], py_abi_tag="py2.py3-none")
     assert str(tags) == "py2.py3-none-macosx_10_10_x86_64"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -89,3 +89,21 @@ def test_wheel_tag(monkeypatch, minver, archs, answer):
     tags = WheelTag.compute_best(archs)
     plat = str(tags).split("-")[-1]
     assert plat == answer
+
+
+def test_wheel_tag_with_abi_darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", "10.10")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9", "", ""))
+
+    tags = WheelTag.compute_best(["x86_64"], abi_tag="cp39")
+    assert str(tags) == "cp39-abi3-macosx_10_10_x86_64"
+
+    tags = WheelTag.compute_best(["x86_64"], abi_tag="cp37")
+    assert str(tags) == "cp37-abi3-macosx_10_10_x86_64"
+
+    tags = WheelTag.compute_best(["x86_64"], abi_tag="py3")
+    assert str(tags) == "py3-none-macosx_10_10_x86_64"
+
+    tags = WheelTag.compute_best(["x86_64"], abi_tag="py2.py3")
+    assert str(tags) == "py2.py3-none-macosx_10_10_x86_64"

--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -16,6 +16,10 @@ ABI_PKG = DIR / "packages/abi3_pyproject_ext"
 @pytest.mark.skipif(
     sys.implementation.name == "pypy", reason="pypy does not support abi3"
 )
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="abi3 is hard to target with FindPython on Windows",
+)
 def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"
     dist.mkdir()

--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -1,0 +1,55 @@
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.build import build_wheel
+
+DIR = Path(__file__).parent.resolve()
+ABI_PKG = DIR / "packages/abi3_pyproject_ext"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy", reason="pypy does not support abi3"
+)
+def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    monkeypatch.chdir(ABI_PKG)
+    if Path("dist").is_dir():
+        shutil.rmtree("dist")
+    if Path("build").is_dir():
+        shutil.rmtree("build")
+
+    out = build_wheel(str(dist))
+    (wheel,) = dist.glob("abi3_example-0.0.1-*.whl")
+    assert wheel == dist / out
+    assert "-cp37-abi3-" in out
+
+    if sys.version_info >= (3, 8):
+        with wheel.open("rb") as f:
+            p = zipfile.Path(f)
+            file_names = [p.name for p in p.iterdir()]
+
+        assert len(file_names) == 2
+        assert "abi3_example-0.0.1.dist-info" in file_names
+        file_names.remove("abi3_example-0.0.1.dist-info")
+        (so_file,) = file_names
+
+        assert (
+            so_file == "abi3_example.pyd"
+            if sys.platform.startswith("win")
+            else "abi3_example.abi3.so"
+        )
+
+    virtualenv.run(f"python -m pip install {wheel}")
+
+    output = virtualenv.run(
+        'python -c "import abi3_example; print(abi3_example.square(2))"',
+        capture=True,
+    )
+    assert output.strip() == "4.0"

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -16,6 +16,10 @@ ABI_PKG = DIR / "packages/abi3_setuptools_ext"
 @pytest.mark.skipif(
     sys.implementation.name == "pypy", reason="pypy does not support abi3"
 )
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="abi3 is hard to target with FindPython on Windows",
+)
 def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"
     dist.mkdir()

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -1,0 +1,49 @@
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.setuptools.build_meta import build_wheel
+
+DIR = Path(__file__).parent.resolve()
+ABI_PKG = DIR / "packages/abi3_setuptools_ext"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy", reason="pypy does not support abi3"
+)
+def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    monkeypatch.chdir(ABI_PKG)
+    if Path("dist").is_dir():
+        shutil.rmtree("dist")
+
+    out = build_wheel(str(dist))
+    (wheel,) = dist.glob("abi3_example-0.0.1-*.whl")
+    assert wheel == dist / out
+    assert "-cp37-abi3-" in out
+
+    if sys.version_info >= (3, 8):
+        with wheel.open("rb") as f:
+            p = zipfile.Path(f)
+            file_names = {p.name for p in p.iterdir()}
+
+        so_file = (
+            "abi3_example.pyd"
+            if sys.platform.startswith("win")
+            else "abi3_example.abi3.so"
+        )
+        assert so_file in file_names
+
+    virtualenv.run(f"python -m pip install {wheel}")
+
+    output = virtualenv.run(
+        'python -c "import abi3_example; print(abi3_example.square(2))"',
+        capture=True,
+    )
+    assert output.strip() == "4.0"


### PR DESCRIPTION
Supported in both modes. Should also support Pythonless wheels. Upstream request at https://gitlab.kitware.com/cmake/cmake/-/issues/24141. Closes #39.

Setuptools support is pretty bad due to wheel not having a public API, so in setuptools mode this should still be specified in the same way (pyproject.toml), rather than by setting `py_limited_abi`, so you get the proper wheel name. But it should still work as before, you just have to also set up the wheel name if you only specify `py_limited_api`.