### PR TITLE
docs: prepare for 0.4.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Version 0.4.0
+
+An important fix/feature: LICENSE files were not being included in the wheel's
+metadata folder. You can configure the license file selection via a new
+configuration option, and a reasonable default was added. You can now select a
+source directory for your CMakeLists.txt. A lot of work was done on the still
+experimental setuptools backend; it still should be seen as completely
+experimental while it is being finished.
+
+Features:
+
+- `cmake.source-dir` for CMakeLists in subdirectories by @henryiii in #323
+- Add `LICENSE` file option by @henryiii in #321
+
+Fixes:
+
+- Ninja wasn't being used if present by @henryiii in #310
+- Wheels were not including the `LICENSE` file by @henryiii in #321
+
+Setuptools plugin:
+
+- Refactor plugin as custom setuptools command by @henryiii in #312
+- Adding `cmake_args` by @henryiii in #314
+- Add wrapper for `skbuild.setup` compat by @henryiii in #315
+
+Other:
+
+- ci: add rpmlint and smoke tests by @LecrisUT in #313
+
 ## Version 0.3.3
 
 This version improves WebAssembly support (Pyodide) and fixes a reported bug in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,15 +380,15 @@ CMAKE_ARGS: -DSOME_DEFINE=ON;-DOTHER=OFF
 
 ````
 
-## Dynamic metadata (WIP)
+## Dynamic metadata
 
-Scikit-build-core 0.3.0 will support dynamic metadata. This is not ready for
-plugin development outside of scikit-build-core;
-`tool.scikit-build.experimental=true` is required to use external plugins, since
-the interface is provisional. Nested arbitrary dicts (as seen here) are not
-supported in config-settings or environment variables.
+Scikit-build-core 0.3.0 supports dynamic metadata with two built-in plugins.
 
-There currently are two built-in plugins for dynamic metadata.
+:::{warning}
+
+This is not ready for plugin development outside of scikit-build-core;
+`tool.scikit-build.experimental=true` is required to use plugins that are not
+shipped with scikit-build-core, since the interface is provisional. :::
 
 :::{tab} Setuptools-scm
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -159,7 +159,7 @@ class BuildCMake(setuptools.Command):
         builder.build(build_args=build_args)
         builder.install(Path(self.build_lib))
 
-    # def get_source_files(self) -> list[str]:
+    # def "get_source_file+ys"(self) -> list[str]:
     #    return ["CMakeLists.txt"]
 
     # def get_outputs(self) -> list[str]:


### PR DESCRIPTION
Added one small feature (`cmake.source-dir`), so this is a 0.4.0 release.

