### PR TITLE
fix: unused prefix warning

### DIFF
--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -22,17 +22,7 @@ def configure_args(config: CMaker, *, init: bool = False) -> Generator[str, None
         yield f"-C{cmake_init}"
 
     if config.single_config:
-        yield f"-DCMAKE_BUILD_TYPE={config.build_type}"
-
-    if config.module_dirs:
-        yield "-DCMAKE_MODULE_PATH:PATH={}".format(
-            ";".join(str(p).replace("\\", "/") for p in config.module_dirs)
-        )
-
-    if config.prefix_dirs:
-        yield "-DCMAKE_PREFIX_PATH:PATH={}".format(
-            ";".join(str(p).replace("\\", "/") for p in config.prefix_dirs)
-        )
+        yield f"-DCMAKE_BUILD_TYPE:STRING={config.build_type}"
 
 
 @pytest.mark.configure()

--- a/tests/test_custom_modules.py
+++ b/tests/test_custom_modules.py
@@ -9,5 +9,7 @@ PROJECT_DIR = DIR / "packages" / "custom_cmake"
 def test_ep(isolated):
     isolated.install("hatchling", "scikit-build-core[pyproject]")
     isolated.install(PROJECT_DIR / "extern", isolated=False)
-    isolated.install(PROJECT_DIR, isolated=False)
+    isolated.install(
+        PROJECT_DIR, "-v", "--config-settings=logging.level=DEBUG", isolated=False
+    )
     # Needs script fix: assert isolated.run("script1") == ""

--- a/tests/test_custom_modules.py
+++ b/tests/test_custom_modules.py
@@ -9,7 +9,5 @@ PROJECT_DIR = DIR / "packages" / "custom_cmake"
 def test_ep(isolated):
     isolated.install("hatchling", "scikit-build-core[pyproject]")
     isolated.install(PROJECT_DIR / "extern", isolated=False)
-    isolated.install(
-        PROJECT_DIR, "-v", "--config-settings=logging.level=DEBUG", isolated=False
-    )
+    isolated.install(PROJECT_DIR, "-v", isolated=False)
     # Needs script fix: assert isolated.run("script1") == ""


### PR DESCRIPTION
This warning is showing up, fix by moving the setting into -C.
