### PR TITLE
feat: Add CLI interface

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -26,11 +26,14 @@ A next generation Python CMake adaptor and Python API for plugins
 Summary:        %{summary}
 Requires:       cmake
 Recommends:     (ninja-build or make)
-Recommends:     python3dist(pyproject-metadata)
-Recommends:     python3dist(pathspec)
+Recommends:     python3-scikit-build-core+pyproject
+Recommends:     python3-scikit-build-core+cli
 Suggests:       ninja-build
 Suggests:       gcc
 %description -n python3-scikit-build-core %_description
+
+%pyproject_extras_subpkg -n python3-scikit-build-core pyproject
+%pyproject_extras_subpkg -n python3-scikit-build-core cli -F
 
 
 %prep
@@ -58,6 +61,11 @@ Suggests:       gcc
 %files -n python3-scikit-build-core -f %{pyproject_files}
 %license LICENSE
 %doc README.md
+%exclude %{python3_sitelib}/scikit_build_core/__main__.py
+
+%files -n python3-scikit-build-core+cli -f %{_pyproject_ghost_distinfo}
+%{python3_sitelib}/scikit_build_core/__main__.py
+%{_bindir}/skbuild
 
 
 %changelog

--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -15,6 +15,8 @@ BuildRequires:  ninja-build
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  git
+# Documentation dependencies
+BuildRequires:  python3dist(click-man)
 
 %global _description %{expand:
 A next generation Python CMake adaptor and Python API for plugins
@@ -51,6 +53,7 @@ Suggests:       gcc
 %install
 %pyproject_install
 %pyproject_save_files scikit_build_core
+PYTHONPATH="%{buildroot}%{python3_sitelib}" click-man skbuild --target %{buildroot}%{_mandir}/man1
 
 
 %check
@@ -62,6 +65,7 @@ Suggests:       gcc
 %license LICENSE
 %doc README.md
 %exclude %{python3_sitelib}/scikit_build_core/__main__.py
+%{_mandir}/man1/skbuild*.1*
 
 %files -n python3-scikit-build-core+cli -f %{_pyproject_ghost_distinfo}
 %{python3_sitelib}/scikit_build_core/__main__.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,7 @@ repos:
         additional_dependencies:
           - build
           - cattrs
+          - click
           - cmake
           - exceptiongroup
           - hatch-fancy-pypi-readme

--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. click:: scikit_build_core.cli.build:build
+   :prog: skbuild build
+
+```

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. click:: scikit_build_core.cli.configure:configure
+   :prog: skbuild configure
+
+```

--- a/docs/cli/dynamic_metadata.md
+++ b/docs/cli/dynamic_metadata.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. click:: scikit_build_core.cli.dynamic_metadata:dynamic_metadata
+   :prog: skbuild dynamic_metadata
+
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,19 @@
+# CLI interface
+
+```{toctree}
+:maxdepth: 2
+:hidden: true
+:glob:
+
+configure
+build
+install
+metadata
+dynamic_metadata
+```
+
+```{eval-rst}
+.. click:: scikit_build_core.cli.main:skbuild
+   :prog: skbuild
+
+```

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. click:: scikit_build_core.cli.install:install
+   :prog: skbuild install
+
+```

--- a/docs/cli/metadata.md
+++ b/docs/cli/metadata.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. click:: scikit_build_core.cli.metadata:metadata
+   :prog: skbuild metadata
+
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "conftabs",
     "sphinx-jsonschema",
+    "sphinx_click",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ changelog
 :caption: API docs
 
 api/scikit_build_core
+cli/index
 ```
 
 ## Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ docs = [
     "sphinx-inline-tabs",
     "sphinx-jsonschema",
     "sphinx-autodoc-typehints",
+    "sphinx-click",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ pyproject = [
     "pathspec >=0.10.1",
     "pyproject-metadata >=0.5",
 ]
+cli = [
+    "click",
+]
 test = [
+    "scikit-build-core[cli]",
     "build[virtualenv]",
     "cattrs >=22.2.0",
     "pathspec >=0.10.1",
@@ -110,6 +114,9 @@ Issues = "https://github.com/scikit-build/scikit-build-core/issues"
 "distutils.setup_keywords".cmake_args = "scikit_build_core.setuptools.build_cmake:cmake_args"
 "setuptools.finalize_distribution_options".scikit_build_entry = "scikit_build_core.setuptools.build_cmake:finalize_distribution_options"
 "validate_pyproject.tool_schema".scikit-build = "scikit_build_core.settings.skbuild_schema:get_skbuild_schema"
+
+[project.scripts]
+skbuild = "scikit_build_core.__main__:run_cli"
 
 [tool.hatch]
 version.source = "vcs"

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -1,0 +1,17 @@
+def run_cli() -> None:
+    """
+    Entry point to skbuild command.
+
+    Wraps the import and execution in a try-catch to detect any missing dependency
+    """
+    try:
+        from .cli import skbuild
+
+        skbuild()
+    except ImportError as err:
+        msg = "Could not import scikit-build-core cli"
+        raise ImportError(msg) from err
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/src/scikit_build_core/cli/__init__.py
+++ b/src/scikit_build_core/cli/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import importlib.util
+
+if not importlib.util.find_spec("click"):
+    msg = "Missing cli dependencies. Make sure scikit-build-core is installed with [cli] optional dependency"
+    raise ImportError(msg)
+
+from .main import skbuild
+
+__all__: list[str] = ["skbuild"]

--- a/src/scikit_build_core/cli/__init__.py
+++ b/src/scikit_build_core/cli/__init__.py
@@ -6,6 +6,10 @@ if not importlib.util.find_spec("click"):
     msg = "Missing cli dependencies. Make sure scikit-build-core is installed with [cli] optional dependency"
     raise ImportError(msg)
 
+# Load all subcommands
+from . import build, configure, dynamic_metadata, install, metadata  # noqa: F401
+
+# Load and expose the main CLI interface
 from .main import skbuild
 
 __all__: list[str] = ["skbuild"]

--- a/src/scikit_build_core/cli/build.py
+++ b/src/scikit_build_core/cli/build.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from .main import skbuild
+from .utils import _build_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__: list[str] = ["build"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@skbuild.command()
+@_build_dir
+@click.pass_context
+def build(ctx: click.Context, build_dir: Path) -> None:  # noqa: ARG001
+    """
+    Run cmake build step
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/configure.py
+++ b/src/scikit_build_core/cli/configure.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from .main import skbuild
+from .utils import _build_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__: list[str] = ["configure"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@skbuild.command()
+@_build_dir
+@click.pass_context
+def configure(ctx: click.Context, build_dir: Path) -> None:  # noqa: ARG001
+    """
+    Run cmake configure step
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/dynamic_metadata.py
+++ b/src/scikit_build_core/cli/dynamic_metadata.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import click
+
+from .main import skbuild
+
+__all__: list[str] = ["dynamic_metadata"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@skbuild.command()
+@click.pass_context
+def dynamic_metadata(ctx: click.Context) -> None:  # noqa: ARG001
+    """
+    Get the generated dynamic metadata
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/install.py
+++ b/src/scikit_build_core/cli/install.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from .main import skbuild
+from .utils import _build_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__: list[str] = ["install"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@skbuild.command()
+@_build_dir
+@click.pass_context
+def install(ctx: click.Context, build_dir: Path) -> None:  # noqa: ARG001
+    """
+    Run cmake install step
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/main.py
+++ b/src/scikit_build_core/cli/main.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import pathlib
+import sys
+
 import click
 
 from .. import __version__
+from .._compat.importlib import metadata
 
 __all__ = ["skbuild"]
 
@@ -13,9 +17,36 @@ def __dir__() -> list[str]:
 
 @click.group("skbuild")
 @click.version_option(__version__)
+@click.option(
+    "--root",
+    "-r",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        path_type=pathlib.Path,
+    ),
+    help="Path to the python project's root",
+)
 @click.pass_context
-def skbuild(ctx: click.Context) -> None:  # noqa: ARG001
+def skbuild(ctx: click.Context, root: pathlib.Path) -> None:  # noqa: ARG001
     """
     scikit-build Main CLI interface
     """
     # TODO: Add specific implementations
+
+
+# Add all plugin commands. Native subcommands are loaded in the package's __init__
+for ep in metadata.entry_points(group="skbuild.commands"):
+    try:
+        # Entry point can either point to a whole module or the decorated command
+        if not ep.attr:
+            # If it's a module, just load the module. It should have the necessary `sbuild.command` interface
+            ep.load()
+        else:
+            # Otherwise assume it is a decorated command that needs to be loaded manually
+            skbuild.add_command(ep.load())
+    except Exception as err:  # noqa: PERF203
+        # TODO: the print should go through the click logging interface
+        print(f"Could not load cli plugin: {ep}\n{err}", file=sys.stderr)  # noqa: T201

--- a/src/scikit_build_core/cli/main.py
+++ b/src/scikit_build_core/cli/main.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import click
+
+from .. import __version__
+
+__all__ = ["skbuild"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@click.group("skbuild")
+@click.version_option(__version__)
+@click.pass_context
+def skbuild(ctx: click.Context) -> None:  # noqa: ARG001
+    """
+    scikit-build Main CLI interface
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/metadata.py
+++ b/src/scikit_build_core/cli/metadata.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import click
+
+from .main import skbuild
+
+__all__: list[str] = ["metadata"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@skbuild.command()
+@click.pass_context
+def metadata(ctx: click.Context) -> None:  # noqa: ARG001
+    """
+    Write out the project's metadata
+    """
+    # TODO: Add specific implementations

--- a/src/scikit_build_core/cli/utils.py
+++ b/src/scikit_build_core/cli/utils.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import functools
+import pathlib
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any, TypeVar
+
+    F = TypeVar("F", bound=Callable[..., Any])
+
+
+__all__: list[str] = ["_build_dir"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _build_dir(func: F) -> F:
+    """Add build_dir click option"""
+
+    @click.option(
+        "--build-dir",
+        "-B",
+        type=click.Path(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            writable=True,
+            path_type=pathlib.Path,
+        ),
+        help="Path to cmake build directory",
+    )
+    @functools.wraps(func)
+    # TODO: Fix mypy checks here.
+    #  See upstream approach: https://github.com/pallets/click/blob/main/src/click/decorators.py
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]


### PR DESCRIPTION
Here's a CLI interface example with `click` that could be later expanded in `scikit-build` or other plugins as needed.

TODO:
- [ ] Add specific implementation
- [ ] Add basic CLI/module/click tests. I've heard that it is possible to write tests common for all three interfaces, but I don't know of an example of how to do that
- [ ] Add subcommand tests
- [ ] Fix `mypy` check for reusable options
- [ ] Conform to code-style
- [x] Documentation:
  - https://github.com/click-contrib/click-man
  - https://github.com/click-contrib/sphinx-click

Issues:
- [x] CI fail because `scikit_build_core.cli` is being imported. Not sure why it is imported in those tests, but I was trying to make it an optional dependency

Closes: #517 

I am not sure yet how to approach all of these, but I wanted to at least make some placeholders for what CLI options would be useful for packaging and gradually work our way up.