### PR TITLE
tests: support running without pytest-virtualenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ markers = [
     "configure: Configures CMake code",
     "integration: Full package build",
     "setuptools: Tests setuptools integration",
+    "virtualenv: Needs a virtualenv",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -66,3 +67,18 @@ def pep518(pep518_wheelhouse, monkeypatch):
     monkeypatch.setenv("PIP_FIND_LINKS", pep518_wheelhouse)
     monkeypatch.setenv("PIP_NO_INDEX", "true")
     return pep518_wheelhouse
+
+
+has_pyvenv = importlib.util.find_spec("pytest_virtualenv") is not None
+
+if not has_pyvenv:
+
+    @pytest.fixture
+    def virtualenv():
+        pytest.skip("pytest-virtualenv not available")
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "virtualenv" in item.fixturenames:
+            item.add_marker(pytest.mark.virtualenv)


### PR DESCRIPTION
Useful for conda-forge.
