### PR TITLE
Add isolated marker to test_pep518_sdist

### DIFF
--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -13,6 +13,7 @@ DIR = Path(__file__).parent.resolve()
 HELLO_PEP518 = DIR / "packages/simple_pyproject_ext"
 
 
+@pytest.mark.isolated()
 @pytest.mark.integration()
 def test_pep518_sdist():
     correct_metadata = textwrap.dedent(


### PR DESCRIPTION
The `python -m build --sdist` command used in this test creates an isolated venv which requires wheels for pybind11 and scikit_build_core[rich]:

```
[   45s] =================================== FAILURES ===================================
[   45s] ______________________________ test_pep518_sdist _______________________________
[   45s] 
[   45s]     @pytest.mark.integration
[   45s]     def test_pep518_sdist():
[   45s]         correct_metadata = textwrap.dedent(
[   45s]             """\
[   45s]             Metadata-Version: 2.1
[   45s]             Name: cmake-example
[   45s]             Version: 0.0.1
[   45s]             Requires-Python: >=3.7
[   45s]             Provides-Extra: test
[   45s]             Requires-Dist: pytest>=6.0; extra == "test"
[   45s]             """
[   45s]         )
[   45s]     
[   45s]         dist = HELLO_PEP518 / "dist"
[   45s]         shutil.rmtree(dist, ignore_errors=True)
[   45s] >       subprocess.run(
[   45s]             [sys.executable, "-m", "build", "--sdist"], cwd=HELLO_PEP518, check=True
[   45s]         )
[   45s] 
[   45s] tests/test_pyproject_pep518.py:31: 
[   45s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   45s] 
[   45s] input = None, capture_output = False, timeout = None, check = True
[   45s] popenargs = (['/usr/bin/python3.8', '-m', 'build', '--sdist'],)
[   45s] kwargs = {'cwd': PosixPath('/home/abuild/rpmbuild/BUILD/scikit_build_core-0.1.5/tests/packages/simple_pyproject_ext')}
[   45s] process = <subprocess.Popen object at 0x7effdbfafa00>, stdout = None
[   45s] stderr = None, retcode = 1
[   45s] 
[   45s]     def run(*popenargs,
[   45s]             input=None, capture_output=False, timeout=None, check=False, **kwargs):
[   45s]         """Run command with arguments and return a CompletedProcess instance.
[   45s]     
[   45s]         The returned instance will have attributes args, returncode, stdout and
[   45s]         stderr. By default, stdout and stderr are not captured, and those attributes
[   45s]         will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.
[   45s]     
[   45s]         If check is True and the exit code was non-zero, it raises a
[   45s]         CalledProcessError. The CalledProcessError object will have the return code
[   45s]         in the returncode attribute, and output & stderr attributes if those streams
[   45s]         were captured.
[   45s]     
[   45s]         If timeout is given, and the process takes too long, a TimeoutExpired
[   45s]         exception will be raised.
[   45s]     
[   45s]         There is an optional argument "input", allowing you to
[   45s]         pass bytes or a string to the subprocess's stdin.  If you use this argument
[   45s]         you may not also use the Popen constructor's "stdin" argument, as
[   45s]         it will be used internally.
[   45s]     
[   45s]         By default, all communication is in bytes, and therefore any "input" should
[   45s]         be bytes, and the stdout and stderr will be bytes. If in text mode, any
[   45s]         "input" should be a string, and stdout and stderr will be strings decoded
[   45s]         according to locale encoding, or by "encoding" if set. Text mode is
[   45s]         triggered by setting any of text, encoding, errors or universal_newlines.
[   45s]     
[   45s]         The other arguments are the same as for the Popen constructor.
[   45s]         """
[   45s]         if input is not None:
[   45s]             if kwargs.get('stdin') is not None:
[   45s]                 raise ValueError('stdin and input arguments may not both be used.')
[   45s]             kwargs['stdin'] = PIPE
[   45s]     
[   45s]         if capture_output:
[   45s]             if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
[   45s]                 raise ValueError('stdout and stderr arguments may not be used '
[   45s]                                  'with capture_output.')
[   45s]             kwargs['stdout'] = PIPE
[   45s]             kwargs['stderr'] = PIPE
[   45s]     
[   45s]         with Popen(*popenargs, **kwargs) as process:
[   45s]             try:
[   45s]                 stdout, stderr = process.communicate(input, timeout=timeout)
[   45s]             except TimeoutExpired as exc:
[   45s]                 process.kill()
[   45s]                 if _mswindows:
[   45s]                     # Windows accumulates the output in a single blocking
[   45s]                     # read() call run on child threads, with the timeout
[   45s]                     # being done in a join() on those threads.  communicate()
[   45s]                     # _after_ kill() is required to collect that and add it
[   45s]                     # to the exception.
[   45s]                     exc.stdout, exc.stderr = process.communicate()
[   45s]                 else:
[   45s]                     # POSIX _communicate already populated the output so
[   45s]                     # far into the TimeoutExpired exception.
[   45s]                     process.wait()
[   45s]                 raise
[   45s]             except:  # Including KeyboardInterrupt, communicate handled that.
[   45s]                 process.kill()
[   45s]                 # We don't call process.wait() as .__exit__ does that for us.
[   45s]                 raise
[   45s]             retcode = process.poll()
[   45s]             if check and retcode:
[   45s] >               raise CalledProcessError(retcode, process.args,
[   45s]                                          output=stdout, stderr=stderr)
[   45s] E               subprocess.CalledProcessError: Command '['/usr/bin/python3.8', '-m', 'build', '--sdist']' returned non-zero exit status 1.
[   45s] 
[   45s] /usr/lib64/python3.8/subprocess.py:516: CalledProcessError
[   45s] ----------------------------- Captured stdout call -----------------------------
[   45s] * Creating venv isolated environment...
[   45s] * Installing packages in isolated environment... (pybind11, scikit_build_core[rich])
[   45s] 
[   45s] Traceback (most recent call last):
[   45s]   File "/usr/lib/python3.8/site-packages/build/__main__.py", line 373, in main
[   45s]     built = build_call(
[   45s]   File "/usr/lib/python3.8/site-packages/build/__main__.py", line 206, in build_package
[   45s]     out = _build(isolation, builder, outdir, distribution, config_settings, skip_dependency_check)
[   45s]   File "/usr/lib/python3.8/site-packages/build/__main__.py", line 143, in _build
[   45s]     return _build_in_isolated_env(builder, outdir, distribution, config_settings)
[   45s]   File "/usr/lib/python3.8/site-packages/build/__main__.py", line 111, in _build_in_isolated_env
[   45s]     env.install(builder.build_system_requires)
[   45s]   File "/usr/lib/python3.8/site-packages/build/env.py", line 211, in install
[   45s]     _subprocess(cmd)
[   45s]   File "/usr/lib/python3.8/site-packages/build/env.py", line 76, in _subprocess
[   45s]     raise e
[   45s]   File "/usr/lib/python3.8/site-packages/build/env.py", line 73, in _subprocess
[   45s]     subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
[   45s]   File "/usr/lib64/python3.8/subprocess.py", line 516, in run
[   45s]     raise CalledProcessError(retcode, process.args,
[   45s] subprocess.CalledProcessError: Command '['/tmp/build-env-9e25atfi/bin/python', '-Im', 'pip', 'install', '--use-pep517', '--no-warn-script-location', '-r', '/tmp/build-reqs-rm8cg3wu.txt']' returned non-zero exit status 1.
[   45s] 
[   45s] ERROR Command '['/tmp/build-env-9e25atfi/bin/python', '-Im', 'pip', 'install', '--use-pep517', '--no-warn-script-location', '-r', '/tmp/build-reqs-rm8cg3wu.txt']' returned non-zero exit status 1.
[   45s] ----------------------------- Captured stderr call -----------------------------
[   45s] WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f70d0640e50>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/scikit-build-core/
[   45s] WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f70d065a190>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/scikit-build-core/
[   45s] WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f70d065a400>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/scikit-build-core/
[   45s] WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f70d065a5b0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/scikit-build-core/
[   45s] WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f70d065a760>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/scikit-build-core/
[   45s] ERROR: Could not find a version that satisfies the requirement scikit_build_core[rich] (from versions: none)
[   45s] ERROR: No matching distribution found for scikit_build_core[rich]
```