### PR TITLE
fix: expand macos tags missing

### DIFF
--- a/src/scikit_build_core/pyproject/wheel.py
+++ b/src/scikit_build_core/pyproject/wheel.py
@@ -198,7 +198,11 @@ def build_wheel(
 
         _write_wheel_metadata(packages_dir=wheel_dirs["platlib"], metadata=metadata)
 
-        tags = WheelTag.compute_best(builder.get_arch_tags(), settings.wheel.py_api)
+        tags = WheelTag.compute_best(
+            builder.get_arch_tags(),
+            settings.wheel.py_api,
+            expand_macos=settings.wheel.expand_macos_universal_tags,
+        )
         wheel.build({k: str(v) for k, v in wheel_dirs.items()}, tags=tags.tags_dict())
 
     wheel_filename: str = wheel.filename


### PR DESCRIPTION
Missed in recent fix.
