### PR TITLE
chore: fix ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ target-version = "py37"
 typing-modules = ["scikit_build_core._compat.typing"]
 src = ["src"]
 unfixable = ["T20"]
+exclude = []
 
 [tool.ruff.per-file-ignores]
 "tests/**" = ["T20"]

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -34,9 +34,8 @@ def each_unignored_file(
     Runs through all non-ignored files. Must be run from the root directory.
     """
     exclude_lines = EXCLUDE_LINES + list(exclude)
-    with contextlib.suppress(FileNotFoundError), open(
-        ".gitignore", encoding="utf-8"
-    ) as f:
+    gi = Path(".gitignore")
+    with contextlib.suppress(FileNotFoundError), gi.open(encoding="utf-8") as f:
         exclude_lines += f.readlines()
 
     exclude_spec = pathspec.GitIgnoreSpec.from_lines(exclude_lines)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -149,14 +149,15 @@ def build_wheel(
             d.mkdir(parents=True)
 
         if ".." in settings.wheel.install_dir:
-            raise AssertionError("wheel.install_dir must not contain '..'")
+            msg = "wheel.install_dir must not contain '..'"
+            raise AssertionError(msg)
         if settings.wheel.install_dir.startswith("/"):
             if not settings.experimental:
-                raise AssertionError(
-                    "Experimental features must be enabled to use absolute paths in wheel.install_dir"
-                )
+                msg = "Experimental features must be enabled to use absolute paths in wheel.install_dir"
+                raise AssertionError(msg)
             if settings.wheel.install_dir[1:].split("/")[0] not in wheel_dirs:
-                raise AssertionError("Must target a valid wheel directory")
+                msg = "Must target a valid wheel directory"
+                raise AssertionError(msg)
             install_dir = wheel_dir / settings.wheel.install_dir[1:]
         else:
             install_dir = wheel_dirs["platlib"] / settings.wheel.install_dir


### PR DESCRIPTION
Some of our files are being skipped because they have "build" in the name. Noticed this in https://github.com/pypa/build/pull/573, and turns out problems were being masked here too.
