### PR TITLE
Revert "fix: support setuptools_scm 8+ (#497)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
 [[tool.mypy.overrides]]
-module = ["numpy", "pathspec", "setuptools_scm.*", "hatch_fancy_pypi_readme"]
+module = ["numpy", "pathspec", "setuptools_scm", "hatch_fancy_pypi_readme"]
 ignore_missing_imports = true
 
 

--- a/src/scikit_build_core/metadata/setuptools_scm.py
+++ b/src/scikit_build_core/metadata/setuptools_scm.py
@@ -22,13 +22,7 @@ def dynamic_metadata(
         msg = "No inline configuration is supported"
         raise ValueError(msg)
 
-    from setuptools_scm import Configuration
-
-    try:
-        from setuptools_scm import _get_version
-    except ImportError:
-        # Support setuptools_scm 8
-        from setuptools_scm._get_version import _get_version
+    from setuptools_scm import Configuration, _get_version
 
     config = Configuration.from_file("pyproject.toml")
     version: str = _get_version(config)


### PR DESCRIPTION
`setputools_scm` still provides this private value for now. We are working on getting better, not-private support soon.
