### PR TITLE
test: editable install cover package navigation

### DIFF
--- a/tests/packages/navigate_editable/pyproject.toml
+++ b/tests/packages/navigate_editable/pyproject.toml
@@ -10,4 +10,4 @@ dependencies = [
 ]
 
 [tool.scikit-build]
-wheel.packages = ["python/shared_pkg"]
+wheel.packages = ["python/shared_pkg", "python/py_pkg"]

--- a/tests/packages/navigate_editable/python/py_pkg/py1_pkg/__init__.py
+++ b/tests/packages/navigate_editable/python/py_pkg/py1_pkg/__init__.py
@@ -1,0 +1,3 @@
+from ..py2_pkg import py2_method_a
+
+__all__ = ["py2_method_a"]

--- a/tests/packages/navigate_editable/python/py_pkg/py1_pkg/py1_module.py
+++ b/tests/packages/navigate_editable/python/py_pkg/py1_pkg/py1_module.py
@@ -1,0 +1,4 @@
+from ..py2_pkg import py2_method_b
+from ..py2_pkg.py2_module import py2_method_c
+
+__all__ = ["py2_method_b", "py2_method_c"]

--- a/tests/packages/navigate_editable/python/py_pkg/py2_pkg/__init__.py
+++ b/tests/packages/navigate_editable/python/py_pkg/py2_pkg/__init__.py
@@ -1,0 +1,6 @@
+def py2_method_a():
+    print("py2_method_a")
+
+
+def py2_method_b():
+    print("py2_method_b")

--- a/tests/packages/navigate_editable/python/py_pkg/py2_pkg/py2_module.py
+++ b/tests/packages/navigate_editable/python/py_pkg/py2_pkg/py2_module.py
@@ -1,0 +1,2 @@
+def py2_method_c():
+    print("py2_method_c")

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -48,3 +48,35 @@ def test_navigate_editable(isolated, isolate, package):
 
     value = isolated.execute("import shared_pkg; shared_pkg.read_c_generated_txt()")
     assert value == "Some_value_C"
+
+
+@pytest.mark.compile()
+@pytest.mark.configure()
+@pytest.mark.integration()
+@pytest.mark.parametrize("isolate", [True, False], ids=["isolated", "notisolated"])
+@pytest.mark.usefixtures("navigate_editable")
+def test_navigate_editable2(isolated, isolate):
+    isolate_args = ["--no-build-isolation"] if not isolate else []
+    isolated.install("pip>=23")
+    if not isolate:
+        isolated.install("scikit-build-core[pyproject]")
+
+    isolated.install(
+        "-v", "--config-settings=build-dir=build/{wheel_tag}", *isolate_args, "-e", "."
+    )
+
+    # Navigate from py_package to py_package
+    value = isolated.execute("import py_pkg.py1_pkg; py_pkg.py1_pkg.py2_method_a()")
+    assert value == "py2_method_a"
+
+    # Navigate from py_package.py_module to py_package
+    value = isolated.execute(
+        "import py_pkg.py1_pkg.py1_module; py_pkg.py1_pkg.py1_module.py2_method_b()"
+    )
+    assert value == "py2_method_b"
+
+    # Navigate from py_package.py_module to py_package.py_module
+    value = isolated.execute(
+        "import py_pkg.py1_pkg.py1_module; py_pkg.py1_pkg.py1_module.py2_method_c()"
+    )
+    assert value == "py2_method_c"


### PR DESCRIPTION
TODO:
- [ ] Add test-cases for relative navigation
  - [x] python-python navigation (`py1_pkg.py1_module` -> `py2_pkg.py2_module`)
  - [ ] namespace-python-python navigations (`(ns1)py3_pkg.pya_module` -> `(ns2)py3_pkg.pyb_module`)
  - [ ] c-c nagivation (`(_c_lib.so)c1_pkg.c1_module` -> `(_c_lib.so)c2_pkg.c2_module`; `(_c3_lib.so)c3_pkg.c3_module` -> `(_c4_lib.so)c4_pkg.c4_mdoule`)
  - [ ] Mixed packaging (`shared_pkg.c1_pkg.c1_module` with `c1_pkg` and `c1_module` in the same `.so` file; `shared_pkg.c1_pkg.py2_module` with `py2_module` from python)
- [ ] Fix python-python navigation
- [ ] Fix c-python navigation 

Naming could be a bit cumbersome. Is there a convention or some reusable structure that we can import