### PR TITLE
chore: bump ruff and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,13 @@ repos:
         exclude: "^tests"
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.239
+    rev: v0.0.243
     hooks:
       - id: ruff
         args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.0
     hooks:
       - id: mypy
         exclude: tests/packages/(simplest_c/src/simplest/__init__.py|.*/setup.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ select = [
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
 ]
-ignore = ["PLR2004", "E501"]
+extend-ignore = ["PLR0915", "PLR0912", "PLR2004", "E501"]
 target-version = "py37"
 typing-modules = ["scikit_build_core._compat.typing"]
 src = ["src"]

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -29,7 +29,7 @@ def __dir__() -> list[str]:
 
 
 @functools.lru_cache(maxsize=2)
-def known_wheels(name: Literal["ninja", "cmake"]) -> frozenset[str]:  # noqa: F821
+def known_wheels(name: Literal["ninja", "cmake"]) -> frozenset[str]:
     with resources.joinpath("known_wheels.toml").open("rb") as f:
         return frozenset(tomllib.load(f)["tool"]["scikit-build"][name]["known-wheels"])
 


### PR DESCRIPTION
Relative imports now work for typing-modules. :)

Closes #192.