### PR TITLE
Doc updates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ reproducible builds if you prefer, however:
 
 ```toml
 [tool.scikit-build]
-sdist.reproducible = true
+sdist.reproducible = false
 ```
 
 ## Customizing the built wheel

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,12 +124,12 @@ backport.find-python = "3.15"
 ## Configuring source file inclusion
 
 Scikit-build-core defaults to using your `.gitignore` to select what to exclude
-from the wheel. You can list files to explicitly include and exclude if you
+from the source distribution. You can list files to explicitly include and exclude if you
 want:
 
 ```toml
 [tool.scikit-build]
-sdist.include = ["src/some_geneerated_file.txt"]
+sdist.include = ["src/some_generated_file.txt"]
 sdist.exclude = [".github"]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,8 +124,8 @@ backport.find-python = "3.15"
 ## Configuring source file inclusion
 
 Scikit-build-core defaults to using your `.gitignore` to select what to exclude
-from the source distribution. You can list files to explicitly include and exclude if you
-want:
+from the source distribution. You can list files to explicitly include and
+exclude if you want:
 
 ```toml
 [tool.scikit-build]


### PR DESCRIPTION
Note the `reproducible-builds` which in the documentation say:

> By default, scikit-build-core will respect SOURCE_DATE_EPOCH, and will lock the modification time to a reproducible value if it’s not set. You can disable reproducible builds if you prefer, however:
> ```
> [tool.scikit-build]
> sdist.reproducible = true
> ```
which didn't make sense to me? Am I wrong in changing this to `false`? Please advice.