### PR TITLE
fix: CMake 3.26.0 (exactly) needs the backport too

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features over classic Scikit-build:
 - No dependency on setuptools, distutils, or wheel in build mode.
 - Powerful config system, including config options support in build mode.
 - Automatic inclusion of site-packages in `CMAKE_PREFIX_PATH`
-- FindPython is backported if running on CMake < 3.26 (configurable), supports
+- FindPython is backported if running on CMake < 3.26.1 (configurable), supports
   PyPY SOABI.
 - Limited API / Stable ABI and pythonless tags supported via config option
 - No slow generator search, ninja/make or MSVC used by default, respects
@@ -95,8 +95,8 @@ Python_add_library(_module MODULE src/module.c WITH_SOABI)
 install(TARGETS _module DESTINATION ${SKBUILD_PROJECT_NAME})
 ```
 
-Scikit-build-core will backport FindPython from CMake 3.26 to older versions of
-Python, and will handle PyPy for you if you are building from PyPy. You will
+Scikit-build-core will backport FindPython from CMake 3.26.1 to older versions
+of Python, and will handle PyPy for you if you are building from PyPy. You will
 need to install everything you want into the full final path inside site-modules
 (so you will usually prefix everything by the package name).
 
@@ -167,7 +167,7 @@ wheel.install-dir = "."
 # This will backport an internal copy of FindPython if CMake is less than this
 # value. Set to 0 or the empty string to disable. The default will be kept in
 # sync with the version of FindPython stored in scikit-build-core.
-backport.find-python = "3.26"
+backport.find-python = "3.26.1"
 
 # Enable experimental features if any are available
 experimental = false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ For example, to require a recent CMake and Ninja:
 
 ```toml
 [tool.scikit-build]
-cmake.minimum-version = "3.26"
+cmake.minimum-version = "3.26.1"
 ninja.minimum-version = "1.11"
 ```
 
@@ -112,9 +112,9 @@ ninja.make-fallback = false
 ```
 
 You can also control the FindPython backport; by default, a backport of CMake
-3.26's FindPython will be used if the CMake version is less than 3.26; you can
-turn this down if you'd like ("3.15", scikit-build-core's minimum version, would
-turn it off).
+3.26.1's FindPython will be used if the CMake version is less than 3.26.1; you
+can turn this down if you'd like ("3.15", scikit-build-core's minimum version,
+would turn it off).
 
 ```toml
 [tool.scikit-build]
@@ -423,10 +423,12 @@ this, you can:
 strict-config = false
 ```
 
-Scikit-build-core also occasionally has experimental features; these can only be
-used if you enable them:
+Scikit-build-core also occasionally has experimental features. This is applied
+to features that do not yet carry the same forward compatibility (using
+minimum-version) guarantee that other scikit-build-core features have. These can
+only be used if you enable them:
 
 ```toml
 [tool.cmake]
-expiremental = true
+experimental = true
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -255,7 +255,7 @@ to `pybind11::module`, your choice.
 
 ````{tab} SWIG
 
-```{literalinclude} examples/getting_started/SWIG/CMakeLists.txt
+```{literalinclude} examples/getting_started/swig/CMakeLists.txt
 :language: cmake
 ```
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -99,7 +99,7 @@ class WheelSettings:
 class BackportSettings:
     #: If CMake is less than this value, backport a copy of FindPython. Set
     #: to 0 disable this, or the empty string.
-    find_python: str = "3.26"
+    find_python: str = "3.26.1"
 
 
 @dataclasses.dataclass

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -36,11 +36,12 @@ def test_skbuild_settings_default(tmp_path):
     assert settings.wheel.packages is None
     assert settings.wheel.py_api == ""
     assert not settings.wheel.expand_macos_universal_tags
-    assert settings.backport.find_python == "3.26"
+    assert settings.backport.find_python == "3.26.1"
     assert settings.strict_config
     assert not settings.experimental
     assert settings.minimum_version is None
     assert settings.build_dir == ""
+    assert settings.metadata == {}
 
 
 def test_skbuild_settings_envvar(tmp_path, monkeypatch):
@@ -67,6 +68,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_MINIMUM_VERSION", "0.1")
     monkeypatch.setenv("SKBUILD_CMAKE_VERBOSE", "TRUE")
     monkeypatch.setenv("SKBUILD_BUILD_DIR", "a/b/c")
+    monkeypatch.setenv("SKBUILD_METADATA", "a=b;c=d")
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -96,6 +98,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     assert settings.experimental
     assert settings.minimum_version == "0.1"
     assert settings.build_dir == "a/b/c"
+    assert settings.metadata == {"a": "b", "c": "d"}
 
 
 def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
@@ -127,6 +130,8 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
         "experimental": "1",
         "minimum-version": "0.1",
         "build-dir": "a/b/c",
+        "metadata.a": "b",
+        "metadata.c": "d",
     }
 
     settings_reader = SettingsReader.from_file(pyproject_toml, config_settings)
@@ -152,6 +157,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
     assert settings.experimental
     assert settings.minimum_version == "0.1"
     assert settings.build_dir == "a/b/c"
+    assert settings.metadata == {"a": "b", "c": "d"}
 
 
 def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
@@ -182,6 +188,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
             experimental = true
             minimum-version = "0.1"
             build-dir = "a/b/c"
+            metadata = {a="b", c="d"}
             """
         ),
         encoding="utf-8",
@@ -212,6 +219,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
     assert settings.experimental
     assert settings.minimum_version == "0.1"
     assert settings.build_dir == "a/b/c"
+    assert settings.metadata == {"a": "b", "c": "d"}
 
 
 def test_skbuild_settings_pyproject_toml_broken(tmp_path, capsys):


### PR DESCRIPTION
Adding some missing tests and a bit of polish.

Also fixing a bug were 3.26.0 doesn't backport the 3.26.1 ABI3 fix.