### PR TITLE
typo on tab Fortran (was Cython)

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -324,7 +324,7 @@ A helper (similar to scikti-build classic) might be added in the future.
 
 ````
 
-````{tab} Cython
+````{tab} Fortran
 
 ```{literalinclude} examples/getting_started/fortran/CMakeLists.txt
 :language: cmake


### PR DESCRIPTION
A typo in the documentation.

The tab was Cython | Cython, but the latter should have been fortran.