### PR TITLE
fix: only link to valid module paths

### DIFF
--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ._file_processor import each_unignored_file
 
-__all__ = ["scantree", "path_to_module", "packages_to_file_mapping"]
+__all__ = ["scantree", "path_to_module", "packages_to_file_mapping", "is_valid_module"]
 
 
 def __dir__() -> list[str]:
@@ -50,3 +50,11 @@ def packages_to_file_mapping(
                 mapping[str(filepath)] = str(package_dir)
 
     return mapping
+
+
+def is_valid_module(path: Path) -> bool:
+    parts = path.parts
+    return (
+        all(p.isidentifier() for p in parts[:-1])
+        and parts[-1].split(".", 1)[0].isidentifier()
+    )

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -22,7 +22,12 @@ from ..resources import resources
 from ..settings.metadata import get_standard_metadata
 from ..settings.skbuild_read_settings import SettingsReader
 from ._init import setup_logging
-from ._pathutil import packages_to_file_mapping, path_to_module, scantree
+from ._pathutil import (
+    is_valid_module,
+    packages_to_file_mapping,
+    path_to_module,
+    scantree,
+)
 from ._scripts import process_script_dir
 from ._wheelfile import WheelWriter
 
@@ -256,6 +261,7 @@ def _build_wheel_impl(
                         Path(k).resolve()
                     )
                     for k, v in mapping.items()
+                    if is_valid_module(Path(v).relative_to(wheel_dirs["platlib"]))
                 }
                 installed = {
                     path_to_module(v.relative_to(wheel_dirs["platlib"])): str(


### PR DESCRIPTION
Partial fix to #437. The other part is revisiting the ignore patterns, probably using the default Python.gitignore, and having one for SDist and another for Wheel (TBD).
