### PR TITLE
feat: support reproducible sdist builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ tags.extra = false
 sdist.include = []
 sdist.exclude = []
 
+# Make reproducible SDists (at least with Python 3.9+ and UNIX). Respects
+# SOURCE_DATE_EPOCH when true (the default).
+sdist.reproducible = true
+
 # The root-level packages to include. Special default: if not given, the package
 # is auto-discovered if it's name matches the main name.
 wheel.packages = ["src/<package>", "<package>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ strict_equality = true
 strict_concatenate = true
 
 [[tool.mypy.overrides]]
-module = ["scikit-build-core.*"]
+module = ["scikit_build_core.*"]
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -40,7 +40,7 @@ def normalize_file_permissions(st_mode: int) -> int:
     permissions can vary on systems with different umasks. Normalising
     to 644 (non executable) or 755 (executable) makes builds more reproducible.
 
-    Taken from https://github.com/takluyver/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
+    Taken from https://github.com/pypa/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
     """
     # Set 644 permissions, leaving higher bits of st_mode unchanged
     new_mode = (st_mode | 0o644) & ~0o133

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import contextlib
+import copy
+import gzip
 import io
+import os
 import tarfile
+import time
 from pathlib import Path
 
 from pyproject_metadata import StandardMetadata
@@ -18,6 +23,49 @@ def __dir__() -> list[str]:
     return __all__
 
 
+def get_reproducible_epoch() -> int:
+    """
+    Return an integer representing the integer number of seconds since the Unix epoch.
+
+    If the `SOURCE_DATE_EPOCH` environment variable is set, use that value. Otherwise,
+    always return `1667997441`.
+    """
+    return int(os.environ.get("SOURCE_DATE_EPOCH", "1667997441"))
+
+
+def normalize_file_permissions(st_mode: int) -> int:
+    """
+    Normalize the permission bits in the st_mode field from stat to 644/755
+    Popular VCSs only track whether a file is executable or not. The exact
+    permissions can vary on systems with different umasks. Normalising
+    to 644 (non executable) or 755 (executable) makes builds more reproducible.
+
+    Taken from https://github.com/takluyver/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
+    """
+    # Set 644 permissions, leaving higher bits of st_mode unchanged
+    new_mode = (st_mode | 0o644) & ~0o133
+    if st_mode & 0o100:
+        new_mode |= 0o111  # Executable: 644 -> 755
+    return new_mode
+
+
+def normalize_tar_info(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
+    """
+    Normalize the TarInfo associated with a file to improve reproducibility.
+
+    Inspired by Hatch
+    https://github.com/pypa/hatch/blob/573192f88022bb781c698dae2c0b84ef3fb9a7ad/backend/src/hatchling/builders/sdist.py#L51
+    """
+    tar_info = copy.copy(tar_info)
+    tar_info.uname = ""
+    tar_info.gname = ""
+    tar_info.uid = 0
+    tar_info.gid = 0
+    tar_info.mode = normalize_file_permissions(tar_info.mode)
+    tar_info.mtime = get_reproducible_epoch()
+    return tar_info
+
+
 def build_sdist(
     sdist_directory: str,
     # pylint: disable-next=unused-argument
@@ -31,23 +79,39 @@ def build_sdist(
     with Path("pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
+    if settings.sdist.reproducible:
+        transform_tar_info = normalize_tar_info
+        timestamp = get_reproducible_epoch()
+    else:
+
+        def transform_tar_info(tar_info):
+            return tar_info
+
+        timestamp = int(time.time())
+
     metadata = StandardMetadata.from_pyproject(pyproject)
     pkg_info = bytes(metadata.as_rfc822())
 
     srcdirname = f"{metadata.name}-{metadata.version}"
     filename = f"{srcdirname}.tar.gz"
 
-    # TODO: support SOURCE_DATE_EPOCH for reproducible builds
     sdist_dir.mkdir(parents=True, exist_ok=True)
-    with tarfile.open(sdist_dir / filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
+    with contextlib.ExitStack() as stack:
+        gzip_container = stack.enter_context(
+            gzip.GzipFile(sdist_dir / filename, mode="wb", mtime=timestamp)
+        )
+        tar = stack.enter_context(
+            tarfile.TarFile(fileobj=gzip_container, mode="w", format=tarfile.PAX_FORMAT)
+        )
         for filepath in each_unignored_file(
             Path("."), include=settings.sdist.include, exclude=settings.sdist.exclude
         ):
-            tar.add(filepath, arcname=srcdirname / filepath)
+            tar.add(filepath, arcname=srcdirname / filepath, filter=transform_tar_info)
 
-        tarinfo = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
-        tarinfo.size = len(pkg_info)
+        tar_info = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
+        tar_info.size = len(pkg_info)
+        tar_info = transform_tar_info(tar_info)
         with io.BytesIO(pkg_info) as fileobj:
-            tar.addfile(tarinfo, fileobj)
+            tar.addfile(tar_info, fileobj)
 
     return filename

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -108,10 +108,10 @@ def build_sdist(
         ):
             tar.add(filepath, arcname=srcdirname / filepath, filter=transform_tar_info)
 
-        tar_info = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
-        tar_info.size = len(pkg_info)
-        tar_info = transform_tar_info(tar_info)
+        tarinfo = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
+        tarinfo.size = len(pkg_info)
+        tarinfo = transform_tar_info(tarinfo)
         with io.BytesIO(pkg_info) as fileobj:
-            tar.addfile(tar_info, fileobj)
+            tar.addfile(tarinfo, fileobj)
 
     return filename

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -99,7 +99,11 @@ def build_sdist(
         for filepath in each_unignored_file(
             Path("."), include=settings.sdist.include, exclude=settings.sdist.exclude
         ):
-            tar.add(filepath, arcname=srcdirname / filepath, filter=normalize_tar_info if reproducible else lambda x: x)
+            tar.add(
+                filepath,
+                arcname=srcdirname / filepath,
+                filter=normalize_tar_info if reproducible else lambda x: x,
+            )
 
         tarinfo = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
         tarinfo.size = len(pkg_info)

--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -107,7 +107,8 @@ def build_sdist(
 
         tarinfo = tarfile.TarInfo(name=f"{srcdirname}/PKG-INFO")
         tarinfo.size = len(pkg_info)
-        tarinfo = transform_tar_info(tarinfo)
+        if reproducible:
+            tarinfo = normalize_tar_info(tarinfo)
         with io.BytesIO(pkg_info) as fileobj:
             tar.addfile(tarinfo, fileobj)
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -64,6 +64,10 @@ class SDistSettings:
     #: Files to exclude from the SDist even if they are included by default.
     exclude: List[str] = dataclasses.field(default_factory=list)
 
+    #: If set to True, try to build a reproducible distribution.
+    #: SOURCE_DATE_EPOCH will be used for timestamps, or a fixed value if not set.
+    reproducible: bool = True
+
 
 @dataclasses.dataclass
 class WheelSettings:

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -12,7 +12,6 @@ from scikit_build_core.build import build_sdist, build_wheel
 
 DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_pyproject_ext"
-KNOWN_SDIST_HASH = "03455cc6996c1d0d4977bedb611180cf561ade9d70d7b5d1216a40405adf7b47"
 ENTRYPOINTS = """\
 [one.two]
 three = four
@@ -31,6 +30,11 @@ Requires-Python: >=3.7
 Provides-Extra: test
 Requires-Dist: pytest>=6.0; extra == "test"
 """
+
+mark_hashes_different = pytest.mark.xfail(
+    sys.version_info < (3, 9) or sys.platform.startswith("win32"),
+    reason="hashes differ on Windows and Python < 3.9",
+)
 
 
 def test_pep517_sdist(tmp_path, monkeypatch):
@@ -62,10 +66,7 @@ def test_pep517_sdist(tmp_path, monkeypatch):
         assert pkg_info_contents == METADATA
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 9) or sys.platform.startswith("win32"),
-    reason="hashes are different on Python < 3.9 or Windows",
-)
+@mark_hashes_different
 def test_pep517_sdist_hash(tmp_path, monkeypatch):
     dist = tmp_path.resolve() / "dist"
     monkeypatch.chdir(HELLO_PEP518)
@@ -73,7 +74,8 @@ def test_pep517_sdist_hash(tmp_path, monkeypatch):
         shutil.rmtree("dist")
     out = build_sdist(str(dist))
     sdist = dist / out
-    assert hashlib.sha256(sdist.read_bytes()).hexdigest() == KNOWN_SDIST_HASH
+    hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    assert hash == "03455cc6996c1d0d4977bedb611180cf561ade9d70d7b5d1216a40405adf7b47"
 
 
 def test_pep517_sdist_time_hash(tmp_path, monkeypatch):
@@ -87,6 +89,7 @@ def test_pep517_sdist_time_hash(tmp_path, monkeypatch):
     hash1 = hashlib.sha256(sdist.read_bytes()).hexdigest()
 
     time.sleep(2)
+    Path("src/main.cpp").touch()
 
     if Path("dist").is_dir():
         shutil.rmtree("dist")
@@ -97,6 +100,43 @@ def test_pep517_sdist_time_hash(tmp_path, monkeypatch):
     hash2 = hashlib.sha256(sdist.read_bytes()).hexdigest()
 
     assert hash1 == hash2
+
+
+def test_pep517_sdist_time_hash_nonreproducable(tmp_path, monkeypatch):
+    dist = tmp_path.resolve() / "dist"
+    monkeypatch.chdir(HELLO_PEP518)
+    if Path("dist").is_dir():
+        shutil.rmtree("dist")
+
+    out = build_sdist(str(dist), {"scikit-build.sdist.reproducible": "false"})
+    sdist = dist / out
+    hash1 = hashlib.sha256(sdist.read_bytes()).hexdigest()
+
+    time.sleep(2)
+
+    if Path("dist").is_dir():
+        shutil.rmtree("dist")
+
+    out = build_sdist(str(dist))
+    sdist = dist / out
+
+    hash2 = hashlib.sha256(sdist.read_bytes()).hexdigest()
+
+    assert hash1 != hash2
+
+
+@mark_hashes_different
+def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch):
+    dist = tmp_path.resolve() / "dist"
+    monkeypatch.chdir(HELLO_PEP518)
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "12345")
+    if Path("dist").is_dir():
+        shutil.rmtree("dist")
+
+    out = build_sdist(str(dist), {"scikit-build-core.sdist.reproducible": "false"})
+    sdist = dist / out
+    hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    assert hash == "a39a0eecb02f7b583ab3008c0c64c55eaef9d0bb5e712b6cb8d469598771ddfb"
 
 
 @pytest.mark.compile

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -1,3 +1,4 @@
+import hashlib
 import shutil
 import subprocess
 import sys
@@ -10,6 +11,7 @@ import pytest
 
 DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_pyproject_ext"
+KNOWN_SDIST_HASH = "03455cc6996c1d0d4977bedb611180cf561ade9d70d7b5d1216a40405adf7b47"
 
 
 @pytest.mark.integration
@@ -32,6 +34,9 @@ def test_pep518_sdist(pep518, virtualenv):
     )
     (sdist,) = dist.iterdir()
     assert "cmake-example-0.0.1.tar.gz" == sdist.name
+
+    if sys.version_info >= (3, 9) and not sys.platform.startswith("win32"):
+        assert hashlib.sha256(sdist.read_bytes()).hexdigest() == KNOWN_SDIST_HASH
 
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -32,6 +32,7 @@ def test_pep517_sdist(tmp_path, monkeypatch):
     monkeypatch.chdir(HELLO_PEP518)
     if Path("dist").is_dir():
         shutil.rmtree("dist")
+
     out = build_sdist(str(dist))
 
     (sdist,) = dist.iterdir()


### PR DESCRIPTION
Hey @henryiii,

This is rudimentary, but sets the scene for reproducible builds. I don't love the ergonomics and you seem to have a design vision here, so feel free to rewrite / ignore this if it needs another pass.

I'm not sure whether we need to offer an option for non-reproducible builds. I don't know enough about when you *wouldn't* want this to make a strong decision. But, it might also be something that the Hatch builder can deal with down the line, and sciki-build-core's backend can just be opinionated.