### PR TITLE
tests: clear CMAKE_GENERATOR

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ Fixes:
 Testing:
 
 - Support make missing by @henryiii in #140
+- Clear `CMAKE_GENERATOR` by @henryiii in #141
 
 ## Version 0.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### What's Changed
+
+Fixes:
+
+- Windows non-default generators by @henryiii in #137
+- Compute the correct default generator for CMake by @henryiii in #139
+
+Testing:
+
+- Support make missing by @henryiii in #140
+
 ## Version 0.1.0
 
 First non-prerelease! Scikit-build-core is ready to be used. The remaining
@@ -12,7 +23,7 @@ released.
 
 Still preparing for release. One small addition to the error printout.
 
-# ## What's Changed
+### What's Changed
 
 Features:
 

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 from .._compat import tomllib
 from .._compat.typing import Literal
+from .._logging import logger
 from ..program_search import (
     best_program,
     get_cmake_programs,
@@ -54,6 +55,8 @@ def cmake_ninja_for_build_wheel(
     cmake = best_program(get_cmake_programs(module=False), minimum_version=cmake_min)
     if cmake is None:
         packages.append(f"cmake>={cmake_min}")
+    else:
+        logger.debug("Found system CMake: {} - not requiring PyPI package", cmake)
 
     if (
         not sys.platform.startswith("win")
@@ -71,5 +74,11 @@ def cmake_ninja_for_build_wheel(
                 or not list(get_make_programs())
             ):
                 packages.append(f"ninja>={ninja_min}")
+            else:
+                logger.debug(
+                    "Found system Make & not on known platform - not requiring PyPI package for Ninja"
+                )
+        else:
+            logger.debug("Found system Ninja: {} - not requiring PyPI package", ninja)
 
     return packages

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -21,6 +21,7 @@ def which_mock(name: str) -> str | None:
 def test_get_requires_for_build_wheel(fp, monkeypatch):
     cmake = Path("cmake/path").resolve()
     monkeypatch.setattr(shutil, "which", which_mock)
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([os.fspath(cmake), "--version"], stdout="3.14.0")
     assert cmake_ninja_for_build_wheel() == ["cmake>=3.15", *ninja]
 
@@ -28,6 +29,7 @@ def test_get_requires_for_build_wheel(fp, monkeypatch):
 def test_get_requires_for_build_wheel_uneeded(fp, monkeypatch):
     cmake = Path("cmake/path").resolve()
     monkeypatch.setattr(shutil, "which", which_mock)
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([os.fspath(cmake), "--version"], stdout="3.18.0")
     assert cmake_ninja_for_build_wheel() == [*ninja]
 
@@ -35,6 +37,7 @@ def test_get_requires_for_build_wheel_uneeded(fp, monkeypatch):
 def test_get_requires_for_build_wheel_settings(fp, monkeypatch):
     cmake = Path("cmake/path").resolve()
     monkeypatch.setattr(shutil, "which", which_mock)
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([os.fspath(cmake), "--version"], stdout="3.18.0")
     config = {"cmake.minimum-version": "3.20"}
     assert cmake_ninja_for_build_wheel(config) == [
@@ -53,5 +56,6 @@ def test_get_requires_for_build_wheel_pyproject(fp, monkeypatch, tmp_path):
     )
     cmake = Path("cmake/path").resolve()
     monkeypatch.setattr(shutil, "which", which_mock)
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([os.fspath(cmake), "--version"], stdout="3.18.0")
     assert cmake_ninja_for_build_wheel() == ["cmake>=3.21", *ninja]


### PR DESCRIPTION
Should allow conda-forge to reenable this test. Adding a little more debug logging.
