### PR TITLE
fix: specify platform properly for non-MSVC

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -288,6 +288,28 @@ cmake_extensions=[CMakeExtension("cmake_example")],
 
 Which should eventually support multiple extensions.
 
+## Patterns
+
+### Backports
+
+All backported standard library code is in `scikit_build_core._compat`, in a
+module with the stdlib name.
+
+### Detecting the platform
+
+Here are some common platforms and the reported values:
+
+| OS      | Compiler   | `sys.platform` | `sysconfig.get_platform()`   |
+| ------- | ---------- | -------------- | ---------------------------- |
+| Windows | MSVC       | `win32`        | `win-amd64`                  |
+| Windows | MinGW      | `win32`        | `mingw_x86_64`               |
+| Windows | MinGW URCT | `win32`        | `mingw_x86_64_ucrt`          |
+| Windows | Cygwin     | `cygwin`       | `cygwin-3.4.6-x86_64`        |
+| macOS   | Clang      | `darwin`       | `macosx-10.15-x86_64`        |
+| Linux   | GCC        | `linux`        | `linux-x86_64`               |
+| Pyodide | Clang      | `emscripten`   | `emscripten-3.1.32-wasm32`   |
+| FreeBSD | GCC        | `freebsd13`    | `freebsd-13.2-RELEASE-amd64` |
+
 # Downstream packaging
 
 ## Fedora packaging

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -4,6 +4,7 @@ import dataclasses
 import os
 import shutil
 import sys
+import sysconfig
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -180,7 +181,8 @@ def _build_wheel_impl(
         )
 
         generator = builder.config.env.get(
-            "CMAKE_GENERATOR", "MSVC" if sys.platform.startswith("win32") else "Unknown"
+            "CMAKE_GENERATOR",
+            "MSVC" if sysconfig.get_platform().startswith("win") else "Unknown",
         )
         rich_print(
             f"[green]***[/green] [bold]Building project with [blue]{generator}[/blue]..."

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -145,12 +145,12 @@ class Builder:
             cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
             # FindPython may break if this is set - only useful on Windows
-            if python_library and sys.platform.startswith("win"):
+            if python_library and sysconfig.get_platform().startswith("win"):
                 cache_config[f"{prefix}_LIBRARY"] = python_library
 
         if limited_abi:
             cache_config["SKBUILD_SOABI"] = (
-                "" if sys.platform.startswith("win") else "abi3"
+                "" if sysconfig.get_platform().startswith("win") else "abi3"
             )
         else:
             # Workaround for bug in PyPy and packaging that is not handled in CMake

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import sysconfig
 from collections.abc import Mapping, MutableMapping
 
 from packaging.version import Version
@@ -67,13 +68,19 @@ def set_environment_for_gen(
     if default:
         logger.debug("Default generator: {}", default)
 
-    if sys.platform.startswith("win32") and "Visual Studio" in env.get(
+    if sysconfig.get_platform().startswith("win") and "Visual Studio" in env.get(
         "CMAKE_GENERATOR", default
     ):
         # This must also be set when *_PLATFORM is set.
         env.setdefault("CMAKE_GENERATOR", default)
         env.setdefault("CMAKE_GENERATOR_PLATFORM", get_cmake_platform(env))
         return {}
+
+    if sys.platform.startswith("win") and not sysconfig.get_platform().startswith(
+        "win"
+    ):
+        # Non-MSVC Windows platforms require Ninja
+        env.setdefault("CMAKE_GENERATOR", "Ninja")
 
     if env.get("CMAKE_GENERATOR", default or "Ninja") == "Ninja":
         min_ninja = Version(ninja_settings.minimum_version)

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import os
-import sys
+import sysconfig
 from collections.abc import Generator, Mapping
 
 from packaging.tags import sys_tags
@@ -60,8 +60,8 @@ class GetRequires:
         logger.debug("Found system CMake: {} - not requiring PyPI package", cmake)
 
     def ninja(self) -> Generator[str, None, None]:
-        # On Windows, Ninja is not default
-        if sys.platform.startswith("win") and "Ninja" not in os.environ.get(
+        # On Windows MSVC, Ninja is not default
+        if sysconfig.get_platform().startswith("win") and "Ninja" not in os.environ.get(
             "CMAKE_GENERATOR", ""
         ):
             return

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -110,7 +110,7 @@ def get_platform(env: Mapping[str, str] | None = None) -> str:
     """
     if env is None:
         env = os.environ
-    if sys.platform.startswith("win"):
+    if sysconfig.get_platform().startswith("win"):
         if "VSCMD_ARG_TGT_ARCH" in env:
             logger.debug(
                 "Selecting {} or {} due to VSCMD_ARG_TARGET_ARCH",

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import textwrap
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -66,7 +67,7 @@ class CMaker:
     prefix_dirs: list[Path] = dataclasses.field(default_factory=list)
     init_cache_file: Path = dataclasses.field(init=False, default=Path())
     env: dict[str, str] = dataclasses.field(init=False, default_factory=os.environ.copy)
-    single_config: bool = not sys.platform.startswith("win32")
+    single_config: bool = not sysconfig.get_platform().startswith("win")
 
     def __post_init__(self) -> None:
         self.init_cache_file = self.build_dir / "CMakeInit.txt"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import types
 import warnings
 from collections.abc import Generator
@@ -296,4 +297,8 @@ def pytest_report_header() -> str:
         with contextlib.suppress(ModuleNotFoundError):
             valid.append(f"{package}=={metadata.version(package)}")  # type: ignore[no-untyped-call]
     reqs = " ".join(valid)
-    return f"installed packages of interest: {reqs}"
+    lines = [
+        f"installed packages of interest: {reqs}",
+        f"sysconfig platform: {sysconfig.get_platform()}",
+    ]
+    return "\n".join(lines)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -56,14 +56,14 @@ def test_get_python_library():
     pprint.pprint(sysconfig.get_config_vars())
 
     lib = get_python_library({})
-    if sys.platform.startswith("win"):
-        assert lib is None
-    else:
+    if sysconfig.get_platform().startswith("win"):
         assert lib
         assert lib.is_file()
+    else:
+        assert lib is None
 
 
-@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
+@pytest.mark.skipif(not sysconfig.get_platform().startswith("win"), reason="MSVC only")
 def test_get_python_library_xcompile(tmp_path):
     config_path = tmp_path / "tmp.cfg"
     config_path.write_text(

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
+import sysconfig
 from pathlib import Path
 
 import pytest
@@ -24,7 +24,7 @@ has_ninja = shutil.which("ninja") is not None
 def prepare_env_or_skip() -> None:
     if (
         "CMAKE_GENERATOR" not in os.environ
-        and not sys.platform.startswith("win32")
+        and not sysconfig.get_platform().startswith("win")
         and not has_make
     ):
         if has_ninja:

--- a/tests/test_fortran.py
+++ b/tests/test_fortran.py
@@ -19,12 +19,8 @@ FORTRAN_EXAMPLE = DIR / "packages/fortran_example"
 @pytest.mark.fortran()
 @pytest.mark.skipif(shutil.which("gfortran") is None, reason="gfortran not available")
 @pytest.mark.skipif(
-    sysconfig.get_platform().startswith("msys"),
-    reason="Fortran not working with MSYS yet",
-)
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="No reasonable Fortran compiler available on Windows",
+    sysconfig.get_platform().startswith("win"),
+    reason="No reasonable Fortran compiler for MSVC",
 )
 def test_pep517_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import sys
+import sysconfig
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,7 @@ from scikit_build_core.build import (
 )
 from scikit_build_core.builder.get_requires import GetRequires
 
-ninja = [] if sys.platform.startswith("win") else ["ninja>=1.5"]
+ninja = [] if sysconfig.get_platform().startswith("win") else ["ninja>=1.5"]
 
 
 def which_mock(name: str) -> str | None:

--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -19,7 +19,7 @@ SYSCONFIGPLAT = sysconfig.get_platform()
     sys.implementation.name == "pypy", reason="pypy does not support abi3"
 )
 @pytest.mark.skipif(
-    SYSCONFIGPLAT.startswith(("msys", "mingw")),
+    sysconfig.get_platform().startswith(("msys", "mingw")),
     reason="abi3 FindPython on MSYS/MinGW reports not found",
 )
 def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
@@ -46,7 +46,7 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
         file_names.remove("abi3_example-0.0.1.dist-info")
         (so_file,) = file_names
 
-        if sys.platform.startswith("win"):
+        if sysconfig.get_platform().startswith("win"):
             assert so_file == "abi3_example.pyd"
         elif sys.platform.startswith("cygwin"):
             assert so_file == "abi3_example.abi3.dll"

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -31,7 +31,7 @@ Requires-Dist: pytest>=6.0; extra == "test"
 """
 
 mark_hashes_different = pytest.mark.xfail(
-    sys.platform.startswith("win32") or sys.platform.startswith("cygwin"),
+    sys.platform.startswith(("win", "cygwin")),
     reason="hashes differ on Windows",
     strict=False,
 )

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -28,7 +28,7 @@ def test_pep518_sdist(package_simple_pyproject_ext):
     (sdist,) = Path("dist").iterdir()
     assert sdist.name == "cmake-example-0.0.1.tar.gz"
 
-    if not (sys.platform.startswith("win32") or sys.platform.startswith("cygwin")):
+    if not sys.platform.startswith(("win", "cygwin")):
         hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
         assert hash == package_simple_pyproject_ext.sdist_hash
 

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -48,7 +48,7 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
             p = zipfile.Path(f)
             file_names = {p.name for p in p.iterdir()}
 
-        if sys.platform.startswith("win"):
+        if sysconfig.get_platform().startswith("win"):
             assert "abi3_example.pyd" in file_names
         elif sys.platform.startswith("cygwin"):
             assert "abi3_example.abi3.dll" in file_names

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -63,8 +63,10 @@ def test_pep517_sdist():
 @pytest.mark.configure()
 @pytest.mark.broken_on_urct()
 @pytest.mark.usefixtures("package_simple_setuptools_ext")
-@pytest.mark.skipif(
-    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+@pytest.mark.xfail(
+    sys.platform.startswith("cygwin"),
+    reason="Cygwin fails here with ld errors",
+    strict=False,
 )
 def test_pep517_wheel(virtualenv):
     dist = Path("dist")

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -12,8 +12,10 @@ pytestmark = pytest.mark.setuptools
 @pytest.mark.configure()
 @pytest.mark.integration()
 @pytest.mark.broken_on_urct()
-@pytest.mark.skipif(
-    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+@pytest.mark.xfail(
+    sys.platform.startswith("cygwin"),
+    reason="Cygwin fails here with ld errors",
+    strict=False,
 )
 @pytest.mark.usefixtures("package_simple_setuptools_ext")
 def test_pep518_wheel(isolated):
@@ -50,8 +52,10 @@ def test_pep518_wheel(isolated):
 @pytest.mark.configure()
 @pytest.mark.integration()
 @pytest.mark.broken_on_urct()
-@pytest.mark.skipif(
-    sys.platform.startswith("cygwin"), reason="Cygwin fails here with ld errors"
+@pytest.mark.xfail(
+    sys.platform.startswith("cygwin"),
+    reason="Cygwin fails here with ld errors",
+    strict=False,
 )
 @pytest.mark.usefixtures("package_simple_setuptools_ext")
 def test_pep518_pip(isolated):

--- a/tests/test_simple_pure.py
+++ b/tests/test_simple_pure.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 import pytest
@@ -21,7 +22,7 @@ has_ninja = shutil.which("ninja") is not None
 def prepare_env_or_skip() -> None:
     if (
         "CMAKE_GENERATOR" not in os.environ
-        and not sys.platform.startswith("win32")
+        and not sysconfig.get_platform().startswith("win")
         and not has_make
     ):
         if has_ninja:


### PR DESCRIPTION
This uses `sysconfig.get_platform()` to identify non-MSVC Windows platforms. Ninja is set to the default on non-MSVC.