### PR TITLE
feat: include 'python' dir as an auto search path

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,10 @@ sdist.reproducible = true
 sdist.cmake = false
 
 # A list of packages to auto-copy into the wheel. If this is not set, it will
-# default to the first of ``src/<package>`` or ``<package>`` if they exist. The
-# prefix(s) will be stripped from the package name inside the wheel.
-wheel.packages = ["src/<package>", "<package>"]
+# default to the first of ``src/<package>``, ``python/<package>``, or
+# ``<package>`` if they exist.  The prefix(s) will be stripped from the package
+# name inside the wheel.
+wheel.packages = ["src/<package>", "python/<package>", "<package>"]
 
 # The Python tags. The default (empty string) will use the default Python
 # version. You can also set this to "cp37" to enable the CPython 3.7+ Stable ABI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,16 +200,17 @@ sdist.include = [
 
 ## Customizing the built wheel
 
-The wheel will automatically look for Python packages at `<package_name>` and
-`src/<package_name>`. If you want to list packages explicitly, you can:
+The wheel will automatically look for Python packages at `src/<package_name>`,
+`python/<package_name>`, and `<package_name>`, in that order. If you want to
+list packages explicitly, you can. The final path element is the package.
 
 ```toml
 [tool.scikit-build]
-wheel.packages = ["python/mypackage"]
+wheel.packages = ["python/src/mypackage"]
 ```
 
 Or you can disable Python file inclusion entirely, and rely only on CMake's
-installs, you can:
+install mechanism, you can do that instead:
 
 ```toml
 [tool.scikit-build]

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -51,7 +51,7 @@ def _get_packages(
 
     # Auto package discovery
     packages = []
-    for base_path in (Path("src"), Path()):
+    for base_path in (Path("src"), Path("python"), Path()):
         path = base_path / name
         if path.is_dir() and (
             (path / "__init__.py").is_file() or (path / "__init__.pyi").is_file()

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -134,7 +134,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of packages to auto-copy into the wheel. If this is not set, it will default to the first of ``src/<package>`` or ``<package>`` if they exist. The prefix(s) will be stripped from the package name inside the wheel."
+          "description": "A list of packages to auto-copy into the wheel. If this is not set, it will default to the first of ``src/<package>``, ``python/<package>``, or ``<package>`` if they exist.  The prefix(s) will be stripped from the package name inside the wheel."
         },
         "py-api": {
           "type": "string",

--- a/src/scikit_build_core/settings/skbuild_docs.py
+++ b/src/scikit_build_core/settings/skbuild_docs.py
@@ -25,7 +25,7 @@ def mk_skbuild_docs() -> str:
         if item.name == "install.strip":
             item.default = "false"
         if item.name == "wheel.packages":
-            item.default = '["src/<package>", "<package>"]'
+            item.default = '["src/<package>", "python/<package>", "<package>"]'
     return "\n".join(str(item) for item in items)
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -129,8 +129,9 @@ class WheelSettings:
     packages: Optional[List[str]] = None
     """
     A list of packages to auto-copy into the wheel. If this is not set, it will
-    default to the first of ``src/<package>`` or ``<package>`` if they exist.
-    The prefix(s) will be stripped from the package name inside the wheel.
+    default to the first of ``src/<package>``, ``python/<package>``, or
+    ``<package>`` if they exist.  The prefix(s) will be stripped from the
+    package name inside the wheel.
     """
 
     py_api: str = ""


### PR DESCRIPTION
This is a rather common structure for mixed language projects.
