### PR TITLE
fix: make abi3 support conditional on Python version

### DIFF
--- a/docs/cmakelists.md
+++ b/docs/cmakelists.md
@@ -67,6 +67,21 @@ configuration, with the variables:
 - `${SKBUILD_NULL_DIR}`: Anything installed here will not be placed in the
   wheel.
 
+## Limited API / Stable ABI
+
+You can activate the limited ABI by setting When you do that,
+`${SKBUILD_SABI_COMPONENT}` will be set to `Development.SABIModule` if you can
+target this (new enough CPython), and will remain an empty string otherwise
+(PyPy). This allows the following idiom:
+
+```cmake
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
+```
+
+This will add this only if scikit-build-core is driving the compilation and is
+targeting ABI3. If you want to support limited ABI from outside
+scikit-build-core, look into the `OPTIONAL_COMPONENTS` flag for `find_package`.
+
 ## Future additions
 
 Scikit-build-core does not include helpers for F2Py or Cython like scikit-build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,6 +198,10 @@ the wheel tags for the version you support:
 wheel.py-api = "cp37"
 ```
 
+Scikit-build-core will only target ABI3 if the version of Python is equal to or
+newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
+`Development.SABIModule` when targeting ABI3, and is an empty string otherwise.
+
 If you are not using CPython at all, you can specify any version of Python is
 fine:
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -127,7 +127,11 @@ class Builder:
             cache_config["SKBUILD_PROJECT_VERSION"] = str(version)
 
         if limited_abi is None:
-            limited_abi = self.settings.wheel.py_api.startswith("cp3")
+            if self.settings.wheel.py_api.startswith("cp3"):
+                target_minor_version = int(self.settings.wheel.py_api[3:])
+                limited_abi = target_minor_version >= sys.version_info.minor
+            else:
+                limited_abi = False
 
         python_library = get_python_library(self.config.env, abi3=limited_abi)
         python_include_dir = get_python_include_dir()


### PR DESCRIPTION
This makes it much easier to support setting something in the middle of your supported range (like `"cp312"` for nanobind).

This was already supported in WheelTag.