### PR TITLE
docs: fix typo in `SKBUILD_CMAKE_DEFINE` env var

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,7 +347,7 @@ $ pipx run build --wheel -Ccmake.define.SOME_DEFINE=ON
 ````{tab} Environment
 
 ```yaml
-SKBUILD_CMAKE_DEFINES: SOME_DEFINE=ON
+SKBUILD_CMAKE_DEFINE: SOME_DEFINE=ON
 ```
 
 ````


### PR DESCRIPTION
This environment variable is called `SKBUILD_CMAKE_DEFINE` (without the trailing `s`) to match the name used in the `pyproject.toml` file/`--config-settings`.

Currently, the documentation says `SKBUILD_CMAKE_DEFINES`, which doesn't do anything.

---

I know this is a super minor change, but I thought it might help other people, since it took me quite a while to realize why my environment variable wasn't working :)