### PR TITLE
fix: fallback to ninja sooner if on known platform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,7 @@ repos:
           - cattrs
           - cmake
           - importlib_metadata
+          - importlib_resources
           - ninja
           - packaging
           - pyproject_metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = ["version"]
 
 dependencies = [
     "exceptiongroup; python_version<'3.11'",
+    "importlib_resources; python_version<'3.9'",
     "packaging",  # TODO: set a min version
     "tomli; python_version<'3.11'",
     "typing_extensions >=3.7; python_version<'3.8'",

--- a/src/scikit_build_core/_compat/importlib.py
+++ b/src/scikit_build_core/_compat/importlib.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
+else:
+    from importlib import resources
+
+__all__ = ["resources"]
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+import functools
 import sys
 from collections.abc import Mapping
 from pathlib import Path
 
+from packaging.tags import sys_tags
 from packaging.version import Version
 
+from .._compat import tomllib
+from .._compat.typing import Literal
 from ..program_search import (
     best_program,
     get_cmake_programs,
     get_make_programs,
     get_ninja_programs,
 )
+from ..resources import resources
 from ..settings.skbuild_read_settings import SettingsReader
 
 __all__ = ["cmake_ninja_for_build_wheel"]
@@ -19,6 +24,20 @@ __all__ = ["cmake_ninja_for_build_wheel"]
 
 def __dir__() -> list[str]:
     return __all__
+
+
+@functools.lru_cache(maxsize=2)
+def known_wheels(name: Literal["ninja", "cmake"]) -> frozenset[str]:
+    with resources.joinpath("known_wheels.toml").open("rb") as f:
+        return frozenset(tomllib.load(f)["tool"]["scikit-build"][name]["known-wheels"])
+
+
+@functools.lru_cache(maxsize=2)
+def is_known_platform(platforms: frozenset[str]) -> bool:
+    for tag in sys_tags():
+        if tag.platform in platforms:
+            return True
+    return False
 
 
 def cmake_ninja_for_build_wheel(
@@ -41,7 +60,11 @@ def cmake_ninja_for_build_wheel(
             get_ninja_programs(module=False), minimum_version=ninja_min
         )
         if ninja is None:
-            if not settings.ninja.make_fallback or not list(get_make_programs()):
+            if (
+                not settings.ninja.make_fallback
+                or is_known_platform(known_wheels("ninja"))
+                or not list(get_make_programs())
+            ):
                 packages.append(f"ninja>={ninja_min}")
 
     return packages

--- a/src/scikit_build_core/resources/__init__.py
+++ b/src/scikit_build_core/resources/__init__.py
@@ -1,3 +1,8 @@
 from __future__ import annotations
 
-__all__: list[str] = []
+from .._compat.importlib import resources as _resources
+
+__all__: list[str] = ["resources"]
+
+
+resources = _resources.files(__name__)

--- a/src/scikit_build_core/resources/known_wheels.toml
+++ b/src/scikit_build_core/resources/known_wheels.toml
@@ -1,0 +1,35 @@
+[tool.scikit-build.cmake]
+known-wheels = [
+    "win_amd64",
+    "win32",
+    "macosx_10_10_universal2",
+    "musllinux_1_1_x86_64",
+    "musllinux_1_1_s390x",
+    "musllinux_1_1_ppc64le",
+    "musllinux_1_1_i686",
+    "musllinux_1_1_aarch64",
+    "manylinux_2_17_s390x",
+    "manylinux_2_17_ppc64le",
+    "manylinux_2_17_aarch64",
+    "manylinux_2_17_x86_64",
+    "manylinux_2_17_i686",
+    "manylinux_2_5_x86_64",
+    "manylinux_2_5_i686",
+]
+
+[tool.scikit-build.ninja]
+known-wheels = [
+    "win_amd64",
+    "win32",
+    "macosx_10_9_universal2",
+    "musllinux_1_1_x86_64",
+    "musllinux_1_1_s390x",
+    "musllinux_1_1_ppc64le",
+    "musllinux_1_1_i686",
+    "musllinux_1_1_aarch64",
+    "manylinux_2_17_s390x",
+    "manylinux_2_17_ppc64le",
+    "manylinux_2_17_aarch64",
+    "manylinux_2_5_x86_64",
+    "manylinux_2_5_i686",
+]


### PR DESCRIPTION
Quicker fallback to ninja if on a platform that is known to distribute ninja wheels. Expose similar info for CMake, too.
