### PR TITLE
fix: drop rich logging/error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ version = "0.0.1"
 ```
 
 You can (and should) specify the rest of the entries in `project`, but these are
-the minimum to get started. You can also add the `rich` (more colorful
-printouts) or `pyproject` (pre-load some dependencies) extras if you want.
+the minimum to get started. You can also `scikit-build-core[pyproject]` to
+pre-load some dependencies if you want; in some cases this might be marginally
+faster.
 
 An example `CMakeLists.txt`:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,9 +59,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests. Includes coverage if --cov passed.
     """
-    _run_tests(
-        session, install_args=["hatch-fancy-pypi-readme", "rich", "setuptools-scm"]
-    )
+    _run_tests(session, install_args=["hatch-fancy-pypi-readme", "setuptools-scm"])
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ pyproject = [
     "pyproject-metadata >=0.5",
     "pathspec >=0.10.1",
 ]
-rich = [
-    "rich",
-]
 test = [
     "build[virtualenv]",
     "cattrs >=22.2.0",

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import sys
-import typing
 from typing import Any
 
 __all__ = ["logger", "raw_logger", "ScikitBuildLogger", "rich_print"]
@@ -125,17 +124,8 @@ def _process_rich(msg: object) -> str:
     )
 
 
-def fake_rich_print(*args: object, **kwargs: object) -> None:
+def rich_print(*args: object, **kwargs: object) -> None:
     args_2 = tuple(_process_rich(arg) for arg in args)
     if args != args_2:
         args_2 = (*args_2[:-1], args_2[-1] + colors()["reset"])
     print(*args_2, **kwargs)  # type: ignore[call-overload] # noqa: T201
-
-
-if typing.TYPE_CHECKING:
-    rich_print = fake_rich_print
-else:
-    try:
-        from rich import print as rich_print
-    except ModuleNotFoundError:
-        rich_print = fake_rich_print

--- a/src/scikit_build_core/build/_init.py
+++ b/src/scikit_build_core/build/_init.py
@@ -23,27 +23,12 @@ def setup_logging(log_level: str) -> None:
         "NOTSET": logging.NOTSET,
     }[log_level]
 
-    try:
-        import rich.logging
-        import rich.traceback
-    except ModuleNotFoundError:
-        ch = logging.StreamHandler()
-        ch.setLevel(level_value)
-        # create formatter and add it to the handlers
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-        ch.setFormatter(formatter)
-        # add the handlers to the logger
-        logger.addHandler(ch)
-        return
-
-    FORMAT = "%(message)s"
-    logging.basicConfig(
-        level=level_value,
-        format=FORMAT,
-        datefmt="[%X]",
-        handlers=[rich.logging.RichHandler(level=log_level)],
+    ch = logging.StreamHandler()
+    ch.setLevel(level_value)
+    # create formatter and add it to the handlers
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
-
-    rich.traceback.install(suppress=["pep517", "pip"])
+    ch.setFormatter(formatter)
+    # add the handlers to the logger
+    logger.addHandler(ch)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
         "hatchling",
         "pip>=23",
         "pybind11",
-        "rich",
         "setuptools",
         "virtualenv",
         "wheel",
@@ -223,10 +222,10 @@ def package_simple_pyproject_ext(
 ) -> PackageInfo:
     package = PackageInfo(
         "simple_pyproject_ext",
-        "920c8475bf53c67231dbe3a08c1b533306e89f79dfbd09c1fe2ec55ec6c8fe0c",
-        "617737581c2e6f42137539c46c0bf904ea43a7b653925dbbcf8dce88e4a835a8",
-        "b41badc7999eddd2f4a59aa244baa04b9498d699888c2ced33655396108616a4",
-        "2fb6482b83f624d1fe83e30579f9507167e1db9e5256bc0f47a907abb9ae98ec",
+        "cbf3102cf86f709dfd3f244b69e5ee3faff9e3c94c53ef85f146d9bad96660b3",
+        "538a8221e10c5029c78127e4169d2df622b9a88dfce12a8b63eeaaa98cda8a09",
+        "0dab37b48497f95c044781204b7d49c752739b32a0ef7a7a02ec987b5c4a210b",
+        "feeedcb0070a211d93b967fe083aa31e448842eb9b93d5e428807348e40e44e8",
     )
     process_package(package, tmp_path, monkeypatch)
     return package
@@ -306,7 +305,6 @@ def pytest_report_header() -> str:
         "pip",
         "pybind11",
         "pyproject_metadata",
-        "rich",
         "scikit_build_core",
         "setuptools",
         "virtualenv",

--- a/tests/packages/simple_pyproject_ext/pyproject.toml
+++ b/tests/packages/simple_pyproject_ext/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core[rich]",
+    "scikit_build_core[pyproject]",
     "pybind11",
 ]
 build-backend = "scikit_build_core.build"

--- a/tests/packages/simple_pyproject_source_dir/pyproject.toml
+++ b/tests/packages/simple_pyproject_source_dir/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core[rich]",
+    "scikit_build_core[pyproject]",
     "pybind11",
 ]
 build-backend = "scikit_build_core.build"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,13 +1,13 @@
-from scikit_build_core._logging import fake_rich_print
+from scikit_build_core._logging import rich_print
 
 
-def test_fake_rich_print_nocolor(capsys, monkeypatch):
+def test_rich_print_nocolor(capsys, monkeypatch):
     monkeypatch.setenv("NO_COLOR", "1")
-    fake_rich_print("[red]hello[/red] world", end="")
+    rich_print("[red]hello[/red] world", end="")
     assert capsys.readouterr().out == "hello world"
 
 
-def test_fake_rich_print_forcecolor(capsys, monkeypatch):
+def test_rich_print_forcecolor(capsys, monkeypatch):
     monkeypatch.setenv("FORCE_COLOR", "1")
-    fake_rich_print("[red bold]hello[/bold] world", end="")
+    rich_print("[red bold]hello[/bold] world", end="")
     assert capsys.readouterr().out == "\33[91m\33[1mhello\33[22m world\33[0m"


### PR DESCRIPTION
Pip doesn't allow rich to see the terminal, and because of this, the very narrow formatting makes the logs quite hard to read. Let's drop the option for now - if it's fixed in Pip, we can revisit.
