### PR TITLE
fix: Add purelib site-packages to sys.path

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -105,7 +105,7 @@ class Builder:
         logger.debug("SITE_PACKAGES: {}", site_packages)
         if site_packages != DIR.parent.parent:
             self.config.prefix_dirs.append(DIR.parent.parent)
-            logger.debug("Extra SITE_PACKAGES: {}", site_packages)
+            logger.debug("Extra SITE_PACKAGES: {}", DIR.parent.parent)
 
         # Add the FindPython backport if needed
         fp_backport = self.settings.backport.find_python


### PR DESCRIPTION
In order to actually discover entry points provided by dependencies, the purelib site-packages need to be part of sys.path when looking for entry points. This is not the case by default when building with PEP517 build isolation enabled.

I've found that without this PR, there is no way to actually utilize `cmake.prefix` or `cmake.module` since the entry points never get picked up by scikit-build-core.