### PR TITLE
Parse CMake version strings containing '-'

### DIFF
--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -78,7 +78,7 @@ def get_cmake_programs(*, module: bool = True) -> Generator[Program, None, None]
 
         try:
             version = Version(
-                result.stdout.splitlines()[0].split()[-1].split("-msvc")[0]
+                result.stdout.splitlines()[0].split()[-1].split("-")[0]
             )
         except (IndexError, InvalidVersion):
             logger.warning(f"Could not determine CMake version, got {result.stdout!r}")

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -77,9 +77,7 @@ def get_cmake_programs(*, module: bool = True) -> Generator[Program, None, None]
             continue
 
         try:
-            version = Version(
-                result.stdout.splitlines()[0].split()[-1].split("-")[0]
-            )
+            version = Version(result.stdout.splitlines()[0].split()[-1].split("-")[0])
         except (IndexError, InvalidVersion):
             logger.warning(f"Could not determine CMake version, got {result.stdout!r}")
             yield Program(cmake_path, None)

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -77,7 +77,7 @@ def get_cmake_programs(*, module: bool = True) -> Generator[Program, None, None]
             continue
 
         try:
-            version = Version(result.stdout.splitlines()[0].split()[-1])
+            version = Version(result.stdout.splitlines()[0].split()[-1].split('-msvc')[0])
         except (IndexError, InvalidVersion):
             logger.warning(f"Could not determine CMake version, got {result.stdout!r}")
             yield Program(cmake_path, None)

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -77,7 +77,9 @@ def get_cmake_programs(*, module: bool = True) -> Generator[Program, None, None]
             continue
 
         try:
-            version = Version(result.stdout.splitlines()[0].split()[-1].split('-msvc')[0])
+            version = Version(
+                result.stdout.splitlines()[0].split()[-1].split("-msvc")[0]
+            )
         except (IndexError, InvalidVersion):
             logger.warning(f"Could not determine CMake version, got {result.stdout!r}")
             yield Program(cmake_path, None)


### PR DESCRIPTION
Uses a simple `str.split('-msvc')` to extract the version number. `'-msvc'` in particular was chosen to allow for forwards-compatibility with future builds of MSVC CMake. I did not check for older versions as I do not expect they will be any less compatible and this is still an improvement on the current situation of no compatibility at all.

In my opinion, splitting on `-` should be sufficient and provide compatibility with any other builds of CMake with custom version strings. However, I did not do this as I'm not familiar with all of the possible builds of CMake out there and wanted to ensure functionality.

---
Update: Now parses using `str.split('-')` for extended compatibility. Thanks @henryiii 

---
Resolves: #500 