### PR TITLE
feat: change editable.verbose to default True

### DIFF
--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
@@ -105,10 +106,15 @@ _NO_COLORS = {color: "" for color in _COLORS}
 def colors() -> dict[str, str]:
     if "NO_COLOR" in os.environ:
         return _NO_COLORS
+    # Pip reroutes sys.stdout, so FORCE_COLOR is required there
     if os.environ.get("FORCE_COLOR", ""):
         return _COLORS
-    if sys.stdout.isatty() and not sys.platform.startswith("win"):
-        return _COLORS
+    # Avoid ValueError: I/O operation on closed file
+    with contextlib.suppress(ValueError):
+        # Assume sys.stderr is similar to sys.stdout
+        isatty = sys.stdout.isatty()
+        if isatty and not sys.platform.startswith("win"):
+            return _COLORS
     return _NO_COLORS
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -107,12 +107,12 @@ class Editable:
     #: Select the editable mode to use. Currently only "redirect" is supported.
     mode: str = "redirect"
 
-    #: Turn on verbose output for the editable mode.
-    verbose: bool = False
+    #: Turn on verbose output for the editable mode rebuilds.
+    verbose: bool = True
 
     #: Rebuild the project when the package is imported.
-    #: This will do nothing if the build-directory is not set.
-    rebuild: Optional[bool] = None
+    #: The build-directory must be set.
+    rebuild: bool = False
 
 
 @dataclasses.dataclass

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -43,8 +43,8 @@ def test_skbuild_settings_default(tmp_path):
     assert settings.build_dir == ""
     assert settings.metadata == {}
     assert settings.editable.mode == "redirect"
-    assert settings.editable.rebuild is None
-    assert not settings.editable.verbose
+    assert not settings.editable.rebuild
+    assert settings.editable.verbose
 
 
 def test_skbuild_settings_envvar(tmp_path, monkeypatch):
@@ -72,7 +72,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     monkeypatch.setenv("SKBUILD_CMAKE_VERBOSE", "TRUE")
     monkeypatch.setenv("SKBUILD_BUILD_DIR", "a/b/c")
     monkeypatch.setenv("SKBUILD_EDITABLE_REBUILD", "True")
-    monkeypatch.setenv("SKBUILD_EDITABLE_VERBOSE", "True")
+    monkeypatch.setenv("SKBUILD_EDITABLE_VERBOSE", "False")
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -105,7 +105,7 @@ def test_skbuild_settings_envvar(tmp_path, monkeypatch):
     assert settings.metadata == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
-    assert settings.editable.verbose
+    assert not settings.editable.verbose
 
 
 def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
@@ -139,7 +139,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
         "build-dir": "a/b/c",
         "editable.mode": "redirect",
         "editable.rebuild": "True",
-        "editable.verbose": "True",
+        "editable.verbose": "False",
     }
 
     settings_reader = SettingsReader.from_file(pyproject_toml, config_settings)
@@ -168,7 +168,7 @@ def test_skbuild_settings_config_settings(tmp_path, monkeypatch):
     assert settings.metadata == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
-    assert settings.editable.verbose
+    assert not settings.editable.verbose
 
 
 def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
@@ -202,7 +202,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
             metadata.version.provider = "a"
             editable.mode = "redirect"
             editable.rebuild = true
-            editable.verbose = true
+            editable.verbose = false
             """
         ),
         encoding="utf-8",
@@ -236,7 +236,7 @@ def test_skbuild_settings_pyproject_toml(tmp_path, monkeypatch):
     assert settings.metadata == {"version": {"provider": "a"}}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
-    assert settings.editable.verbose
+    assert not settings.editable.verbose
 
 
 def test_skbuild_settings_pyproject_toml_broken(tmp_path, capsys):


### PR DESCRIPTION
Since this isn't on by default and redirects to stderr, I think it's fine to default verbose to on.
