### PR TITLE
chore: update to CMake 3.25

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -223,7 +223,7 @@ test = ["pytest>=6.0"]
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)
@@ -266,7 +266,7 @@ build-backend = "scikit_build_core.setuptools.build_meta"
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Features over classic Scikit-build:
 - No dependency on setuptools, distutils, or wheel in build mode.
 - Powerful config system, including config options support in build mode.
 - Automatic inclusion of site-packages in `CMAKE_PREFIX_PATH`
-- FindPython is backported if running on CMake < 3.24 (included via hatchling in
-  a submodule)
+- FindPython is backported if running on CMake 3.24 (included via hatchling in a
+  submodule)
 - Limited API / Stable ABI and pythonless tags supported via config option
 - No slow generator search, ninja/make or MSVC used by default, respects
   `CMAKE_GENERATOR`
@@ -83,7 +83,7 @@ printouts) or `pyproject` (pre-load some dependencies) extras if you want.
 An example `CMakeLists.txt`:
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C VERSION ${SKBUILD_PROJECT_VERSION})
 

--- a/tests/packages/abi3_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/abi3_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/abi3_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/abi3_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/filepath_pure/CMakeLists.txt
+++ b/tests/packages/filepath_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simple_pure/CMakeLists.txt
+++ b/tests/packages/simple_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 project(simple_pure LANGUAGES CXX)
 

--- a/tests/packages/simple_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES CXX

--- a/tests/packages/simple_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/simple_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES CXX

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.24)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -78,11 +78,11 @@ def test_pep517_sdist_hash(tmp_path, monkeypatch):
     hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
     if sys.version_info < (3, 9):
         assert (
-            hash == "0f2ef937723753cb4df8154cddfc71d9b6451738f55392b184a0ca49ed8b2364"
+            hash == "600ed996e51642027557759ee9eeb31b5cae1f443313f5f7d0a40d9cc9cbdd13"
         )
     else:
         assert (
-            hash == "f22eaa307456a812fce6b9bd7386189c9c7e3bd10bbc6feee4f5ab0b1733b272"
+            hash == "4f47a4e797db1cb8e15afb368360d5f2ac5ae4b6c7e38e0771f8eba65fab65e4"
         )
 
 
@@ -146,11 +146,11 @@ def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch):
     hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
     if sys.version_info < (3, 9):
         assert (
-            hash == "df1d1d2fd7a8a438d506d7e734f00790dd2c37e52cde9874cc2300dd2c21660e"
+            hash == "505cb72c11e9b8344e6d467aef94f3e96d66d1c618a0703e4fcdbb623f28c23c"
         )
     else:
         assert (
-            hash == "03273c438a0215e476060f6dfa21e2e87e410e10f4f17ad706fdf37b43612942"
+            hash == "68703d101d8185d86ec7496285ddf46e302166c60a10372682de82f70bba847a"
         )
 
 

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -39,12 +39,12 @@ def test_pep518_sdist():
         if sys.version_info < (3, 9):
             assert (
                 hash
-                == "0f2ef937723753cb4df8154cddfc71d9b6451738f55392b184a0ca49ed8b2364"
+                == "600ed996e51642027557759ee9eeb31b5cae1f443313f5f7d0a40d9cc9cbdd13"
             )
         else:
             assert (
                 hash
-                == "f22eaa307456a812fce6b9bd7386189c9c7e3bd10bbc6feee4f5ab0b1733b272"
+                == "4f47a4e797db1cb8e15afb368360d5f2ac5ae4b6c7e38e0771f8eba65fab65e4"
             )
 
     with tarfile.open(sdist) as f:


### PR DESCRIPTION
Updating examples ~and built-in backport~ to 3.25.

@jcfr and @thewtex, backporting was broken in 3.25 (and we need it for the SOABI fix from 3.26, and probably ABI3 if that's added, etc). See https://gitlab.kitware.com/cmake/cmake/-/issues/24185. If upstream is unwilling to fix it, we might have to maintain our own fork. :(