### PR TITLE
fix: better macOS deployment target handling

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -10,8 +10,6 @@ from typing import Mapping
 from packaging.version import Version
 
 from .. import __version__
-from .._logging import logger
-from ..builder.macos import get_macosx_deployment_target
 from ..builder.sysconfig import get_python_include_dir, get_python_library
 from ..cmake import CMakeConfig
 from ..errors import NinjaNotFoundError
@@ -156,14 +154,6 @@ class Builder:
             archs = self.get_archs()
             if archs:
                 cmake_defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
-
-            self.config.env.setdefault(
-                "MACOSX_DEPLOYMENT_TARGET", get_macosx_deployment_target()
-            )
-            logger.info(
-                "MACOSX_DEPLOYMENT_TARGET is {}",
-                self.config.env["MACOSX_DEPLOYMENT_TARGET"],
-            )
 
         self.config.configure(
             defines=cmake_defines,

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -2,17 +2,26 @@ from __future__ import annotations
 
 import os
 import platform
+from typing import NamedTuple
 
 from .._logging import logger
 
-__all__ = ["get_macosx_deployment_target", "get_macosx_deployment_target_tuple"]
+__all__ = ["normalize_macos_version", "get_macosx_deployment_target", "MacOSVer"]
+
+
+class MacOSVer(NamedTuple):
+    major: int
+    minor: int
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}"
 
 
 def __dir__() -> list[str]:
     return __all__
 
 
-def normalize_macos_version(version: str, arm: bool) -> tuple[int, int]:
+def normalize_macos_version(version: str, arm: bool) -> MacOSVer:
     """
     Set minor version to 0 if major is 11+.
     """
@@ -21,10 +30,10 @@ def normalize_macos_version(version: str, arm: bool) -> tuple[int, int]:
     major, minor = (int(d) for d in version.split(".")[:2])
     major = max(major, 11) if arm else major
     minor = 0 if major >= 11 else minor
-    return major, minor
+    return MacOSVer(major, minor)
 
 
-def get_macosx_deployment_target_tuple(arm: bool) -> tuple[int, int]:
+def get_macosx_deployment_target(arm: bool) -> MacOSVer:
     """
     Get the MACOSX_DEPLOYMENT_TARGET environment variable. If not set, use the
     current macOS version. If arm=True, then this will always return at least (11, 0).
@@ -47,12 +56,3 @@ def get_macosx_deployment_target_tuple(arm: bool) -> tuple[int, int]:
 
     logger.debug("MACOSX_DEPLOYMENT_TARGET is set to {}", env_target)
     return norm_env_target
-
-
-def get_macosx_deployment_target(arm: bool) -> str:
-    """
-    Get the MACOSX_DEPLOYMENT_TARGET environment variable. If not set, use the
-    current macOS version. If arm=True, then this will always return at least 11.0.
-    Versions after 11 will be normalized to 0 for minor version.
-    """
-    return ".".join(str(d) for d in get_macosx_deployment_target_tuple(arm))

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-import sysconfig
+import platform
 
 from .._logging import logger
 
@@ -12,40 +12,36 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def normalize_macos_version(version: str) -> tuple[int, int]:
+def normalize_macos_version(version: str, arm: bool) -> tuple[int, int]:
     """
     Set minor version to 0 if major is 11+.
     """
     if "." not in version:
         version = f"{version}.0"
     major, minor = (int(d) for d in version.split(".")[:2])
+    major = max(major, 11) if arm else major
     minor = 0 if major >= 11 else minor
     return major, minor
 
 
-def get_macosx_deployment_target_tuple() -> tuple[int, int]:
+def get_macosx_deployment_target_tuple(arm: bool) -> tuple[int, int]:
     """
-    Get the MACOSX_DEPLOYMENT_TARGET environment variable or use the version
-    Python was built with. Suggestion: do not touch MACOSX_DEPLOYMENT_TARGET
-    if it's set.
+    Get the MACOSX_DEPLOYMENT_TARGET environment variable. If not set, use the
+    current macOS version. If arm=True, then this will always return at least (11, 0).
+    Versions after 11 will be normalized to 0 for minor version.
     """
     target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
-    plat_ver_str = sysconfig.get_platform().rsplit("-", 1)[0].split("-", 1)[1]
-    plat_target = normalize_macos_version(plat_ver_str)
+    plat_ver_str, _, _ = platform.mac_ver()
+    plat_target = normalize_macos_version(plat_ver_str, arm)
     if target is None:
         logger.debug("MACOSX_DEPLOYMENT_TARGET not set, using {}", plat_target)
         return plat_target
 
     env_target = ".".join(target.split(".")[:2]) if "." in target else f"{target}.0"
     try:
-        norm_env_target = normalize_macos_version(env_target)
+        norm_env_target = normalize_macos_version(env_target, arm)
     except ValueError:
         msg = "MACOSX_DEPLOYMENT_TARGET not readable ({}), using {} instead"
-        logger.warning(msg, env_target, plat_target)
-        return plat_target
-
-    if norm_env_target < plat_target:
-        msg = "MACOSX_DEPLOYMENT_TARGET ({}) is less than that which Python was compiled with, {}, using that instead"
         logger.warning(msg, env_target, plat_target)
         return plat_target
 
@@ -53,10 +49,10 @@ def get_macosx_deployment_target_tuple() -> tuple[int, int]:
     return norm_env_target
 
 
-def get_macosx_deployment_target() -> str:
+def get_macosx_deployment_target(arm: bool) -> str:
     """
-    Get the MACOSX_DEPLOYMENT_TARGET environment variable or use the version
-    Python was built with. Suggestion: do not touch MACOSX_DEPLOYMENT_TARGET
-    if it's set.
+    Get the MACOSX_DEPLOYMENT_TARGET environment variable. If not set, use the
+    current macOS version. If arm=True, then this will always return at least 11.0.
+    Versions after 11 will be normalized to 0 for minor version.
     """
-    return ".".join(str(d) for d in get_macosx_deployment_target_tuple())
+    return ".".join(str(d) for d in get_macosx_deployment_target_tuple(arm))

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -34,11 +34,7 @@ class WheelTag:
         interp, abi, *plats = (best_tag.interpreter, best_tag.abi, best_tag.platform)
         pyvers = [interp]
         if sys.platform.startswith("darwin"):
-            major, minor = get_macosx_deployment_target_tuple()
-            if archs == ["arm64"] and major < 11:
-                major = 11
-            if major >= 11:
-                minor = 0
+            major, minor = get_macosx_deployment_target_tuple(archs == ["arm64"])
             if archs:
                 plats = [
                     next(packaging.tags.mac_platforms((major, minor), arch))

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 
 import packaging.tags
 
-from .macos import get_macosx_deployment_target_tuple
+from .macos import get_macosx_deployment_target
 
 __all__ = ["WheelTag"]
 
@@ -34,7 +34,7 @@ class WheelTag:
         interp, abi, *plats = (best_tag.interpreter, best_tag.abi, best_tag.platform)
         pyvers = [interp]
         if sys.platform.startswith("darwin"):
-            major, minor = get_macosx_deployment_target_tuple(archs == ["arm64"])
+            major, minor = get_macosx_deployment_target(archs == ["arm64"])
             if archs:
                 plats = [
                     next(packaging.tags.mac_platforms((major, minor), arch))

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -40,7 +40,7 @@ def test_macos_version(monkeypatch, pycom, envvar, answer):
     else:
         monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", envvar)
 
-    assert get_macosx_deployment_target(arm=False) == answer
+    assert str(get_macosx_deployment_target(arm=False)) == answer
 
 
 def test_get_python_include_dir():
@@ -113,7 +113,7 @@ def test_builder_macos_arch_extra(monkeypatch):
 def test_wheel_tag_with_abi_darwin(monkeypatch):
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", "10.10")
-    monkeypatch.setattr(sysconfig, "get_platform", lambda: "macosx-10.9-x86_64")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9.2", "", ""))
 
     tags = WheelTag.compute_best(["x86_64"], py_abi_tag="cp39-abi3")
     assert str(tags) == "cp39-abi3-macosx_10_10_x86_64"


### PR DESCRIPTION
Closes #70. We still have to set MACOSX_DEPLOYMENT_TARGET in setuptools mode to avoid a warning there.