### PR TITLE
feat: build directory setting & reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ strict-config = true
 # scikit-build-core version.
 minimum-version = "0.1"  # current version
 
+# Build directory (empty will use a temporary directory)
+build-dir = ""
+
 [tool.scikit-build.cmake.define]
 # Put CMake defines in this table.
 ```

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -131,7 +131,6 @@ def build_wheel(
 
         # A build dir can be specified, otherwise use a temporary directory
         build_dir = settings.cmake.build_dir or build_tmp_folder / "build"
-
         logger.info("Build directory: {}", build_dir.resolve())
 
         wheel_dirs = {

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -128,7 +128,11 @@ def build_wheel(
     with tempfile.TemporaryDirectory() as tmpdir:
         build_tmp_folder = Path(tmpdir)
         wheel_dir = build_tmp_folder / "wheel"
-        build_dir = build_tmp_folder / "build"
+
+        # A build dir can be specified, otherwise use a temporary directory
+        build_dir = settings.cmake.build_dir or build_tmp_folder / "build"
+
+        logger.info("Build directory: {}", build_dir.resolve())
 
         wheel_dirs = {
             "platlib": wheel_dir / "platlib",

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -130,7 +130,11 @@ def build_wheel(
         wheel_dir = build_tmp_folder / "wheel"
 
         # A build dir can be specified, otherwise use a temporary directory
-        build_dir = settings.cmake.build_dir or build_tmp_folder / "build"
+        build_dir = (
+            Path(settings.build_dir)
+            if settings.build_dir
+            else build_tmp_folder / "build"
+        )
         logger.info("Build directory: {}", build_dir.resolve())
 
         wheel_dirs = {

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -131,7 +131,7 @@ def build_wheel(
 
         # A build dir can be specified, otherwise use a temporary directory
         build_dir = (
-            Path(settings.build_dir)
+            Path(settings.build_dir.format(cache_tag=sys.implementation.cache_tag))
             if settings.build_dir
             else build_tmp_folder / "build"
         )

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -77,11 +77,13 @@ class Builder:
         cmake_defines = dict(defines)
         cmake_args: list[str] = []
 
+        # Add site-packages to the prefix path for CMake
         site_packages = Path(sysconfig.get_path("purelib"))
         self.config.prefix_dirs.append(site_packages)
         if site_packages != DIR.parent.parent:
             self.config.prefix_dirs.append(DIR.parent.parent)
 
+        # Add the FindPython backport if needed
         fp_backport = self.settings.backport.find_python
         if fp_backport and self.config.cmake.version < Version(fp_backport):
             self.config.module_dirs.append(Path(find_python.__file__).parent.resolve())

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -92,9 +92,9 @@ class CMaker:
             with skbuild_info.open("r", encoding="utf-8") as f:
                 info = json.load(f)
 
-            cached_source_dir = info["source_dir"]
-            if cached_source_dir != self.source_dir:
-                logger.info(
+            cached_source_dir = Path(info["source_dir"])
+            if cached_source_dir.resolve() != self.source_dir.resolve():
+                logger.warning(
                     "Original src {} != {}, wiping build directory",
                     cached_source_dir,
                     self.source_dir,

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,4 +1,5 @@
 import dataclasses
+from pathlib import Path
 from typing import Dict, List, Optional
 
 __all__ = [
@@ -45,6 +46,9 @@ class CMakeSettings:
     #: Valid options are: "Debug", "Release", "RelWithDebInfo", "MinSizeRel",
     #: "", etc.
     build_type: str = "Release"
+
+    #: The build directory. Defaults to a temporary directory, but can be set.
+    build_dir: Optional[Path] = None
 
 
 @dataclasses.dataclass

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,5 +1,4 @@
 import dataclasses
-from pathlib import Path
 from typing import Dict, List, Optional
 
 __all__ = [
@@ -46,9 +45,6 @@ class CMakeSettings:
     #: Valid options are: "Debug", "Release", "RelWithDebInfo", "MinSizeRel",
     #: "", etc.
     build_type: str = "Release"
-
-    #: The build directory. Defaults to a temporary directory, but can be set.
-    build_dir: Optional[Path] = None
 
 
 @dataclasses.dataclass
@@ -124,3 +120,6 @@ class ScikitBuildSettings:
 
     #: If set, this will provide a method for backward compatibility.
     minimum_version: Optional[str] = None
+
+    #: The build directory. Defaults to a temporary directory, but can be set.
+    build_dir: str = ""

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -60,9 +60,9 @@ def test_init_cache(fp, tmp_path):
     assert (
         cmake_init.read_text()
         == f"""\
-set(SKBUILD ON CACHE BOOL "")
-set(SKBUILD_VERSION [===[1.0.0]===] CACHE STRING "")
-set(SKBUILD_PATH [===[{source_dir_str}]===] CACHE PATH "")
+set(SKBUILD ON CACHE BOOL "" FORCE)
+set(SKBUILD_VERSION [===[1.0.0]===] CACHE STRING "" FORCE)
+set(SKBUILD_PATH [===[{source_dir_str}]===] CACHE PATH "" FORCE)
 """
     )
 

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -126,7 +126,7 @@ def test_pep518_rebuild_build_dir(isolated, monkeypatch, tmp_path, build_args):
             "build",
             *build_args,
             "--config-setting=logging.level=DEBUG",
-            f"--config-setting=cmake.build-dir={build_dir}",
+            f"--config-setting=build-dir={build_dir}",
         )
     (wheel,) = dist.glob("cmake_example-0.0.1-*.whl")
 

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -25,6 +26,7 @@ def test_skbuild_settings_default(tmp_path):
     assert settings.cmake.args == []
     assert settings.cmake.define == {}
     assert not settings.cmake.verbose
+    assert settings.cmake.build_dir is None
     assert settings.cmake.build_type == "Release"
     assert settings.logging.level == "WARNING"
     assert settings.sdist.include == []
@@ -50,6 +52,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_CMAKE_ARGS", "-DFOO=BAR;-DBAR=FOO")
     monkeypatch.setenv("SKBUILD_CMAKE_DEFINE", "a=1;b=2")
     monkeypatch.setenv("SKBUILD_CMAKE_BUILD_TYPE", "Debug")
+    monkeypatch.setenv("SKBUILD_CMAKE_BUILD_DIR", "a/b/c")
     monkeypatch.setenv("SKBUILD_LOGGING_LEVEL", "DEBUG")
     monkeypatch.setenv("SKBUILD_SDIST_INCLUDE", "a;b; c")
     monkeypatch.setenv("SKBUILD_SDIST_EXCLUDE", "d;e;f")
@@ -78,6 +81,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
+    assert settings.cmake.build_dir == Path("a/b/c")
     assert not settings.ninja.make_fallback
     assert settings.logging.level == "DEBUG"
     assert settings.sdist.include == ["a", "b", "c"]
@@ -109,6 +113,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
         "cmake.define.b": "2",
         "cmake.verbose": "true",
         "cmake.build-type": "Debug",
+        "cmake.build-dir": "a/b/c",
         "logging.level": "INFO",
         "sdist.include": ["a", "b", "c"],
         "sdist.exclude": "d;e;f",
@@ -133,6 +138,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
+    assert settings.cmake.build_dir == Path("a/b/c")
     assert settings.logging.level == "INFO"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]
@@ -162,6 +168,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
             cmake.define = {a = "1", b = "2"}
             cmake.build-type = "Debug"
             cmake.verbose = true
+            cmake.build-dir = "a/b/c"
             logging.level = "ERROR"
             sdist.include = ["a", "b", "c"]
             sdist.exclude = ["d", "e", "f"]
@@ -191,6 +198,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
+    assert settings.cmake.build_dir == Path("a/b/c")
     assert settings.logging.level == "ERROR"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import textwrap
-from pathlib import Path
 
 import pytest
 
@@ -26,7 +25,6 @@ def test_skbuild_settings_default(tmp_path):
     assert settings.cmake.args == []
     assert settings.cmake.define == {}
     assert not settings.cmake.verbose
-    assert settings.cmake.build_dir is None
     assert settings.cmake.build_type == "Release"
     assert settings.logging.level == "WARNING"
     assert settings.sdist.include == []
@@ -39,6 +37,7 @@ def test_skbuild_settings_default(tmp_path):
     assert settings.strict_config
     assert not settings.experimental
     assert settings.minimum_version is None
+    assert settings.build_dir == ""
 
 
 def test_skbuild_settings_envvar(tmp_path, monkeypatch):
@@ -52,7 +51,6 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_CMAKE_ARGS", "-DFOO=BAR;-DBAR=FOO")
     monkeypatch.setenv("SKBUILD_CMAKE_DEFINE", "a=1;b=2")
     monkeypatch.setenv("SKBUILD_CMAKE_BUILD_TYPE", "Debug")
-    monkeypatch.setenv("SKBUILD_CMAKE_BUILD_DIR", "a/b/c")
     monkeypatch.setenv("SKBUILD_LOGGING_LEVEL", "DEBUG")
     monkeypatch.setenv("SKBUILD_SDIST_INCLUDE", "a;b; c")
     monkeypatch.setenv("SKBUILD_SDIST_EXCLUDE", "d;e;f")
@@ -65,6 +63,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_EXPERIMENTAL", "1")
     monkeypatch.setenv("SKBUILD_MINIMUM_VERSION", "0.1")
     monkeypatch.setenv("SKBUILD_CMAKE_VERBOSE", "TRUE")
+    monkeypatch.setenv("SKBUILD_BUILD_DIR", "a/b/c")
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -81,7 +80,6 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
-    assert settings.cmake.build_dir == Path("a/b/c")
     assert not settings.ninja.make_fallback
     assert settings.logging.level == "DEBUG"
     assert settings.sdist.include == ["a", "b", "c"]
@@ -94,6 +92,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     assert not settings.strict_config
     assert settings.experimental
     assert settings.minimum_version == "0.1"
+    assert settings.build_dir == "a/b/c"
 
 
 def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
@@ -113,7 +112,6 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
         "cmake.define.b": "2",
         "cmake.verbose": "true",
         "cmake.build-type": "Debug",
-        "cmake.build-dir": "a/b/c",
         "logging.level": "INFO",
         "sdist.include": ["a", "b", "c"],
         "sdist.exclude": "d;e;f",
@@ -125,6 +123,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
         "strict-config": "false",
         "experimental": "1",
         "minimum-version": "0.1",
+        "build-dir": "a/b/c",
     }
 
     settings_reader = SettingsReader(pyproject_toml, config_settings)
@@ -138,7 +137,6 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
-    assert settings.cmake.build_dir == Path("a/b/c")
     assert settings.logging.level == "INFO"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]
@@ -150,6 +148,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
     assert not settings.strict_config
     assert settings.experimental
     assert settings.minimum_version == "0.1"
+    assert settings.build_dir == "a/b/c"
 
 
 def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
@@ -168,7 +167,6 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
             cmake.define = {a = "1", b = "2"}
             cmake.build-type = "Debug"
             cmake.verbose = true
-            cmake.build-dir = "a/b/c"
             logging.level = "ERROR"
             sdist.include = ["a", "b", "c"]
             sdist.exclude = ["d", "e", "f"]
@@ -180,6 +178,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
             strict-config = false
             experimental = true
             minimum-version = "0.1"
+            build-dir = "a/b/c"
             """
         ),
         encoding="utf-8",
@@ -198,7 +197,6 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.verbose
     assert settings.cmake.build_type == "Debug"
-    assert settings.cmake.build_dir == Path("a/b/c")
     assert settings.logging.level == "ERROR"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]
@@ -210,6 +208,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
     assert not settings.strict_config
     assert settings.experimental
     assert settings.minimum_version == "0.1"
+    assert settings.build_dir == "a/b/c"
 
 
 def test_skbuild_settings_pyproject_toml_broken(tmp_path, capsys):


### PR DESCRIPTION
Support for custom build directory, opt-in. Using `FORCE` for the moment. Doesn't try to rewrite the paths for moving CMake yet, but the info for this is there in the new json file.

Maybe this shouldn't have a `cmake.` prefix? Edit: yes, looks like we could sync-up with meson-python if we just use `build-dir`, so let's go with that. See https://github.com/mesonbuild/meson-python/issues/275 for `builddir` -> `build-dir` there.

- [x] TODO: this should be able to (maybe via substitution?) have a unique path per interpreter.

Might adjust this later. My thought is we can make this opt-in for now, then if we make it opt-out, we can protect the change on a minimum version selection.