### PR TITLE
fix: allow CMake to detect if limited API is targeted

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -165,7 +165,7 @@ class Builder:
                 ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
             assert isinstance(ext_suffix, str)
             cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
-            
+
         # Allow CMakeLists to detect this is supposed to be a limited ABI build
         cache_config["SKBUILD_LIMITED_ABI"] = limited_abi
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -165,6 +165,9 @@ class Builder:
                 ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
             assert isinstance(ext_suffix, str)
             cache_config["SKBUILD_SOABI"] = ext_suffix.rsplit(".", 1)[0].lstrip(".")
+            
+        # Allow CMakeLists to detect this is supposed to be a limited ABI build
+        cache_config["SKBUILD_LIMITED_ABI"] = limited_abi
 
         if cache_entries:
             cache_config.update(cache_entries)

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -115,7 +115,7 @@ class Builder:
         )
         cmake_defines.update(local_def)
 
-        cache_config: dict[str, str | Path] = {
+        cache_config: dict[str, str | Path | bool] = {
             "SKBUILD": "2",
             "SKBUILD_CORE_VERSION": __version__,
         }


### PR DESCRIPTION
Might be nice if we could indicate the target value too. But that will still be "truthful", so could be changed later.