### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         args: [--prose-wrap=always]
         exclude: "^tests"
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.275
     hooks:
       - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Committed via https://github.com/asottile/all-repos