### PR TITLE
fix: report cmake/ninja requried if already present

### DIFF
--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import importlib.util
 import os
 import sysconfig
 from collections.abc import Generator, Mapping
@@ -55,6 +56,13 @@ class GetRequires:
 
     def cmake(self) -> Generator[str, None, None]:
         cmake_min = self.settings.cmake.minimum_version
+
+        # If the module is already installed (via caching the build
+        # environment, for example), we will use that
+        if importlib.util.find_spec("cmake") is not None:
+            yield f"cmake>={cmake_min}"
+            return
+
         cmake = best_program(
             get_cmake_programs(module=False), minimum_version=cmake_min
         )
@@ -79,6 +87,13 @@ class GetRequires:
             return
 
         ninja_min = self.settings.ninja.minimum_version
+
+        # If the module is already installed (via caching the build
+        # environment, for example), we will use that
+        if importlib.util.find_spec("ninja") is not None:
+            yield f"ninja>={ninja_min}"
+            return
+
         ninja = best_program(
             get_ninja_programs(module=False), minimum_version=ninja_min
         )

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import sys
 import sysconfig
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -34,6 +36,15 @@ def protect_get_requires(fp, monkeypatch):
     fp.pass_command([sys.executable, fp.any()])
     monkeypatch.setattr(shutil, "which", which_mock)
     monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
+
+    orig_find_spec = importlib.util.find_spec
+
+    def find_spec(name: str, package: str | None = None) -> Any:
+        if name in {"cmake", "ninja"}:
+            return None
+        return orig_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
 
 
 def test_get_requires_parts(fp):


### PR DESCRIPTION
Fix #458.

@bennyrowland, I think this either fixes this or is a good start.
