### PR TITLE
fix: remove duplicate ruff code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ select = [
   "EM",          # flake8-errmsg
   "ICN",         # flake8-import-conventions
   "ISC",         # flake8-implicit-str-concat
-  "ISC",         # flake8-implicit-str-concat
   "PGH",         # pygrep-hooks
   "PIE",         # flake8-pie
   "PL",          # pylint


### PR DESCRIPTION
This tiny PR removes a duplicate code definition in the `ruff` configuration.