### PR TITLE
Add gitignore to list of ignored files

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -11,6 +11,7 @@ __all__: list[str] = ["each_unignored_file"]
 
 EXCLUDE_LINES = [
     ".git/",
+    ".gitignore",
     ".tox/",
     ".nox/",
     ".egg-info/",


### PR DESCRIPTION
I didn't add a test, but would be happy to do so. The reason I waited is that it seems like the easiest option would be to add the file to one of the existing tests/packages examples, but that would require modifying the hashes and I wasn't sure if that would be the preferred result.

Partially addresses #437, but only for the special case of gitignore. This doesn't fix the more general case of hidden files.