### PR TITLE
fix: warn on scripts with invalid shebangs

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -196,6 +196,15 @@ def build_wheel(
             exclude=settings.sdist.exclude,
         )
 
+        for item in wheel_dirs["scripts"].iterdir():
+            with item.open("rb") as f:
+                content = f.read(len(b"#!python"))
+                if content.startswith(b"#!/") and not b"#!python" != content:
+                    logger.warning(
+                        "Files in scripts/ are not post-processed yet for shabang fixes"
+                    )
+                    break
+
         _write_wheel_metadata(packages_dir=wheel_dirs["platlib"], metadata=metadata)
 
         tags = WheelTag.compute_best(

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -43,7 +43,7 @@ def get_python_library() -> Path | None:
         if libpath.is_file():
             return libpath
 
-    logger.error(
+    logger.warning(
         "Can't find a Python library, got libdir={}, ldlibrary={}, multiarch={}, masd={}",
         libdir,
         ldlibrary,


### PR DESCRIPTION
- fix: missing lib is warning, not error
- fix: warn if scripts included with potentially invalid shebangs

See #130.
