### PR TITLE
refactor: sort RUNENV debugging log output

### DIFF
--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -44,7 +44,7 @@ class Run:
 
         if self.env:
             logger.debug(
-                "RUNENV:\n  {}", "\n  ".join(f"{k}={v}" for k, v in self.env.items())
+                "RUNENV:\n  {}", "\n  ".join(f"{k}={self.env[k]}" for k in sorted(self.env.keys()))
             )
         logger.debug("RUN: {}", " ".join(options))
 

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -44,7 +44,8 @@ class Run:
 
         if self.env:
             logger.debug(
-                "RUNENV:\n  {}", "\n  ".join(f"{k}={self.env[k]}" for k in sorted(self.env.keys()))
+                "RUNENV:\n  {}",
+                "\n  ".join(f"{k}={self.env[k]}" for k in sorted(self.env.keys())),
             )
         logger.debug("RUN: {}", " ".join(options))
 

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -45,7 +45,7 @@ class Run:
         if self.env:
             logger.debug(
                 "RUNENV:\n  {}",
-                "\n  ".join(f"{k}={self.env[k]}" for k in sorted(self.env.keys())),
+                "\n  ".join(f"{k}={v}" for k, v in sorted(self.env.items())),
             )
         logger.debug("RUN: {}", " ".join(options))
 


### PR DESCRIPTION
Running with `logging.level = "DEBUG"`, `scikit-build-core` emits a log message listing environment variables for the build, like this:

```text
2023-06-05 00:48:26,822 - scikit_build_core - DEBUG - RUNENV:
  SYSTEM_PULLREQUEST_SOURCECOMMITID=77b0ed1470cbf63d39ddae10915e96cea2804783
  BUILD_QUEUEDBY=Microsoft.VisualStudio.Services.TFS
  CONDA_SHLVL=1
  LC_ALL=en_US.UTF-8
  LD_LIBRARY_PATH=/usr/local/lib64:/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rh/gcc-toolset-12/root/usr/lib:/opt/rh/gcc-toolset-12/root/usr/lib64/dyninst:/opt/rh/  gcc-toolset-12/root/usr/lib/dyninst:/usr/local/lib
  CONDA_EXE=/opt/miniforge/bin/conda
  AGENT_HOMEDIRECTORY=/__a
  SYSTEM_POSTLINESSPEED=10000
  AGENT_USEWORKSPACEID=true
  SYSTEM_STAGEDISPLAYNAME=__default
  AGENT_VERSION=3.220.2
  SYSTEM_JOBATTEMPT=1
  SYSTEM_TEAMFOUNDATIONSERVERURI=https://dev.azure.com/lightgbm-ci/
  AGENT_TOOLSDIRECTORY=/__t
  INPUT_ARGUMENTS=
  SYSTEM_DEFINITIONID=1
  AGENT_DISABLELOGPLUGIN_TESTFILEPUBLISHERPLUGIN=true
  LANG=en_US.UTF-8
  ...
```

I've found that very useful when trying to debug build issues in a project I'm working on (https://github.com/microsoft/LightGBM/pull/5061).

This PR proposes a change that I think might make it even more useful...sorting that output alphabetically, like this:

```text
2023-06-05 00:48:26,822 - scikit_build_core - DEBUG - RUNENV:
  AGENT_DISABLELOGPLUGIN_TESTFILEPUBLISHERPLUGIN=true
  AGENT_HOMEDIRECTORY=/__a
  AGENT_TOOLSDIRECTORY=/__t
  AGENT_USEWORKSPACEID=true
  AGENT_VERSION=3.220.2
  BUILD_QUEUEDBY=Microsoft.VisualStudio.Services.TFS
  CONDA_EXE=/opt/miniforge/bin/conda
  CONDA_SHLVL=1
  INPUT_ARGUMENTS=
  LANG=en_US.UTF-8
  LC_ALL=en_US.UTF-8
  LD_LIBRARY_PATH=/usr/local/lib64:/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rh/gcc-toolset-12/root/usr/lib:/opt/rh/gcc-toolset-12/root/usr/lib64/dyninst:/opt/rh/gcc-toolset-12/root/usr/lib/dyninst:/usr/local/lib
  SYSTEM_DEFINITIONID=1
  SYSTEM_JOBATTEMPT=1
  SYSTEM_POSTLINESSPEED=10000
  SYSTEM_PULLREQUEST_SOURCECOMMITID=77b0ed1470cbf63d39ddae10915e96cea2804783
  SYSTEM_STAGEDISPLAYNAME=__default
  SYSTEM_TEAMFOUNDATIONSERVERURI=https://dev.azure.com/lightgbm-ci/
```

In addition to making the output a bit easier to scan visually (in my opinion), that also makes the use of text-diffing tools to compare log output a bit easier.

Thanks very much for your time and consideration.