### PR TITLE
fix: abi3 backwards & Python_SABI_LIBRARY bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ backends:
 - [meson-python][]: A meson-based build backend; has some maintainer overlap
   with scikit-build-core.
 - [maturin][]: A build backend for Rust projects, using Cargo.
-- [enscons][]: A SCons based backend, not very actively developed (it predates
-  all the others in modern standard support!)
+- [enscons][]: A SCons based backend, not very actively developed (but it
+  predates all the others in modern standard support!)
 
 If you don't need a binary build, you don't need to use a binary build backend!
 There are some very good Python build backends; we recommend [hatchling][] as a
@@ -253,6 +253,7 @@ Support for this work was provided by NSF cooperative agreement [OAC-2209877][].
 [OAC-2209877]:              https://www.nsf.gov/awardsearch/showAward?AWD_ID=2209877&HistoricalAwards=false
 [hatchling]:                https://hatch.pypa.io/latest
 [maturin]:                  https://www.maturin.rs
+[meson-python]:             https://meson-python.readthedocs.io
 [enscons]:                  https://pypi.org/project/enscons
 [py-build-cmake]:           https://tttapa.github.io/py-build-cmake
 <!-- prettier-ignore-end -->

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -134,7 +134,9 @@ class Builder:
                 limited_abi = False
 
         python_library = get_python_library(self.config.env, abi3=False)
-        python_sabi_library = get_python_library(self.config.env, abi3=False) if limited_abi else None
+        python_sabi_library = (
+            get_python_library(self.config.env, abi3=False) if limited_abi else None
+        )
         python_include_dir = get_python_include_dir()
 
         # Classic Find Python

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -133,7 +133,8 @@ class Builder:
             else:
                 limited_abi = False
 
-        python_library = get_python_library(self.config.env, abi3=limited_abi)
+        python_library = get_python_library(self.config.env, abi3=False)
+        python_sabi_library = get_python_library(self.config.env, abi3=False) if limited_abi else None
         python_include_dir = get_python_include_dir()
 
         # Classic Find Python
@@ -151,6 +152,8 @@ class Builder:
             # FindPython may break if this is set - only useful on Windows
             if python_library and sysconfig.get_platform().startswith("win"):
                 cache_config[f"{prefix}_LIBRARY"] = python_library
+            if python_sabi_library and sysconfig.get_platform().startswith("win"):
+                cache_config[f"{prefix}_SABI_LIBRARY"] = python_sabi_library
 
         if limited_abi:
             cache_config["SKBUILD_SOABI"] = (

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -129,7 +129,7 @@ class Builder:
         if limited_abi is None:
             if self.settings.wheel.py_api.startswith("cp3"):
                 target_minor_version = int(self.settings.wheel.py_api[3:])
-                limited_abi = target_minor_version >= sys.version_info.minor
+                limited_abi = target_minor_version <= sys.version_info.minor
             else:
                 limited_abi = False
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -135,7 +135,7 @@ class Builder:
 
         python_library = get_python_library(self.config.env, abi3=False)
         python_sabi_library = (
-            get_python_library(self.config.env, abi3=False) if limited_abi else None
+            get_python_library(self.config.env, abi3=True) if limited_abi else None
         )
         python_include_dir = get_python_include_dir()
 


### PR DESCRIPTION
Discovery doesn't work when cross compiling, so it's important these are set.

Also need to set Python_SABI_LIBRARY separately.