### PR TITLE
fix: EXT_SUFFIX wrong before 3.8.7

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -4,6 +4,7 @@ import dataclasses
 import re
 import sys
 import sysconfig
+import typing
 from pathlib import Path
 from typing import Mapping
 
@@ -120,7 +121,15 @@ class Builder:
             # Workaround for bug in PyPy and packaging that is not handled in CMake
             # According to PEP 3149, SOABI and EXT_SUFFIX are interchangeable (and
             # the latter is much more likely to be correct as it is used elsewhere)
-            ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+            if sys.version_info < (3, 8, 7):
+                # See https://github.com/python/cpython/issues/84006
+                import distutils.sysconfig  # pylint: disable=deprecated-module
+
+                ext_suffix = typing.cast(
+                    str, distutils.sysconfig.get_config_var("EXT_SUFFIX")
+                )
+            else:
+                ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
             assert ext_suffix
             cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -4,7 +4,6 @@ import dataclasses
 import re
 import sys
 import sysconfig
-import typing
 from pathlib import Path
 from typing import Mapping
 
@@ -125,12 +124,10 @@ class Builder:
                 # See https://github.com/python/cpython/issues/84006
                 import distutils.sysconfig  # pylint: disable=deprecated-module
 
-                ext_suffix = typing.cast(
-                    str, distutils.sysconfig.get_config_var("EXT_SUFFIX")
-                )
+                ext_suffix =  distutils.sysconfig.get_config_var("EXT_SUFFIX")
             else:
                 ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
-            assert ext_suffix
+            assert isinstance(ext_suffix, str)
             cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
 
         if cache_entries:

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -124,7 +124,7 @@ class Builder:
                 # See https://github.com/python/cpython/issues/84006
                 import distutils.sysconfig  # pylint: disable=deprecated-module
 
-                ext_suffix =  distutils.sysconfig.get_config_var("EXT_SUFFIX")
+                ext_suffix = distutils.sysconfig.get_config_var("EXT_SUFFIX")
             else:
                 ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
             assert isinstance(ext_suffix, str)


### PR DESCRIPTION
This was fixed in CPython 3.8.7.

Would also be fixed by #148.