### PR TITLE
fix: support prefix dir if toolchain has CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Features over classic Scikit-build:
 - Better warnings, errors, and logging
 - No warning about unused variables
 - Automatically adds Ninja and/or CMake only as required
-- No dependency on setuptools, distutils, or wheel.
-- Powerful config system, including config options support.
+- No dependency on setuptools, distutils, or wheel
+- Powerful config system, including config options support
 - Automatic inclusion of site-packages in `CMAKE_PREFIX_PATH`
 - FindPython is backported if running on CMake < 3.26.1 (configurable), supports
-  PyPY SOABI & Limited API / Stable ABI.
+  PyPY SOABI & Limited API / Stable ABI
 - Limited API / Stable ABI and pythonless tags supported via config option
 - No slow generator search, ninja/make or MSVC used by default, respects
   `CMAKE_GENERATOR`
@@ -37,7 +37,8 @@ Features over classic Scikit-build:
 - Several integrated dynamic metadata plugins (proposing standardized support
   soon)
 - Experimental editable mode support, with optional experimental auto rebuilds
-  on import.
+  on import
+- Supports WebAssembly (Emscripten/Pyodide).
 
 The following limitations are present compared to classic scikit-build:
 

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -149,6 +149,7 @@ class CMaker:
                 f.write(
                     f'set(CMAKE_PREFIX_PATH [===[{prefix_dirs_str}]===] CACHE PATH "" FORCE)\n'
                 )
+                f.write('set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH" CACHE PATH "")\n')
 
         contents = self.init_cache_file.read_text(encoding="utf-8").strip()
         logger.debug(


### PR DESCRIPTION
Fix for now for `CMAKE_PREFIX_PATH` being ignored when used with emscripten (Pyodide). Tested in https://github.com/pybind/scikit_build_example/pull/84.