### PR TITLE
tests: support running in environments with SOURCE_DATE_EPOCH

### DIFF
--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -69,6 +69,8 @@ def test_pep517_sdist(tmp_path, monkeypatch):
 
 @mark_hashes_different
 def test_pep517_sdist_hash(tmp_path, monkeypatch):
+    # Unset SOURCE_DATE_EPOCH in order to guarantee the hash match
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     dist = tmp_path.resolve() / "dist"
     monkeypatch.chdir(HELLO_PEP518)
     if Path("dist").is_dir():


### PR DESCRIPTION
As per [this comment](https://github.com/scikit-build/scikit-build-core/pull/201#issuecomment-1467021496), `SOURCE_DATE_EPOCH` should be unset during this test. It might be necessary in some other tests, but so far no other tests were effected in #201.