### PR TITLE
ci: add cygwin

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 13
+    after_n_builds: 14
 coverage:
   status:
     project:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install .[test,cov]
+        run: python -m pip install .[test,cov] cmake ninja
 
       - name: Test package
         run: python -m pytest -ra --showlocals --cov=scikit_build_core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   FORCE_COLOR: 3
 
 jobs:
-  pre-commit:
+  lint:
     name: Format
     runs-on: ubuntu-latest
     steps:
@@ -70,6 +70,33 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.python-version }}
 
+  cygwin:
+    name: Tests on 🐍 3.9 • cygwin
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: cygwin/cygwin-install-action@v2
+        with:
+          platform: x86_64
+          packages:
+            cmake ninja git make gcc-g++ gcc-fortran python39 python39-devel
+            python39-pip
+
+      - name: Install
+        run: python3.9 -m pip install .[test,cov]
+
+      - name: Test package
+        run: python3.9 -m pytest -ra --showlocals --cov=scikit_build_core
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          name: ${{ runner.os }}-cygwin3.9
+
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
@@ -83,7 +110,7 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@v1
 
   pass:
-    needs: [pre-commit, checks, dist]
+    needs: [lint, checks, cygwin, dist]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All jobs passed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,7 @@ color = [
 test = [
     "build",
     "cattrs >=22.2.0",
-    "cmake >=3.15",
     "distlib",
-    "ninja",
     "pathspec",
     "pybind11",
     "pyproject-metadata",

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -153,7 +153,7 @@ class CMakeConfig:
     ) -> Generator[str, None, None]:
         for _ in range(verbose):
             yield "-v"
-        if not self.single_config:
+        if self.build_type and not self.single_config:
             yield "--config"
             yield self.build_type
 

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -6,12 +6,13 @@ import sys
 from collections.abc import Generator
 from pathlib import Path
 
-import cmake
 import pytest
 from packaging.version import Version
 
 from scikit_build_core.cmake import CMake, CMakeConfig
 from scikit_build_core.errors import CMakeNotFoundError
+
+cmake = pytest.importorskip("cmake")
 
 DIR = Path(__file__).parent.resolve()
 

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -4,8 +4,7 @@ import logging
 import os
 from pathlib import Path
 
-import cmake
-import ninja
+import pytest
 from packaging.version import Version
 
 from scikit_build_core.program_search import (
@@ -16,6 +15,7 @@ from scikit_build_core.program_search import (
 
 
 def test_get_cmake_programs_cmake_module(monkeypatch):
+    cmake = pytest.importorskip("cmake")
     monkeypatch.setattr("shutil.which", lambda x: None)
     programs = list(get_cmake_programs())
     assert len(programs) == 1
@@ -24,6 +24,7 @@ def test_get_cmake_programs_cmake_module(monkeypatch):
 
 
 def test_get_ninja_programs_cmake_module(monkeypatch):
+    ninja = pytest.importorskip("ninja")
     monkeypatch.setattr("shutil.which", lambda x: None)
     programs = list(get_ninja_programs())
     assert len(programs) == 1

--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -44,11 +44,12 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
         file_names.remove("abi3_example-0.0.1.dist-info")
         (so_file,) = file_names
 
-        assert (
-            so_file == "abi3_example.pyd"
-            if sys.platform.startswith("win")
-            else "abi3_example.abi3.so"
-        )
+        if sys.platform.startswith("win"):
+            assert so_file == "abi3_example.pyd"
+        elif sys.platform.startswith("cygwin"):
+            assert so_file == "abi3_example.abi3.dll"
+        else:
+            assert so_file == "abi3_example.abi3.so"
 
     virtualenv.run(f"python -m pip install {wheel}")
 

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -32,7 +32,7 @@ Requires-Dist: pytest>=6.0; extra == "test"
 """
 
 mark_hashes_different = pytest.mark.xfail(
-    sys.platform.startswith("win32"),
+    sys.platform.startswith("win32") or sys.platform.startswith("cygwin"),
     reason="hashes differ on Windows",
 )
 

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -34,7 +34,7 @@ def test_pep518_sdist(pep518, virtualenv):
     (sdist,) = dist.iterdir()
     assert "cmake-example-0.0.1.tar.gz" == sdist.name
 
-    if not sys.platform.startswith("win32"):
+    if not (sys.platform.startswith("win32") or sys.platform.startswith("cygwin")):
         hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
         if sys.version_info < (3, 9):
             assert (

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -38,8 +38,8 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
             file_names = {p.name for p in p.iterdir()}
 
         so_file = (
-            "abi3_example.pyd"
-            if sys.platform.startswith("win")
+            "abi3_example.abi3.dll"
+            if sys.platform.startswith("cygwin")
             else "abi3_example.abi3.so"
         )
         assert so_file in file_names

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -67,6 +67,9 @@ def test_pep517_sdist(tmp_path, monkeypatch):
 
 @pytest.mark.compile
 @pytest.mark.configure
+@pytest.mark.skipif(
+    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+)
 def test_pep517_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"
     dist.mkdir()

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -10,9 +10,13 @@ DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_setuptools_ext"
 
 
+# TODO: work out why this fails on Cygwin
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
+@pytest.mark.skipif(
+    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+)
 def test_pep518_wheel(pep518, virtualenv):
     dist = HELLO_PEP518 / "dist"
     shutil.rmtree(dist, ignore_errors=True)
@@ -55,6 +59,9 @@ def test_pep518_wheel(pep518, virtualenv):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
+@pytest.mark.skipif(
+    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+)
 def test_pep518_pip(pep518, virtualenv):
     virtualenv.run(f"python -m pip install -v {HELLO_PEP518}")
 

--- a/tests/test_simple_pure.py
+++ b/tests/test_simple_pure.py
@@ -35,7 +35,7 @@ def config(tmp_path_factory):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.skipif(
-    sys.platform.startswith("win32"),
+    sys.platform.startswith("win32") or sys.platform.startswith("cygwin"),
     reason="Paths different in build dir on Windows",
 )
 def test_bin_in_config(config):
@@ -49,8 +49,12 @@ def test_bin_in_config(config):
     assert result.stdout == "0 one 2 three \n"
 
 
+# TODO: figure out why gmake is reporting no rule to make simple_pure.cpp
 @pytest.mark.compile
 @pytest.mark.configure
+@pytest.mark.xfail(
+    sys.platform.startswith("cygwin"), strict=False, reason="No idea why this fails"
+)
 def test_install(config):
     install_dir = config.build_dir.parent / "install"
     config.install(install_dir)


### PR DESCRIPTION
Adding a Cygwin test. Closes #79. Not supported in setuptools mode yet.