### PR TITLE
tests: min constraints without Windows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E203, E501, E722, B950
+extend-ignore = E203, E501, E722, B950, T202
 extend-select = B9
 per-file-ignores =
     tests/*: T

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,31 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install .[test,cov] cmake ninja
+        run: pip install .[test,cov] cmake ninja rich
 
       - name: Test package
-        run: python -m pytest -ra --showlocals --cov=scikit_build_core
+        run: pytest -ra --showlocals --cov=scikit_build_core
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3.1.1
         with:
           name: ${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Min requirements
+        if: runner.os != 'Windows'
+        run: |
+          pip uninstall -y cmake ninja
+          pip install --constraint tests/constraints.txt .[test]
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        if: runner.os != 'Windows'
+        with:
+          cmake-version: "3.15.x"
+
+      - name: Test min package
+        if: runner.os != 'Windows'
+        run: pytest -ra --showlocals
 
   cygwin:
     name: Tests on 🐍 3.9 • cygwin

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ More examples are in the
 
 ## Configuration
 
-All configuration options can be placed in `pyproject.toml`, passed via `-C`
-(build only) or `--config-settins` options in `pip` or `build` (warning: pip
+All configuration options can be placed in `pyproject.toml`, passed via `-C` or
+`--config-setting` in build or `--config-settings` in `pip` (warning: pip
 doesn't support list options), or set as environment variables.
 `tool.scikit-build` is used in toml, `skbuild.` for `-C` options, or `SKBUILD_*`
 for environment variables. The defaults are listed below:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "importlib_resources>=1.3; python_version<'3.9'",
     "packaging>=20.9",
     "tomli>=1.1; python_version<'3.11'",
-    "typing_extensions >=3.7; python_version<'3.8'",
+    "typing_extensions >=3.10.0; python_version<'3.8'",
 ]
 # Note: for building wheels and sdists, there are also additional dependencies
 # in the pyproject extra. And cmake and possibly ninja if those are not already
@@ -61,7 +61,6 @@ test = [
     "pyproject-metadata>=0.5",
     "pytest >=7.2",
     "pytest-subprocess",
-    "rich",
     "setuptools",
     "wheel",
 ]

--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -1,8 +1,9 @@
 # pylint: disable=duplicate-code
 
+import builtins
 import json
 from pathlib import Path
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Callable, Dict, Type, TypeVar
 
 import cattr
 import cattr.preconf.json
@@ -61,11 +62,15 @@ def load_reply_dir(reply_dir: Path) -> Index:
 if __name__ == "__main__":
     import argparse
 
-    import rich
+    rich_print: Callable[[object], None]
+    try:
+        from rich import print as rich_print
+    except ModuleNotFoundError:
+        rich_print = builtins.print
 
     parser = argparse.ArgumentParser()
     parser.add_argument("reply_dir", type=Path, help="Path to the reply directory")
     args = parser.parse_args()
 
     reply = Path(args.reply_dir)
-    rich.print(load_reply_dir(reply))
+    rich_print(load_reply_dir(reply))

--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -36,6 +36,8 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
     converter.register_structure_hook(Reply, st_hook)
 
     def from_json_file(with_path: Dict[str, Any], t: Type[T]) -> T:
+        if with_path["jsonFile"] is None:
+            return converter.structure_attrs_fromdict({}, t)
         path = base_dir / Path(with_path["jsonFile"])
         raw = json.loads(path.read_text(encoding="utf-8"))
         return converter.structure_attrs_fromdict(raw, t)

--- a/src/scikit_build_core/file_api/model/cache.py
+++ b/src/scikit_build_core/file_api/model/cache.py
@@ -10,13 +10,13 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Property:
     name: str
     value: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Entry:
     name: str
     value: str
@@ -24,7 +24,7 @@ class Entry:
     properties: List[Property]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Cache:
     kind: str
     version: APIVersion

--- a/src/scikit_build_core/file_api/model/cmakefiles.py
+++ b/src/scikit_build_core/file_api/model/cmakefiles.py
@@ -11,7 +11,7 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Input:
     path: Path
     isGenerated: bool = False
@@ -19,7 +19,7 @@ class Input:
     isCMake: bool = False
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CMakeFiles:
     kind: str
     paths: Paths

--- a/src/scikit_build_core/file_api/model/codemodel.py
+++ b/src/scikit_build_core/file_api/model/codemodel.py
@@ -28,17 +28,17 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class StringCMakeVersion:
     string: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Directory:
     source: Path
     build: Path
-    jsonFile: Path
     projectIndex: int
+    jsonFile: Optional[Path] = None
     parentIndex: Optional[int] = None
     childIndexes: List[int] = dataclasses.field(default_factory=list)
     targetIndexes: List[int] = dataclasses.field(default_factory=list)
@@ -49,7 +49,7 @@ class Directory:
 # Directory is currently not resolved automatically.
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Project:
     name: str
     directoryIndexes: List[int]
@@ -58,40 +58,40 @@ class Project:
     targetIndexes: List[int] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Artifact:
     path: Path
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Prefix:
     path: Path
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Destination:
     path: Path
     backtrace: Optional[int] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Install:
     prefix: Prefix
     destinations: List[Destination]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CommandFragment:
     fragment: str
     role: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Sysroot:
     path: Path
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Link:
     language: str
     commandFragments: List[CommandFragment]
@@ -99,19 +99,19 @@ class Link:
     sysroot: Optional[Sysroot] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Archive:
     commandFragments: List[CommandFragment] = dataclasses.field(default_factory=list)
     lto: Optional[bool] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Dependency:
     id: str
     backtrace: Optional[int] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Source:
     path: Path
     compileGroupIndex: Optional[int] = None
@@ -120,7 +120,7 @@ class Source:
     backtrace: Optional[int] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Target:
     name: str
     id: str
@@ -136,15 +136,15 @@ class Target:
     dependencies: List[Dependency] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Configuration:
     name: str
-    directories: List[Directory]
     projects: List[Project]
     targets: List[Target]
+    directories: List[Directory]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CodeModel:
     kind: str
     version: APIVersion

--- a/src/scikit_build_core/file_api/model/common.py
+++ b/src/scikit_build_core/file_api/model/common.py
@@ -9,13 +9,13 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class APIVersion:
     major: int
     minor: int
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Paths:
     source: Path
     build: Path

--- a/src/scikit_build_core/file_api/model/directory.py
+++ b/src/scikit_build_core/file_api/model/directory.py
@@ -11,13 +11,13 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Target:
     id: str
     index: int
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class InstallRule:
     component: str
     type = str
@@ -42,7 +42,7 @@ class InstallRule:
     backtrace: Optional[int] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Node:
     file: int
     line: Optional[int] = None
@@ -50,14 +50,14 @@ class Node:
     parent: Optional[int] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BacktraceGraph:
     nodes: List[Node]
     commands: List[str]
     files: List[Path]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Directory:
     paths: Paths
     installers: List[InstallRule]

--- a/src/scikit_build_core/file_api/model/index.py
+++ b/src/scikit_build_core/file_api/model/index.py
@@ -23,7 +23,7 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CMakeVersion:
     major: int
     minor: int
@@ -33,7 +33,7 @@ class CMakeVersion:
     isDirty: bool
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CMakePaths:
     cmake: Path
     ctest: Path
@@ -41,21 +41,21 @@ class CMakePaths:
     root: Path
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Generator:
-    multiConfig: bool
     name: str
+    multiConfig: Optional[bool] = None
     platform: Optional[str] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CMake:
     version: CMakeVersion
     paths: CMakePaths
     generator: Generator
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Reply:
     codemodel_v2: Optional[CodeModel]
     cache_v2: Optional[Cache]
@@ -63,14 +63,14 @@ class Reply:
     toolchains_v1: Optional[Toolchains]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Object:
     kind: str
     version: APIVersion
     jsonFile: Path
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Index:
     cmake: CMake
     objects: List[Object]

--- a/src/scikit_build_core/file_api/model/toolchains.py
+++ b/src/scikit_build_core/file_api/model/toolchains.py
@@ -11,7 +11,7 @@ def __dir__() -> List[str]:
     return __all__
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Implicit:
     includeDirectories: List[Path] = dataclasses.field(default_factory=list)
     linkDirectories: List[Path] = dataclasses.field(default_factory=list)
@@ -19,7 +19,7 @@ class Implicit:
     linkLibraries: List[Path] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Compiler:
     implicit: Implicit
     path: Optional[Path] = None
@@ -28,15 +28,15 @@ class Compiler:
     target: Optional[str] = None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Toolchain:
     language: str  # Unique, since CMake supports one toolchain per language
     compiler: Compiler
     sourceFileExtensions: List[str] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Toolchains:
-    kind: str
-    version: APIVersion
+    kind: str = "toolchains"
+    version: APIVersion = APIVersion(1, 0)
     toolchains: List[Toolchain] = dataclasses.field(default_factory=list)

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -50,6 +50,7 @@ class Converter:
         if (
             target in (CodeModel, Target, Cache, CMakeFiles, Directory)
             and "jsonFile" in data
+            and data["jsonFile"] is not None
         ):
             return self._load_from_json(Path(data["jsonFile"]), target)
 

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -1,8 +1,9 @@
+import builtins
 import dataclasses
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Type, TypeVar, Union
 
 from .._compat.builtins import ExceptionGroup
 from .model.cache import Cache
@@ -24,7 +25,7 @@ InputDict = Dict[str, Any]
 
 
 class Converter:
-    def __init__(self, base_dir: Path):
+    def __init__(self, base_dir: Path) -> None:
         self.base_dir = base_dir
 
     def load(self) -> Index:
@@ -100,11 +101,15 @@ def load_reply_dir(path: Path) -> Index:
 if __name__ == "__main__":
     import argparse
 
-    import rich
+    rich_print: Callable[[object], None]
+    try:
+        from rich import print as rich_print
+    except ModuleNotFoundError:
+        rich_print = builtins.print
 
     parser = argparse.ArgumentParser()
     parser.add_argument("reply_dir", type=Path, help="Path to the reply directory")
     args = parser.parse_args()
 
     reply = Path(args.reply_dir)
-    rich.print(load_reply_dir(reply))
+    rich_print(load_reply_dir(reply))

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,0 +1,9 @@
+typing-extensions==3.10.0.0
+cattrs==22.2.0
+pytest==7.2.0
+tomli==1.1.0
+packaging==20.9
+importlib-resources==1.3.0
+pyproject-metadata==0.5.0
+distlib==0.3.5
+pathspec==0.10.1

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -76,7 +76,15 @@ def test_pep518_wheel(virtualenv, build_args):
     dist = HELLO_PEP518 / "dist"
     shutil.rmtree(dist, ignore_errors=True)
     subprocess.run(
-        [sys.executable, "-m", "build", *build_args], cwd=HELLO_PEP518, check=True
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--config-setting=logging.level=DEBUG",
+            *build_args,
+        ],
+        cwd=HELLO_PEP518,
+        check=True,
     )
     (wheel,) = dist.glob("cmake_example-0.0.1-*.whl")
 


### PR DESCRIPTION
Pulled out of #126 

- Fix a few missing values for CMake 3.15 FileAPI
- All FileAPI dataclasses now frozen
- Correct wrong minimum for `typing_extensions`
- Testing minimum requirements
- Rich not required in testing anymore (bad capping practices!)

I am not using/constraining the CMake package since it's broken on macOS 13 until recently. This also means I can't test 3.15 easily locally, but due to `ExeptionGroups` printing all errors at once, I didn't have to iterate!
