### PR TITLE
tests: fix msys failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: python3.9 -m pytest -ra --showlocals -m "not virtualenv"
 
   msys:
-    name: Tests on 🐍 3 • msys
+    name: Tests on 🐍 3 • msys UCRT
     runs-on: windows-latest
 
     defaults:
@@ -141,21 +141,17 @@ jobs:
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: msys
+          msystem: UCRT64
           path-type: minimal
           update: true
           install: >-
             base-devel git
           pacboy: >-
-            python python-pip gcc cmake
+            python:p python-pip:p gcc:p cmake:p
 
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Fix msys by rebasing all
-        run: /usr/bin/rebaseall -v
-        shell: cmd {0}
 
       - name: Install
         run: python -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
           pip install .[test,cov] cmake ninja rich hatch-fancy-pypi-readme
           setuptools-scm
 
+      - name: Add NumPy
+        if: >
+          (matrix.runs-on == 'ubuntu-latest' || matrix.python-version !=
+          'pypy-3.8') && matrix.python-version != '3.12-dev'
+        run: "pip install --only-binary=:all: numpy"
+
       - name: Test package
         run: pytest -ra --showlocals --cov=scikit_build_core
 
@@ -121,8 +127,7 @@ jobs:
         with:
           platform: x86_64
           packages:
-            cmake ninja git make gcc-g++ gcc-fortran python39 python39-devel
-            python39-pip
+            cmake ninja git make gcc-g++ python39 python39-devel python39-pip
 
       - name: Install
         run: python3.9 -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Fix msys by rebasing all
         run: /usr/bin/rebaseall -v
-        shell: ash {0}
+        shell: cmd {0}
 
       - name: Install
         run: python -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: python -m pip install .[test]
 
       - name: Test package
-        run: python -m pytest -ra --showlocals
+        run: python -m pytest -ra --showlocals -m "not broken_on_urct"
 
   mingw64:
     name: Tests on 🐍 3 • mingw64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix msys by rebasing all
+        run: /usr/bin/rebaseall -v
+
       - name: Install
         run: python -m pip install .[test]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
 
       - name: Fix msys by rebasing all
         run: /usr/bin/rebaseall -v
+        shell: ash {0}
 
       - name: Install
         run: python -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
         with:
           cmake-version: "${{ matrix.cmake-version }}"
 
+      # Skipped on pypy to keep the tests fast
       - name: Test min package
+        if: matrix.python-version != 'pypy-3.8'
         run: pytest -ra --showlocals
 
   cygwin:

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,8 @@ def tests(session: nox.Session) -> None:
         extra.append("cmake")
     if shutil.which("ninja") is None:
         extra.append("ninja")
+    if (3, 8) <= sys.version_info < (3, 12):
+        extra.append("numpy")
 
     session.install("-e.[test]", *extra)
     session.run("pytest", *session.posargs, env=env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,13 +107,14 @@ filterwarnings = [
 log_cli_level = "info"
 testpaths = ["tests"]
 markers = [
+    "broken_on_urct: Broken for now due to lib not found",
     "compile: Compiles code",
     "configure: Configures CMake code",
     "fortran: Fortran code",
     "integration: Full package build",
+    "isolated: Needs an isolated virtualenv",
     "setuptools: Tests setuptools integration",
     "virtualenv: Needs a virtualenv",
-    "isolated: Needs an isolated virtualenv",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ test = [
     "cattrs >=22.2.0",
     "gitpython",
     "importlib_metadata; python_version<'3.8'",
-    "numpy; python_version>='3.8' and python_version<'3.12'",
     "pathspec >=0.10.1",
     "pybind11",
     "pyproject-metadata >=0.5",

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -4,7 +4,7 @@ import configparser
 import os
 import sys
 import sysconfig
-from collections.abc import Generator, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 
 from .._logging import logger
@@ -29,15 +29,6 @@ PLAT_TO_CMAKE = {
 
 def __dir__() -> list[str]:
     return __all__
-
-
-def list_files(path: Path, level: int = 0) -> Generator[str, None, None]:
-    for entry in os.scandir(path):
-        if entry.is_dir():
-            yield "  " * level + entry.name + "/"
-            yield from list_files(path / entry.name, level + 1)
-        else:
-            yield "  " * level + entry.name
 
 
 def get_python_library(env: Mapping[str, str], *, abi3: bool = False) -> Path | None:
@@ -75,7 +66,6 @@ def get_python_library(env: Mapping[str, str], *, abi3: bool = False) -> Path | 
             if Path(os.path.expandvars(libpath)).is_file():
                 return libpath
             logger.warning("libdir/ldlibrary: {} is not a real file!", libpath)
-            logger.warning("Contents:\n{}", "\n".join(list_files(libdir)))
         else:
             logger.warning("libdir: {} is not a directory", libdir)
 

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -65,6 +65,10 @@ def get_python_library(env: Mapping[str, str], *, abi3: bool = False) -> Path | 
             libpath = libdir / ldlibrary
             if Path(os.path.expandvars(libpath)).is_file():
                 return libpath
+            logger.warning("libdir/ldlibrary: {} is not a real file!", libpath)
+            logger.warning("Contents: {}", " ".join(str(x) for x in libdir.iterdir()))
+        else:
+            logger.warning("libdir: {} is not a directory", libdir)
 
     framework_prefix = sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
     if framework_prefix and Path(framework_prefix).is_dir() and ldlibrary:

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -4,7 +4,7 @@ import configparser
 import os
 import sys
 import sysconfig
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from pathlib import Path
 
 from .._logging import logger
@@ -29,6 +29,15 @@ PLAT_TO_CMAKE = {
 
 def __dir__() -> list[str]:
     return __all__
+
+
+def list_files(path: Path, level: int = 0) -> Generator[str, None, None]:
+    for entry in os.scandir(path):
+        if entry.is_dir():
+            yield "  " * level + entry.name + "/"
+            yield from list_files(path / entry.name, level + 1)
+        else:
+            yield "  " * level + entry.name
 
 
 def get_python_library(env: Mapping[str, str], *, abi3: bool = False) -> Path | None:
@@ -66,7 +75,7 @@ def get_python_library(env: Mapping[str, str], *, abi3: bool = False) -> Path | 
             if Path(os.path.expandvars(libpath)).is_file():
                 return libpath
             logger.warning("libdir/ldlibrary: {} is not a real file!", libpath)
-            logger.warning("Contents: {}", " ".join(str(x) for x in libdir.iterdir()))
+            logger.warning("Contents:\n{}", "\n".join(list_files(libdir)))
         else:
             logger.warning("libdir: {} is not a directory", libdir)
 

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -75,6 +75,7 @@ def test_pep517_sdist(tmp_path, monkeypatch):
 
 @pytest.mark.compile()
 @pytest.mark.configure()
+@pytest.mark.broken_on_urct()
 @pytest.mark.skipif(
     sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
 )

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -15,6 +15,7 @@ HELLO_PEP518 = DIR / "packages/simple_setuptools_ext"
 @pytest.mark.compile()
 @pytest.mark.configure()
 @pytest.mark.integration()
+@pytest.mark.broken_on_urct()
 @pytest.mark.skipif(
     sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
 )
@@ -56,6 +57,7 @@ def test_pep518_wheel(tmp_path, monkeypatch, isolated):
 @pytest.mark.compile()
 @pytest.mark.configure()
 @pytest.mark.integration()
+@pytest.mark.broken_on_urct()
 @pytest.mark.skipif(
     sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
 )


### PR DESCRIPTION
Testing to see if I can fix the `address space needed by '_common.cpython-311-x86_64-msys.dll' (0x620000) is already occupied` failures. Switching to UCRT instead, currently disabling a few setuptools tests to get it to pass. Speeding up the tests, too.