### PR TITLE
fix: `entrypoints.txt` should be `entry_points.txt`

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -79,7 +79,7 @@ def _write_wheel_metadata(
     dist_info.mkdir(exist_ok=False)
     with dist_info.joinpath("METADATA").open("wb") as f:
         f.write(bytes(metadata.as_rfc822()))
-    with dist_info.joinpath("entrypoints.txt").open("w", encoding="utf_8") as f:
+    with dist_info.joinpath("entry_points.txt").open("w", encoding="utf_8") as f:
         ep = metadata.entrypoints.copy()
         ep["console_scripts"] = metadata.scripts
         ep["gui_scripts"] = metadata.gui_scripts

--- a/tests/packages/simple_pyproject_ext/pyproject.toml
+++ b/tests/packages/simple_pyproject_ext/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.7"
 test = ["pytest>=6.0"]
 
 [project.scripts]
-something = "other"
+something = "other:callme"
 
 [project.gui-scripts]
 guithing = "a.b:c"

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -78,11 +78,11 @@ def test_pep517_sdist_hash(tmp_path, monkeypatch):
     hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
     if sys.version_info < (3, 9):
         assert (
-            hash == "600ed996e51642027557759ee9eeb31b5cae1f443313f5f7d0a40d9cc9cbdd13"
+            hash == "3b4af3fbe3d4505415bb1e55bb2e49902f4633d371ae7288007d90eb1488bc4d"
         )
     else:
         assert (
-            hash == "4f47a4e797db1cb8e15afb368360d5f2ac5ae4b6c7e38e0771f8eba65fab65e4"
+            hash == "d373b8458ee37b176cfd03f0f3199b30fdb034bca465b2826392a6c3af85ca4c"
         )
 
 
@@ -156,11 +156,11 @@ def test_pep517_sdist_time_hash_set_epoch(tmp_path, monkeypatch, reverse_order):
     hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
     if sys.version_info < (3, 9):
         assert (
-            hash == "505cb72c11e9b8344e6d467aef94f3e96d66d1c618a0703e4fcdbb623f28c23c"
+            hash == "99d54d3090f932f00b77f01d12d422aacb674a6a9afd6af24f7afaaab7c3082b"
         )
     else:
         assert (
-            hash == "68703d101d8185d86ec7496285ddf46e302166c60a10372682de82f70bba847a"
+            hash == "359e38eb01415440cc8f7d9ee09612d625b8906ca09cd08c9d56f3eb972b0110"
         )
 
 

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -182,7 +182,7 @@ def test_pep517_wheel(tmp_path, monkeypatch, virtualenv):
             file_names = [p.name for p in p.iterdir()]
             metadata = p.joinpath("cmake_example-0.0.1.dist-info/METADATA").read_text()
             entry_points = p.joinpath(
-                "cmake_example-0.0.1.dist-info/entrypoints.txt"
+                "cmake_example-0.0.1.dist-info/entry_points.txt"
             ).read_text()
 
         assert len(file_names) == 2

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -39,12 +39,12 @@ def test_pep518_sdist():
         if sys.version_info < (3, 9):
             assert (
                 hash
-                == "600ed996e51642027557759ee9eeb31b5cae1f443313f5f7d0a40d9cc9cbdd13"
+                == "3b4af3fbe3d4505415bb1e55bb2e49902f4633d371ae7288007d90eb1488bc4d"
             )
         else:
             assert (
                 hash
-                == "4f47a4e797db1cb8e15afb368360d5f2ac5ae4b6c7e38e0771f8eba65fab65e4"
+                == "d373b8458ee37b176cfd03f0f3199b30fdb034bca465b2826392a6c3af85ca4c"
             )
 
     with tarfile.open(sdist) as f:


### PR DESCRIPTION
This fixes the `entry_points`, including `[project.scripts]`.