### PR TITLE
ci: Fix Fedora CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,15 +32,22 @@ jobs:
     update_release: true
     release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
     targets:
-      - fedora-development
-      - fedora-latest
+      # TODO: Switch to fedora-all once F37 support is dropped
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: tests
     trigger: pull_request
     targets:
       - fedora-development-x86_64
       - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-development-aarch64
       - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: copr_build
     trigger: commit
     branch: main
@@ -49,14 +56,20 @@ jobs:
     targets:
       - fedora-development-x86_64
       - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-development-aarch64
       - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: tests
     trigger: commit
     branch: main
     targets:
-      - fedora-development
-      - fedora-latest
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: copr_build
     trigger: release
     owner: "@scikit-build"
@@ -64,8 +77,10 @@ jobs:
     targets:
       - fedora-development-x86_64
       - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-development-aarch64
       - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: propose_downstream
     trigger: release
     dist_git_branches:

--- a/docs/examples/downstream/main.fmf
+++ b/docs/examples/downstream/main.fmf
@@ -1,0 +1,4 @@
+environment:
+  HAS_PYTEST: true
+require+:
+  - python3-pytest

--- a/docs/examples/downstream/nanobind_example/main.fmf
+++ b/docs/examples/downstream/nanobind_example/main.fmf
@@ -1,0 +1,7 @@
+summary:
+  Nanobind downstream example
+adjust:
+  enabled: false
+  because: Nanobind is not yet packaged on Fedora
+#require+:
+#  - python3-nanobind

--- a/docs/examples/downstream/pybind11_example/main.fmf
+++ b/docs/examples/downstream/pybind11_example/main.fmf
@@ -1,0 +1,5 @@
+summary:
+  Pybind downstream example
+require+:
+  - gcc-c++
+  - pybind11-devel

--- a/docs/examples/getting_started/cython/main.fmf
+++ b/docs/examples/getting_started/cython/main.fmf
@@ -1,2 +1,4 @@
 summary:
   Cython example project
+require+:
+  - python3-cython

--- a/docs/examples/getting_started/fortran/main.fmf
+++ b/docs/examples/getting_started/fortran/main.fmf
@@ -2,3 +2,5 @@ summary:
   F2PY example project
 require+:
   - gcc-gfortran
+  - python3-numpy
+  - python3-numpy-f2py

--- a/docs/examples/getting_started/nanobind/main.fmf
+++ b/docs/examples/getting_started/nanobind/main.fmf
@@ -1,0 +1,7 @@
+summary:
+  Nanobind example project
+adjust:
+  enabled: false
+  because: Nanobind is not yet packaged on Fedora
+#require+:
+#  - python3-nanobind

--- a/docs/examples/getting_started/pybind11/main.fmf
+++ b/docs/examples/getting_started/pybind11/main.fmf
@@ -2,3 +2,4 @@ summary:
   Pybind example project
 require+:
   - gcc-c++
+  - pybind11-devel

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "pip install . --config-settings=cmake.verbose=true" 0 "Build the python project"
+        rlRun "pip install . --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
         rlRun "python3 test.py" 0 "Test project is installed correctly"
     rlPhaseEnd
 

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -21,7 +21,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "pip install . --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
+        rlRun "pip install --user . --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
         if [ "${HAS_PYTEST}" == True ]; then
           rlRun "pytest" 0 "Run built-in pytest"
         else

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -6,8 +6,13 @@ source /usr/share/beakerlib/beakerlib.sh || exit 1
 rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
-		    rlRun "rsync -r ${TMT_SOURCE_DIR:-$TMT_TREE}$TMT_TEST_NAME/ $tmp" 0 "Copy example project"
-		    rlRun "rsync -r ${TMT_SOURCE_DIR:-$TMT_TREE}$TMT_TEST_NAME/../test.py $tmp" 0 "Copy test.py file"
+        if [ -z ${TMT_SOURCE_DIR} ]; then
+          tmt_root=${TMT_TREE}
+        else
+          tmt_root=${TMT_SOURCE_DIR}/scikit_build_core-*
+        fi
+		    rlRun "rsync -r ${tmt_root}$TMT_TEST_NAME/ $tmp" 0 "Copy example project"
+		    rlRun "rsync -r ${tmt_root}/docs/examples/getting_started/test.py $tmp" 0 "Copy test.py file"
         rlRun "pushd $tmp"
         rlRun "tree" 0 "Show directory tree"
         rlRun "set -o pipefail"

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -12,7 +12,9 @@ rlJournalStart
           tmt_root=${TMT_SOURCE_DIR}/scikit_build_core-*
         fi
 		    rlRun "rsync -r ${tmt_root}$TMT_TEST_NAME/ $tmp" 0 "Copy example project"
-		    rlRun "rsync -r ${tmt_root}/docs/examples/getting_started/test.py $tmp" 0 "Copy test.py file"
+        if [ "${HAS_PYTEST}" != True ]; then
+		      rlRun "rsync -r ${tmt_root}/docs/examples/getting_started/test.py $tmp" 0 "Copy test.py file"
+        fi
         rlRun "pushd $tmp"
         rlRun "tree" 0 "Show directory tree"
         rlRun "set -o pipefail"
@@ -20,7 +22,11 @@ rlJournalStart
 
     rlPhaseStartTest
         rlRun "pip install . --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
-        rlRun "python3 test.py" 0 "Test project is installed correctly"
+        if [ "${HAS_PYTEST}" == True ]; then
+          rlRun "pytest" 0 "Run built-in pytest"
+        else
+          rlRun "python3 test.py" 0 "Test project is installed correctly"
+        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
- Use fedora packages with `--no-index` and `--no-build-isolation`
- Enabled missing tests
- Placeholder for nanobind tests (Not yet packaged on fedora)