### PR TITLE
Add rpm spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ tests/**/build/
 
 # VIM temp files
 *~
+
+# RPM spec file
+!/scikit-build-core.spec

--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/scikit-build-core.spec
+++ b/scikit-build-core.spec
@@ -1,0 +1,70 @@
+%global forgeurl https://github.com/scikit-build/scikit-build-core
+# TODO: Retrieve version dynamically. Might not work in copr though
+
+Name:           python-scikit-build-core
+Version:        0.2.1
+Release:        1%{?dist}
+Summary:        Build backend for CMake based projects
+%forgemeta
+
+License:        ASL 2.0
+URL:            %{forgeurl}
+Source0:        %{forgesource}
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(hatch-vcs)
+# TODO: Remove when irrelevant
+# Required by commit https://github.com/pypa/setuptools_scm/commit/4c2cf6e3a369afa05131d6fb3d790822b019abf0
+BuildRequires:  python3-setuptools_scm >= 7.1.0
+BuildRequires:  cmake
+BuildRequires:  ninja-build
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  git
+Recommends:     (ninja-build or make)
+Suggests:       gcc
+Suggests:       clang
+Requires:       python3dist(pyproject-metadata)
+Requires:       python3dist(pathspec)
+
+%global _description %{expand:
+A next generation Python CMake adaptor and Python API for plugins}
+
+%description %_description
+
+%package -n python3-scikit-build-core
+Summary:        %{summary}
+%description -n python3-scikit-build-core %_description
+
+%prep
+%setup -q
+# TODO: Remove when tito upstream issue is fixed
+# https://github.com/rpm-software-management/tito/issues/444
+if grep -q "describe-name: \$Format" .git_archival.txt; then
+   sed -i "s/describe-name:.*/describe-name: v%{version}/g" .git_archival.txt
+fi
+
+%generate_buildrequires
+%pyproject_buildrequires -x test
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files scikit_build_core
+
+
+%check
+%pytest \
+    -m "not isolated"
+
+
+%files -n python3-scikit-build-core -f %{pyproject_files}
+%license
+
+%changelog
+%autochangelog

--- a/scikit-build-core.spec
+++ b/scikit-build-core.spec
@@ -1,33 +1,27 @@
 %global forgeurl https://github.com/scikit-build/scikit-build-core
-# TODO: Retrieve version dynamically. Might not work in copr though
 
 Name:           python-scikit-build-core
-Version:        0.2.1
-Release:        1%{?dist}
+Version:        0.2.2
+Release:        %{autorelease}
 Summary:        Build backend for CMake based projects
 %forgemeta
 
-License:        ASL 2.0
+License:        Apache-2.0
 URL:            %{forgeurl}
 Source0:        %{forgesource}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
-BuildRequires:  python3dist(hatchling)
-BuildRequires:  python3dist(hatch-vcs)
-# TODO: Remove when irrelevant
-# Required by commit https://github.com/pypa/setuptools_scm/commit/4c2cf6e3a369afa05131d6fb3d790822b019abf0
-BuildRequires:  python3-setuptools_scm >= 7.1.0
 BuildRequires:  cmake
 BuildRequires:  ninja-build
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
-BuildRequires:  git
+Requires:       cmake
 Recommends:     (ninja-build or make)
+Recommends:     python3dist(pyproject-metadata)
+Recommends:     python3dist(pathspec)
+Suggests:       ninja-build
 Suggests:       gcc
-Suggests:       clang
-Requires:       python3dist(pyproject-metadata)
-Requires:       python3dist(pathspec)
 
 %global _description %{expand:
 A next generation Python CMake adaptor and Python API for plugins}
@@ -39,6 +33,10 @@ Summary:        %{summary}
 %description -n python3-scikit-build-core %_description
 
 %prep
+# This assumes the source is not retrieved from tar ball, but built in place
+# This makes it possible to build with `tito build --test`
+# Change to `%%autosetup -n %%{pypi_name}-%%{version}` for release
+# TODO: There should be a format to satisfy both
 %setup -q
 # TODO: Remove when tito upstream issue is fixed
 # https://github.com/rpm-software-management/tito/issues/444
@@ -64,7 +62,8 @@ fi
 
 
 %files -n python3-scikit-build-core -f %{pyproject_files}
-%license
+%license LICENSE
+%doc README.md
 
 %changelog
 %autochangelog

--- a/scikit-build-core.spec
+++ b/scikit-build-core.spec
@@ -1,14 +1,11 @@
-%global forgeurl https://github.com/scikit-build/scikit-build-core
-
 Name:           python-scikit-build-core
 Version:        0.2.2
 Release:        %{autorelease}
 Summary:        Build backend for CMake based projects
-%forgemeta
 
 License:        Apache-2.0
-URL:            %{forgeurl}
-Source0:        %{forgesource}
+URL:            https://github.com/scikit-build/scikit-build-core
+Source0:        https://github.com/scikit-build/scikit-build-core/archive/refs/tags/v%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel


### PR DESCRIPTION
This will make it easier for maintainers to keep up to date with upstream package.

Note the version numbering is currently hard coded. It might be possible to retrieve it dynamically, but I'm not sure if it will work on copr. However this should not be much of an issue as long as we can get some notifications of the builds.