### PR TITLE
refactor(setuptools): use native bdist_wheel setting for abi3

### DIFF
--- a/tests/packages/abi3_setuptools_ext/pyproject.toml
+++ b/tests/packages/abi3_setuptools_ext/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
 requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.setuptools.build_meta"
-
-[tool.scikit-build]
-py-abi-tag = "cp37-abi3"

--- a/tests/packages/abi3_setuptools_ext/setup.cfg
+++ b/tests/packages/abi3_setuptools_ext/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = abi3_example
+version = 0.0.1
+
+[options]
+zip_safe = False
+python_requires = >=3.7
+
+
+[bdist_wheel]
+py_limited_api = cp37

--- a/tests/packages/abi3_setuptools_ext/setup.py
+++ b/tests/packages/abi3_setuptools_ext/setup.py
@@ -1,9 +1,5 @@
 from setuptools import setup
 
 setup(
-    name="abi3_example",
-    version="0.0.1",
     cmake_source_dir=".",
-    zip_safe=False,
-    python_requires=">=3.7",
 )


### PR DESCRIPTION
Using the native `bdist_wheel` setting for setuptools mode.
