### PR TITLE
fix: paths on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "pypy-3.8", "3.11"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-latest, windows-2022]
 
         include:
           - python-version: "pypy-3.7"
@@ -49,6 +49,8 @@ jobs:
             runs-on: ubuntu-latest
           - python-version: "3.10"
             runs-on: ubuntu-latest
+          - python-version: "3.8"
+            runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3
@@ -71,19 +73,23 @@ jobs:
           name: ${{ runner.os }}-${{ matrix.python-version }}
 
       - name: Min requirements
-        if: runner.os != 'Windows'
         run: |
           pip uninstall -y cmake
           pip install --constraint tests/constraints.txt .[test]
 
-      - name: Setup cmake
+      - name: Setup CMake 3.15
         uses: jwlawson/actions-setup-cmake@v1.13
-        if: runner.os != 'Windows'
+        if: matrix.runs-on != 'windows-2022'
         with:
           cmake-version: "3.15.x"
 
+      - name: Setup CMake 3.21
+        uses: jwlawson/actions-setup-cmake@v1.13
+        if: matrix.runs-on == 'windows-2022'
+        with:
+          cmake-version: "3.21.x"
+
       - name: Test min package
-        if: runner.os != 'Windows'
         run: pytest -ra --showlocals
 
   cygwin:

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -87,6 +87,8 @@ class CMaker:
                     value = "ON" if value else "OFF"
                     f.write(f'set({key} {value} CACHE BOOL "")\n')
                 elif isinstance(value, os.PathLike):
+                    # Convert to CMake's internal path format
+                    value = str(value).replace("\\", "/")
                     f.write(f'set({key} [===[{value}]===] CACHE PATH "")\n')
                 else:
                     f.write(f'set({key} [===[{value}]===] CACHE STRING "")\n')
@@ -114,17 +116,19 @@ class CMaker:
                 value = "ON" if value else "OFF"
                 yield f"-D{key}:BOOL={value}"
             elif isinstance(value, os.PathLike):
+                value = str(value).replace("\\", "/")
                 yield f"-D{key}:PATH={value}"
             else:
                 yield f"-D{key}={value}"
 
         if self.module_dirs:
-            module_dirs_str = ";".join(map(str, self.module_dirs))
-            yield f"-DCMAKE_MODULE_PATH={module_dirs_str}"
+            # Convert to CMake's internal path format, otherwise this breaks try_compile on Windows
+            module_dirs_str = ";".join(map(str, self.module_dirs)).replace("\\", "/")
+            yield f"-DCMAKE_MODULE_PATH:PATH={module_dirs_str}"
 
         if self.prefix_dirs:
-            prefix_dirs_str = ";".join(map(str, self.prefix_dirs))
-            yield f"-DCMAKE_PREFIX_PATH={prefix_dirs_str}"
+            prefix_dirs_str = ";".join(map(str, self.prefix_dirs)).replace("\\", "/")
+            yield f"-DCMAKE_PREFIX_PATH:PATH={prefix_dirs_str}"
 
     def configure(
         self,


### PR DESCRIPTION
- ci: MSVC 2019 test (2022 requires CMake 3.21+)
- fix: an issue with setting paths in the CLI on Windows
