### PR TITLE
feat: make sure setuptools wrapper is generic

### DIFF
--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
+import setuptools.build_meta
+from setuptools.build_meta import (
+    build_sdist,
+    build_wheel,
+    prepare_metadata_for_build_wheel,
+)
+
 from ..builder.get_requires import cmake_ninja_for_build_wheel
 
+if hasattr(setuptools.build_meta, "build_editable"):
+    from setuptools.build_meta import build_editable  # type: ignore[attr-defined]
+
+if hasattr(setuptools.build_meta, "prepare_metadata_for_build_editable"):
+    from setuptools.build_meta import (  # type: ignore[attr-defined]
+        prepare_metadata_for_build_editable,
+    )
+
+
 __all__ = [
-    "prepare_metadata_for_build_wheel",
-    "build_wheel",
+    "build_editable",
     "build_sdist",
+    "build_wheel",
+    "get_requires_for_build_editable",
     "get_requires_for_build_sdist",
     "get_requires_for_build_wheel",
+    "prepare_metadata_for_build_editable",
+    "prepare_metadata_for_build_wheel",
 ]
 
 
@@ -16,46 +35,30 @@ def __dir__() -> list[str]:
 
 
 def get_requires_for_build_sdist(
-    config_settings: dict[str, str | list[str]] | None = None  # noqa: ARG001
+    config_settings: dict[str, str | list[str]] | None = None
 ) -> list[str]:
-    return ["setuptools"]
+    setuptools_reqs = setuptools.build_meta.get_requires_for_build_sdist(
+        config_settings
+    )
+    return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]
 
 
 def get_requires_for_build_wheel(
     config_settings: dict[str, str | list[str]] | None = None
 ) -> list[str]:
-    return ["setuptools", "wheel", *cmake_ninja_for_build_wheel(config_settings)]
-
-
-def build_sdist(
-    sdist_directory: str,
-    config_settings: dict[str, str | list[str]] | None = None,
-) -> str:
-    import setuptools.build_meta
-
-    return setuptools.build_meta.build_sdist(  # type: ignore[no-any-return]
-        sdist_directory, config_settings
+    setuptools_reqs = setuptools.build_meta.get_requires_for_build_wheel(
+        config_settings
     )
 
-
-def build_wheel(
-    wheel_directory: str,
-    config_settings: dict[str, str | list[str]] | None = None,
-    metadata_directory: str | None = None,
-) -> str:
-    import setuptools.build_meta
-
-    return setuptools.build_meta.build_wheel(  # type: ignore[no-any-return]
-        wheel_directory, config_settings, metadata_directory
-    )
+    return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]
 
 
-def prepare_metadata_for_build_wheel(
-    metadata_directory: str,
-    config_settings: dict[str, str | list[str]] | None = None,
-) -> str:
-    import setuptools.build_meta
+if hasattr(setuptools.build_meta, "get_requires_for_build_editable"):
 
-    return setuptools.build_meta.prepare_metadata_for_build_wheel(  # type: ignore[no-any-return]
-        metadata_directory, config_settings
-    )
+    def get_requires_for_build_editable(
+        config_settings: dict[str, str | list[str]] | None = None
+    ) -> list[str]:
+        setuptools_reqs = setuptools.build_meta.get_requires_for_build_editable(  # type: ignore[attr-defined]
+            config_settings
+        )
+        return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]

--- a/tests/packages/abi3_setuptools_ext/pyproject.toml
+++ b/tests/packages/abi3_setuptools_ext/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["scikit-build-core"]
+requires = ["scikit-build-core", "setuptools"]
 build-backend = "scikit_build_core.setuptools.build_meta"

--- a/tests/packages/simple_setuptools_ext/pyproject.toml
+++ b/tests/packages/simple_setuptools_ext/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "scikit_build_core",
+    "setuptools",
     "pybind11",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"


### PR DESCRIPTION
This should be a safe API for third parties. Even if the setuptools wrapper is externalized.

This does require using `"scikit-build-core", "setuptools"` as requirements for now - this can be fixed later when there's a separate setuptools extension.