### PR TITLE
ci: Python 3.12 alpha 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
             runs-on: ubuntu-latest
           - python-version: "3.8"
             runs-on: windows-2019
+          - python-version: "3.12-dev"
+            runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
             runs-on: windows-2019
           - python-version: "3.12-dev"
             runs-on: ubuntu-latest
+    continue-on-error: ${{ endsWith(matrix.python-version, '-dev') }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
PR for monitoring Python 3.12 support. We pass alpha 2, the removal of distutils!