### PR TITLE
ci: fedora: Correct rsync rule

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,8 @@ files_to_sync:
   - src: distro/plans/
     dest: plans/
     filters:
-      - "- distro/plans/main.fmf.dist-git"
-      - "- distro/plans/rpmlint.fmf"
+      - "- main.fmf.dist-git"
+      - "- rpmlint.fmf"
   - src: distro/plans/main.fmf.dist-git
     dest: plans/main.fmf
 upstream_package_name: scikit_build_core


### PR DESCRIPTION
Small hotfix