### PR TITLE
fix: correct editable template & add more tests

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -47,7 +47,7 @@ def editable_redirect(
         build_options,
         install_options,
     )
-    arguments_str = ", ".join(repr(x) for x in arguments if x is not None)
+    arguments_str = ", ".join(repr(x) for x in arguments)
     editable_txt += f"\n\ninstall({arguments_str})\n"
     return editable_txt
 

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -32,6 +32,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         verbose: bool,
         build_options: list[str],
         install_options: list[str],
+        dir: str = DIR,
     ) -> None:
         self.known_source_files = known_source_files
         self.known_wheel_files = known_wheel_files
@@ -40,6 +41,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.verbose = verbose
         self.build_options = build_options
         self.install_options = install_options
+        self.dir = dir
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
         submodule_search_locations: dict[str, set[str]] = {}
@@ -65,7 +67,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                     msg = f"Unexpected path to source file: {file} [{module}]"
                     raise ImportError(msg)
                 if not os.path.isabs(parent_path):
-                    parent_path = os.path.join(str(DIR), parent_path)
+                    parent_path = os.path.join(self.dir, parent_path)
                 submodule_search_locations[parent].add(parent_path)
         self.submodule_search_locations = submodule_search_locations
         self.pkgs = pkgs
@@ -88,7 +90,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 self.rebuild()
             return importlib.util.spec_from_file_location(
                 fullname,
-                os.path.join(DIR, redir),
+                os.path.join(self.dir, redir),
                 submodule_search_locations=submodule_search_locations,
             )
         if fullname in self.known_source_files:

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scikit_build_core.resources._editable_redirect import ScikitBuildRedirectingFinder
+
+
+def process_dict(d: dict[str, str]) -> dict[str, str]:
+    return {k: str(Path(v)) for k, v in d.items()}
+
+
+def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
+    return {k: {str(Path(x)) for x in v} for k, v in d.items()}
+
+
+def test_editable_redirect():
+    known_source_files = process_dict(
+        {
+            "pkg": "/source/pkg/__init__.py",
+            "pkg.module": "/source/pkg/module.py",
+            "pkg.subpkg": "/source/pkg/subpkg/__init__.py",
+            "pkg.subpkg.module": "/source/pkg/subpkg/module.py",
+            "pkg.resources.file": "/source/pkg/resources/file.txt",
+            "pkg.namespace.module": "/source/pkg/namespace/module.py",
+        }
+    )
+    known_wheel_files = process_dict(
+        {
+            "pkg.subpkg.source": "pkg/subpkg/source.py",
+            "pkg.src_files": "pkg/src_files.py",
+            "pkg.namespace.source": "pkg/namespace/source.py",
+            "pkg.iresources.file": "pkg/iresources/file.txt",
+            "pkg.installed_files": "pkg/installed_files.py",
+            "pkg.source": "pkg/source.py",
+        }
+    )
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files=known_source_files,
+        known_wheel_files=known_wheel_files,
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(Path("/sitepackages")),
+    )
+
+    assert finder.submodule_search_locations == process_dict_set(
+        {
+            "pkg": {
+                "/sitepackages/pkg",
+                "/source/pkg",
+            },
+            "pkg.iresources": {
+                "/sitepackages/pkg/iresources",
+            },
+            "pkg.namespace": {
+                "/sitepackages/pkg/namespace",
+                "/source/pkg/namespace",
+            },
+            "pkg.resources": {"/source/pkg/resources"},
+            "pkg.subpkg": {
+                "/sitepackages/pkg/subpkg",
+                "/source/pkg/subpkg",
+            },
+        }
+    )
+    assert finder.pkgs == ["pkg", "pkg.subpkg"]


### PR DESCRIPTION
I believe this buggy template writing (bug introduced in 0.6.1) actually can't cause a real-world breakage, since the dir is not None if the options after it were set.