### PR TITLE
fix: editable package imports fix

### DIFF
--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -27,11 +27,7 @@ class EditablePackage(NamedTuple):
 @pytest.fixture(
     params=[
         pytest.param(False, id="abs"),
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(strict=True, reason="Rel imports broken"),
-            id="rel",
-        ),
+        pytest.param(True, id="rel"),
     ]
 )
 def editable_package(


### PR DESCRIPTION
Fix https://github.com/scikit-build/scikit-build-core/issues/532. Non-package modules should not have submodule paths set. Builds on #545.
