### PR TITLE
fix: sort filepaths for reproducibility

### DIFF
--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -98,9 +98,13 @@ def build_sdist(
         tar = stack.enter_context(
             tarfile.TarFile(fileobj=gzip_container, mode="w", format=tarfile.PAX_FORMAT)
         )
-        for filepath in each_unignored_file(
-            Path("."), include=settings.sdist.include, exclude=settings.sdist.exclude
-        ):
+        paths = list(
+            each_unignored_file(
+                Path("."), include=settings.sdist.include, exclude=settings.sdist.exclude
+            )
+        )
+        paths.sort()
+        for filepath in paths:
             tar.add(
                 filepath,
                 arcname=srcdirname / filepath,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -100,7 +100,9 @@ def build_sdist(
         )
         paths = list(
             each_unignored_file(
-                Path("."), include=settings.sdist.include, exclude=settings.sdist.exclude
+                Path("."),
+                include=settings.sdist.include,
+                exclude=settings.sdist.exclude,
             )
         )
         paths.sort()

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -105,7 +105,6 @@ def build_sdist(
                 exclude=settings.sdist.exclude,
             )
         )
-        paths.sort()
         for filepath in paths:
             tar.add(
                 filepath,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -98,7 +98,7 @@ def build_sdist(
         tar = stack.enter_context(
             tarfile.TarFile(fileobj=gzip_container, mode="w", format=tarfile.PAX_FORMAT)
         )
-        paths = list(
+        paths = sorted(
             each_unignored_file(
                 Path("."),
                 include=settings.sdist.include,

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -38,14 +38,6 @@ mark_hashes_different = pytest.mark.xfail(
 )
 
 
-_each_unignored_file = _file_processor.each_unignored_file
-
-
-def each_unignored_file_reversed(*args, **kwargs):
-    paths = list(_each_unignored_file(*args, **kwargs))
-    return reversed(paths)
-
-
 def test_pep517_sdist(tmp_path, monkeypatch):
 
     dist = tmp_path.resolve() / "dist"
@@ -150,10 +142,11 @@ def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch, reverse_order):
     if Path("dist").is_dir():
         shutil.rmtree("dist")
 
-    if reverse_order:
-        monkeypatch.setattr(
-            _file_processor, "each_unignored_file", each_unignored_file_reversed
-        )
+    _each_unignored_file = _file_processor.each_unignored_file
+    def each_unignored_file_ordered(*args, **kwargs):
+        return sorted(_each_unignored_file(*args, **kwargs), reverse=reverse_order)
+
+    monkeypatch.setattr(_file_processor, 'each_unignored_file', each_unignored_file_ordered)
 
     out = build_sdist(str(dist), {"sdist.reproducible": "true"})
     sdist = dist / out

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -143,10 +143,13 @@ def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch, reverse_order):
         shutil.rmtree("dist")
 
     _each_unignored_file = _file_processor.each_unignored_file
+
     def each_unignored_file_ordered(*args, **kwargs):
         return sorted(_each_unignored_file(*args, **kwargs), reverse=reverse_order)
 
-    monkeypatch.setattr(_file_processor, 'each_unignored_file', each_unignored_file_ordered)
+    monkeypatch.setattr(
+        _file_processor, "each_unignored_file", each_unignored_file_ordered
+    )
 
     out = build_sdist(str(dist), {"sdist.reproducible": "true"})
     sdist = dist / out

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from scikit_build_core.build import build_sdist, build_wheel, _file_processor
+from scikit_build_core.build import _file_processor, build_sdist, build_wheel
 
 DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_pyproject_ext"
@@ -39,6 +39,8 @@ mark_hashes_different = pytest.mark.xfail(
 
 
 _each_unignored_file = _file_processor.each_unignored_file
+
+
 def each_unignored_file_reversed(*args, **kwargs):
     paths = list(_each_unignored_file(*args, **kwargs))
     return reversed(paths)
@@ -137,7 +139,7 @@ def test_pep517_sdist_time_hash_nonreproducable(tmp_path, monkeypatch):
     hash2 = hashlib.sha256(sdist.read_bytes()).hexdigest()
 
     assert hash1 != hash2
-    
+
 
 @mark_hashes_different
 @pytest.mark.parametrize("reverse_order", [False, True])
@@ -149,7 +151,9 @@ def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch, reverse_order):
         shutil.rmtree("dist")
 
     if reverse_order:
-        monkeypatch.setattr(_file_processor, 'each_unignored_file', each_unignored_file_reversed)
+        monkeypatch.setattr(
+            _file_processor, "each_unignored_file", each_unignored_file_reversed
+        )
 
     out = build_sdist(str(dist), {"sdist.reproducible": "true"})
     sdist = dist / out


### PR DESCRIPTION
Our latest `awkward` deployment failed, and upon inspection I noticed that the file ordering of the sdist differed (producing a different SDist hash). This PR just consumes the file list, and sorts it before writing the archive.
