### PR TITLE
tests: add marker for PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ markers = [
     "integration: Full package build",
     "setuptools: Tests setuptools integration",
     "virtualenv: Needs a virtualenv",
+    "isolated: Isolated builds",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,3 +82,5 @@ def pytest_collection_modifyitems(items):
     for item in items:
         if "virtualenv" in item.fixturenames:
             item.add_marker(pytest.mark.virtualenv)
+        if "pep518" in item.nodeid:
+            item.add_marker(pytest.mark.isolated)


### PR DESCRIPTION
Some platforms don't care about isolated builds.
