### PR TITLE
chore: Self usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     rev: v0.0.246
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
@@ -80,6 +80,7 @@ repos:
           - rich
           - tomli
           - types-setuptools
+          - typing_extensions >=4; python_version<'3.11'
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,8 +170,9 @@ messages_control.disable = [
 
 [tool.coverage]
 report.exclude_lines = [
-  "pragma: no cover",
+  'pragma: no cover',
   '\.\.\.',
+  'if typing.TYPE_CHECKING:',
 ]
 
 [tool.check-wheel-contents]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "importlib_resources>=1.3; python_version<'3.9'",
     "packaging >=20.9",
     "tomli >=1.1; python_version<'3.11'",
+    "typing_extensions >=3.10.0; python_version<'3.8'",
 ]
 # Note: for building wheels and sdists, there are also additional dependencies
 # in the pyproject extra. And cmake and possibly ninja if those are not already

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "importlib_resources>=1.3; python_version<'3.9'",
     "packaging >=20.9",
     "tomli >=1.1; python_version<'3.11'",
-    "typing_extensions >=3.10.0; python_version<'3.8'",
 ]
 # Note: for building wheels and sdists, there are also additional dependencies
 # in the pyproject extra. And cmake and possibly ninja if those are not already

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
 import sys
+import typing
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol, runtime_checkable
+    if typing.TYPE_CHECKING:
+        from typing_extensions import Literal, Protocol, runtime_checkable
+    else:
+        Literal = object
+        Protocol = object
+
+        def runtime_checkable(x):
+            return x
+
 else:
     from typing import Literal, Protocol, runtime_checkable
 
-__all__ = ["Protocol", "runtime_checkable", "Literal"]
+if sys.version_info < (3, 11):
+    if typing.TYPE_CHECKING:
+        from typing_extensions import Self
+    else:
+        Self = object
+
+__all__ = ["Protocol", "runtime_checkable", "Literal", "Self"]
 
 
 def __dir__() -> list[str]:

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -5,7 +5,6 @@ import typing
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal, Protocol, runtime_checkable
-
 else:
     from typing import Literal, Protocol, runtime_checkable
 

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -4,14 +4,7 @@ import sys
 import typing
 
 if sys.version_info < (3, 8):
-    if typing.TYPE_CHECKING:
-        from typing_extensions import Literal, Protocol, runtime_checkable
-    else:
-        Literal = object
-        Protocol = object
-
-        def runtime_checkable(x):
-            return x
+    from typing_extensions import Literal, Protocol, runtime_checkable
 
 else:
     from typing import Literal, Protocol, runtime_checkable

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -21,6 +21,8 @@ if sys.version_info < (3, 11):
         from typing_extensions import Self
     else:
         Self = object
+else:
+    from typing import Self
 
 __all__ = ["Protocol", "runtime_checkable", "Literal", "Self"]
 

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -14,7 +14,6 @@ from collections.abc import Set
 from email.message import Message
 from email.policy import EmailPolicy
 from pathlib import Path, PurePosixPath
-from typing import TypeVar
 from zipfile import ZipInfo
 
 import packaging.utils
@@ -22,13 +21,12 @@ from packaging.tags import Tag
 from packaging.utils import BuildTag
 from pyproject_metadata import StandardMetadata
 
+from .._compat.typing import Self
 from .._version import __version__
 
 EMAIL_POLICY = EmailPolicy(max_line_length=0, mangle_from_=False, utf8=True)
 
 MIN_TIMESTAMP = 315532800  # 1980-01-01 00:00:00 UTC
-
-WWSelf = TypeVar("WWSelf", bound="WheelWriter")
 
 
 def _b64encode(data: bytes) -> bytes:
@@ -170,7 +168,7 @@ class WheelWriter:
             zinfo.external_attr = 0o664 << 16
         self.zipfile.writestr(zinfo, data)
 
-    def __enter__(self: WWSelf) -> WWSelf:
+    def __enter__(self) -> Self:
         if not self.wheelpath.parent.exists():
             self.wheelpath.parent.mkdir(parents=True)
 

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -4,10 +4,10 @@ import dataclasses
 import itertools
 import sys
 from collections.abc import Iterable, Sequence
-from typing import TypeVar
 
 import packaging.tags
 
+from .._compat.typing import Self
 from .._logging import logger
 from .macos import get_macosx_deployment_target
 
@@ -16,9 +16,6 @@ __all__ = ["WheelTag"]
 
 def __dir__() -> list[str]:
     return __all__
-
-
-Self = TypeVar("Self", bound="WheelTag")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -30,7 +27,7 @@ class WheelTag:
     # TODO: plats only used on macOS
     @classmethod
     def compute_best(
-        cls: type[Self],
+        cls,
         archs: Sequence[str],
         py_api: str = "",
         expand_macos: bool = False,

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -10,10 +10,11 @@ import sys
 import textwrap
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Generator, TypeVar
+from typing import Generator
 
 from packaging.version import Version
 
+from ._compat.typing import Self
 from ._logging import logger
 from ._shutil import Run
 from ._version import __version__
@@ -29,8 +30,6 @@ def __dir__() -> list[str]:
 
 DIR = Path(__file__).parent.resolve()
 
-Self = TypeVar("Self", bound="CMake")
-
 
 @dataclasses.dataclass(frozen=True)
 class CMake:
@@ -39,7 +38,7 @@ class CMake:
 
     @classmethod
     def default_search(
-        cls: type[Self], *, minimum_version: Version | None = None, module: bool = True
+        cls, *, minimum_version: Version | None = None, module: bool = True
     ) -> Self:
         candidates = get_cmake_programs(module=module)
         cmake_program = best_program(candidates, minimum_version=minimum_version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ from venv import EnvBuilder
 if sys.version_info < (3, 8):
     import importlib_metadata as metadata
     from typing_extensions import Literal, overload
-
 else:
     from importlib import metadata
     from typing import Literal, overload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import sys
 import types
-import typing
 import warnings
 from collections.abc import Generator
 from pathlib import Path
@@ -14,14 +13,7 @@ from venv import EnvBuilder
 
 if sys.version_info < (3, 8):
     import importlib_metadata as metadata
-
-    if typing.TYPE_CHECKING:
-        from typing_extensions import Literal, overload
-    else:
-        Literal = object
-
-        def overload(x):
-            return x
+    from typing_extensions import Literal, overload
 
 else:
     from importlib import metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import types
+import typing
 import warnings
 from collections.abc import Generator
 from pathlib import Path
@@ -13,7 +14,15 @@ from venv import EnvBuilder
 
 if sys.version_info < (3, 8):
     import importlib_metadata as metadata
-    from typing_extensions import Literal, overload
+
+    if typing.TYPE_CHECKING:
+        from typing_extensions import Literal, overload
+    else:
+        Literal = object
+
+        def overload(x):
+            return x
+
 else:
     from importlib import metadata
     from typing import Literal, overload


### PR DESCRIPTION
Using self with mypy 1.0. Not requiring it at runtime. Typing extensions is required for <3.8 still, since it's used at runtime. Also enabling the shiny new `--show-fixes` in Ruff! :)