### PR TITLE
Handle " " or ";" delimiter for CMAKE_ARGS env var.

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -71,7 +71,11 @@ class Builder:
         """
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSX on conda-forge)
-        env_cmake_args = (b.strip() for a in self.config.env.get("CMAKE_ARGS", "").split() for b in a.split(";"))
+        env_cmake_args = (
+            b.strip()
+            for a in self.config.env.get("CMAKE_ARGS", "").split()
+            for b in a.split(";")
+        )
 
         return [*self.settings.cmake.args, *env_cmake_args]
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -71,7 +71,7 @@ class Builder:
         """
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSX on conda-forge)
-        env_cmake_args = filter(None, self.config.env.get("CMAKE_ARGS", "").split(" "))
+        env_cmake_args = (b.strip() for a in self.config.env.get("CMAKE_ARGS", "").split() for b in a.split(";"))
 
         return [*self.settings.cmake.args, *env_cmake_args]
 


### PR DESCRIPTION
The documentation implies that ";" is the correct delimiter. This change ensures that a CMAKE_ARGS environment variable string will be split on ";" when it is read. Split on " " is preserved, as well.

Ref #335.