### PR TITLE
tests: xfail non-strict for conda-forge

### DIFF
--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -34,6 +34,7 @@ Requires-Dist: pytest>=6.0; extra == "test"
 mark_hashes_different = pytest.mark.xfail(
     sys.platform.startswith("win32") or sys.platform.startswith("cygwin"),
     reason="hashes differ on Windows",
+    strict=False,
 )
 
 


### PR DESCRIPTION
It's passing there. Really need to figure out why Windows is sometimes different when making SDists.
