### PR TITLE
feat(setuptools): adding cmake_args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ Examples = "https://github.com/scikit-build/scikit-build-core/tree/main/tests/pa
 [project.entry-points]
 "distutils.commands".build_cmake = "scikit_build_core.setuptools.build_cmake:BuildCMake"
 "distutils.setup_keywords".cmake_source_dir = "scikit_build_core.setuptools.build_cmake:cmake_source_dir"
+"distutils.setup_keywords".cmake_args = "scikit_build_core.setuptools.build_cmake:cmake_args"
 "setuptools.finalize_distribution_options".scikit_build_entry = "scikit_build_core.setuptools.build_cmake:finalize_distribution_options"
 
 [tool.hatch]

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -4,7 +4,7 @@ import dataclasses
 import re
 import sys
 import sysconfig
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 
 from packaging.version import Version
@@ -83,6 +83,7 @@ class Builder:
         name: str | None = None,
         version: Version | None = None,
         limited_abi: bool | None = None,
+        configure_args: Iterable[str] = (),
     ) -> None:
         cmake_defines = dict(defines)
 
@@ -181,7 +182,7 @@ class Builder:
 
         self.config.configure(
             defines=cmake_defines,
-            cmake_args=self.get_cmake_args(),
+            cmake_args=[*self.get_cmake_args(), *configure_args],
         )
 
     def build(self, build_args: list[str]) -> None:

--- a/tests/packages/mixed_setuptools/CMakeLists.txt
+++ b/tests/packages/mixed_setuptools/CMakeLists.txt
@@ -1,6 +1,26 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX)
 
+if(NOT EXAMPLE_DEFINE1 EQUAL 1)
+  message(FATAL_ERROR "Example define 1 is not set")
+endif()
+
+if(NOT EXAMPLE_DEFINE2 EQUAL 2)
+  message(FATAL_ERROR "Example define 2 is not set")
+endif()
+
+if(NOT EXAMPLE_DEFINE3 EQUAL 3)
+  message(FATAL_ERROR "Example define 3 is not set")
+endif()
+
+if(NOT EXAMPLE_DEFINE4 EQUAL 4)
+  message(FATAL_ERROR "Example define 4 is not set")
+endif()
+
+if(NOT EXAMPLE_DEFINE5 EQUAL 5)
+  message(FATAL_ERROR "Example define 5 is not set")
+endif()
+
 find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_core src/main.cpp)
 

--- a/tests/packages/mixed_setuptools/pyproject.toml
+++ b/tests/packages/mixed_setuptools/pyproject.toml
@@ -5,3 +5,9 @@ requires = [
     "pybind11",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
+
+[tool.scikit-build]
+cmake.args = ["-DEXAMPLE_DEFINE3=3"]
+
+[tool.scikit-build.cmake.define]
+EXAMPLE_DEFINE4 = "4"

--- a/tests/packages/mixed_setuptools/setup.cfg
+++ b/tests/packages/mixed_setuptools/setup.cfg
@@ -14,3 +14,6 @@ where = src
 
 [build_cmake]
 source_dir = .
+cmake_args =
+    -DEXAMPLE_DEFINE1=1
+    -DEXAMPLE_DEFINE2=2

--- a/tests/packages/mixed_setuptools/setup.py
+++ b/tests/packages/mixed_setuptools/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup()
+setup(cmake_args=["-DEXAMPLE_DEFINE5=5"])


### PR DESCRIPTION
Adds cmake_args, can be combined with `[build_cmake] cmake_args` and other ways to set it.

Also fixes keyword specification - the keyword functions are only supposed to be validators.
