### PR TITLE
tests: add a mark for setuptools tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "scikit_build_core"
 authors = [
     { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
 ]
-description = "PEP 517 builder for Scikit-Build"
+description = "Build backend for CMake based projects"
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
@@ -25,7 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
+    "Typing :: Typed",
 ]
 
 dynamic = ["version"]
@@ -37,11 +38,9 @@ dependencies = [
     "tomli; python_version<'3.11'",
     "typing_extensions >=3.7; python_version<'3.8'",
 ]
-# Note: for building wheels and sdists, there are also
-# additional dependencies:
-# pyproject_metadata, distlib, and pathspec
-# And cmake and possibly ninja if those are not already present (user
-# controllable)
+# Note: for building wheels and sdists, there are also additional dependencies
+# in the pyproject extra. And cmake and possibly ninja if those are not already
+# present (user controllable)
 
 [project.optional-dependencies]
 pyproject = [
@@ -92,6 +91,7 @@ Examples = "https://github.com/scikit-build/scikit-build-core/tree/main/tests/pa
 cmake_extensions = "scikit_build_core.setuptools.extension:cmake_extensions"
 cmake_source_dir = "scikit_build_core.setuptools.extension:cmake_source_dir"
 
+
 [tool.hatch]
 build.exclude = ["extern"]
 version.source = "vcs"
@@ -120,6 +120,7 @@ markers = [
     "compile: Compiles code",
     "configure: Configures CMake code",
     "integration: Full package build",
+    "setuptools: Tests setuptools integration",
 ]
 
 
@@ -162,7 +163,7 @@ profile = "black"
 master.py-version = "3.7"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
-good-names = ["f",]
+good-names = ["f"]
 messages_control.disable = [
   "design",
   "fixme",

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -7,6 +7,8 @@ import pytest
 
 from scikit_build_core.setuptools.build_meta import build_wheel
 
+pytestmark = pytest.mark.setuptools
+
 DIR = Path(__file__).parent.resolve()
 ABI_PKG = DIR / "packages/abi3_setuptools_ext"
 

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -9,6 +9,8 @@ import pytest
 
 from scikit_build_core.setuptools.build_meta import build_sdist, build_wheel
 
+pytestmark = pytest.mark.setuptools
+
 DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_setuptools_ext"
 

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.setuptools
+
 DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_setuptools_ext"
 


### PR DESCRIPTION
So it's easy to turn off the setuptools tests if needed.
