### PR TITLE
fix: Change Fedora PR targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ tests/**/build/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+.idea/

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,8 +45,11 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-development
-      - fedora-latest
+      # TODO: Switch to fedora-development and fedora-latest
+      # There is an issue that the commits diverge on different PRs. In the meantime will create PRs on branched fedora
+      # manually
+      # https://github.com/packit/packit/issues/1724
+      - fedora-rawhide
   - job: koji_build
     trigger: commit
     dist_git_branches:


### PR DESCRIPTION
Slight fix to the PR targets for Fedora. There is an [issue](https://github.com/packit/packit/issues/1724) that commits there diverge, so I'll have to manually create PRs on branches until then.

Also, need to add `.idea` to gitignore otherwise sdist pre-commit check complains. Maybe a similar thing will be needed for vs-code and across the other projects?