### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,6 @@ extend-ignore = [
     "PT004",   # Incorrect, just usefixtures instead.
     "RUF009",  # Too easy to get a false positive
 ]
-target-version = "py37"
 typing-modules = ["scikit_build_core._compat.typing"]
 src = ["src"]
 unfixable = ["T20", "F841"]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos