### PR TITLE
fix: don't touch mtime in non-reproducible mode

### DIFF
--- a/src/scikit_build_core/pyproject/sdist.py
+++ b/src/scikit_build_core/pyproject/sdist.py
@@ -6,7 +6,6 @@ import gzip
 import io
 import os
 import tarfile
-import time
 from pathlib import Path
 
 from pyproject_metadata import StandardMetadata
@@ -80,7 +79,7 @@ def build_sdist(
         pyproject = tomllib.load(f)
 
     reproducible = settings.sdist.reproducible
-    timestamp = get_reproducible_epoch() if reproducible else int(time.time())
+    timestamp = get_reproducible_epoch() if reproducible else None
 
     metadata = StandardMetadata.from_pyproject(pyproject)
     pkg_info = bytes(metadata.as_rfc822())


### PR DESCRIPTION
~~I think this will fix the one test in cmake-python-distributions.~~ No, it didn't, but I think it's still a good idea.
