### PR TITLE
docs: `wheel.py.api` -> `wheel.py-api`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,7 @@ fine:
 
 ```toml
 [tool.scikit-build]
-wheel.py.api = "py3"
+wheel.py-api = "py3"
 ```
 
 Or even Python 2 + 3 (you still will need a version of Python scikit-build-core


### PR DESCRIPTION
Fix a typo.