### PR TITLE
feat: get_requires_for_dynamic_metadata

### DIFF
--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -54,18 +54,30 @@ def build_sdist(
 
 
 def get_requires_for_build_sdist(
-    config_settings: dict[str, str | list[str]] | None = None  # noqa: ARG001
+    config_settings: dict[str, str | list[str]] | None = None
 ) -> list[str]:
-    return ["pathspec", "pyproject_metadata"]
+    from ..builder.get_requires import GetRequires
+
+    requires = GetRequires(config_settings)
+
+    return [
+        "pathspec",
+        "pyproject_metadata",
+        *requires.dynamic_metadata(),
+    ]
 
 
 def get_requires_for_build_wheel(
     config_settings: dict[str, str | list[str]] | None = None,
 ) -> list[str]:
-    from ..builder.get_requires import cmake_ninja_for_build_wheel
+    from ..builder.get_requires import GetRequires
+
+    requires = GetRequires(config_settings)
 
     return [
         "pathspec",
         "pyproject_metadata",
-        *cmake_ninja_for_build_wheel(config_settings),
+        *requires.cmake(),
+        *requires.ninja(),
+        *requires.dynamic_metadata(),
     ]

--- a/src/scikit_build_core/metadata/fancy_pypi_readme.py
+++ b/src/scikit_build_core/metadata/fancy_pypi_readme.py
@@ -26,3 +26,9 @@ def dynamic_metadata(
             "text": build_text(config.fragments, config.substitutions),
         }
     }
+
+
+def get_requires_for_dynamic_metadata(
+    _config_settings: dict[str, list[str] | str] | None = None,
+) -> list[str]:
+    return ["hatch-fancy-pypi-readme"]

--- a/src/scikit_build_core/metadata/setuptools_scm.py
+++ b/src/scikit_build_core/metadata/setuptools_scm.py
@@ -19,3 +19,9 @@ def dynamic_metadata(
     version: str = _get_version(config)
 
     return {"version": version}
+
+
+def get_requires_for_dynamic_metadata(
+    _config_settings: dict[str, list[str] | str] | None = None,
+) -> list[str]:
+    return ["setuptools-scm"]

--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -7,8 +7,6 @@ from setuptools.build_meta import (
     prepare_metadata_for_build_wheel,
 )
 
-from ..builder.get_requires import cmake_ninja_for_build_wheel
-
 if hasattr(setuptools.build_meta, "build_editable"):
     from setuptools.build_meta import build_editable  # type: ignore[attr-defined]
 
@@ -40,17 +38,21 @@ def get_requires_for_build_sdist(
     setuptools_reqs = setuptools.build_meta.get_requires_for_build_sdist(
         config_settings
     )
-    return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]
+    return [*setuptools_reqs]
 
 
 def get_requires_for_build_wheel(
     config_settings: dict[str, str | list[str]] | None = None
 ) -> list[str]:
+    from ..builder.get_requires import GetRequires
+
+    requires = GetRequires(config_settings)
+
     setuptools_reqs = setuptools.build_meta.get_requires_for_build_wheel(
         config_settings
     )
 
-    return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]
+    return [*setuptools_reqs, *requires.cmake(), *requires.ninja()]
 
 
 if hasattr(setuptools.build_meta, "get_requires_for_build_editable"):
@@ -58,7 +60,10 @@ if hasattr(setuptools.build_meta, "get_requires_for_build_editable"):
     def get_requires_for_build_editable(
         config_settings: dict[str, str | list[str]] | None = None
     ) -> list[str]:
+        from ..builder.get_requires import GetRequires
+
+        requires = GetRequires(config_settings)
         setuptools_reqs = setuptools.build_meta.get_requires_for_build_editable(  # type: ignore[attr-defined]
             config_settings
         )
-        return [*setuptools_reqs, *cmake_ninja_for_build_wheel(config_settings)]
+        return [*setuptools_reqs, *requires.cmake(), *requires.ninja()]

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -14,6 +14,7 @@ import pytest
 
 from scikit_build_core._compat import tomllib
 from scikit_build_core.build import build_wheel
+from scikit_build_core.builder.get_requires import GetRequires
 from scikit_build_core.settings.metadata import get_standard_metadata
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
@@ -140,6 +141,11 @@ def test_plugin_metadata(tmp_path, monkeypatch):
     assert metadata.readme == pyproject_metadata.Readme(
         "Fragment #1Fragment #2", None, "text/x-rst"
     )
+
+    assert set(GetRequires().dynamic_metadata()) == {
+        "hatch-fancy-pypi-readme",
+        "setuptools-scm",
+    }
 
 
 def test_faulty_metadata(monkeypatch):

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from scikit_build_core.builder.get_requires import cmake_ninja_for_build_wheel
+from scikit_build_core.builder.get_requires import GetRequires
 
 ninja = [] if sys.platform.startswith("win") else ["ninja>=1.5"]
 
@@ -24,7 +24,8 @@ def test_get_requires_for_build_wheel(fp, monkeypatch):
     monkeypatch.setattr(shutil, "which", which_mock)
     monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([cmake, "--version"], stdout="3.14.0")
-    assert cmake_ninja_for_build_wheel() == ["cmake>=3.15", *ninja]
+    assert GetRequires().cmake() == ["cmake>=3.15"]
+    assert GetRequires().ninja() == [*ninja]
 
 
 def test_get_requires_for_build_wheel_uneeded(fp, monkeypatch):
@@ -33,7 +34,8 @@ def test_get_requires_for_build_wheel_uneeded(fp, monkeypatch):
     monkeypatch.setattr(shutil, "which", which_mock)
     monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([cmake, "--version"], stdout="3.18.0")
-    assert cmake_ninja_for_build_wheel() == [*ninja]
+    assert GetRequires().cmake() == []
+    assert GetRequires().ninja() == [*ninja]
 
 
 def test_get_requires_for_build_wheel_settings(fp, monkeypatch):
@@ -43,10 +45,8 @@ def test_get_requires_for_build_wheel_settings(fp, monkeypatch):
     monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([cmake, "--version"], stdout="3.18.0")
     config = {"cmake.minimum-version": "3.20"}
-    assert cmake_ninja_for_build_wheel(config) == [
-        "cmake>=3.20",
-        *ninja,
-    ]
+    assert GetRequires(config).cmake() == ["cmake>=3.20"]
+    assert GetRequires(config).ninja() == [*ninja]
 
 
 def test_get_requires_for_build_wheel_pyproject(fp, monkeypatch, tmp_path):
@@ -62,4 +62,6 @@ def test_get_requires_for_build_wheel_pyproject(fp, monkeypatch, tmp_path):
     monkeypatch.setattr(shutil, "which", which_mock)
     monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
     fp.register([cmake, "--version"], stdout="3.18.0")
-    assert cmake_ninja_for_build_wheel() == ["cmake>=3.21", *ninja]
+
+    assert GetRequires().cmake() == ["cmake>=3.21"]
+    assert GetRequires().ninja() == [*ninja]


### PR DESCRIPTION
Followup to https://github.com/scikit-build/scikit-build-core/pull/197. Supports hooks providing dynamic dependencies. This does not (officially, anyway, without inspecting the call stack) provide a method supporting differentiating between calling hooks.
