### PR TITLE
feat: add inplace mode for editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ wheel.platlib = ""
 # disable this, or the empty string.
 backport.find-python = "3.26.1"
 
-# Select the editable mode to use. Currently only "redirect" is supported.
+# Select the editable mode to use. Can be "redirect" (default) or "inplace".
 editable.mode = "redirect"
 
 # Turn on verbose output for the editable mode rebuilds.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -531,7 +531,7 @@ Known limitations:
 
 - Resources (via `importlib.resources`) are not properly supported (yet).
   Currently experimentally supported except on Python 3.9 (3.7, 3.8, 3.10, 3.11,
-  and 3.12 work).
+  and 3.12 work). `importlib_resources` may work on Python 3.9.
 
 ```console
 # Very experimental rebuild on initial import feature
@@ -559,11 +559,13 @@ in-place CMake build, so all the caveats there apply too -- only one build per
 source directory, you can't change to an out-of-source builds without removing
 the build artifacts, your source directory will be littered with build
 artifacts, etc. Also, to make your binaries importable, you should set
-`LIBRARY_OUTPUT_DIRECTORY` (and `RUNTIME_OUTPUT_DIRECTORY_<CONFIG>` for
-multi-config generator support, like MSVC) to make sure they are placed inside
-your source directory inside the Python packages; this will be run from the
-build directory, rather than installed. This will also not support automatic
-rebuilds. The build directory setting must be empty/unset to use this.
+`LIBRARY_OUTPUT_DIRECTORY` (include a generator expression, like the empty one
+`$<0:>` for multi-config generator support, like MSVC, so you don't have to set
+all possible `*_<CONFIG>` variations) to make sure they are placed inside your
+source directory inside the Python packages; this will be run from the build
+directory, rather than installed. This will also not support automatic rebuilds.
+The build directory setting must be empty/unset to use this. You can detect this
+mode by checking for an in-place build and checking `SKBUILD` being set.
 
 With all the caveats, this is very logically simple (one directory) and a near
 identical replacement for `python setup.py build_ext --inplace`. Some third

--- a/noxfile.py
+++ b/noxfile.py
@@ -136,6 +136,7 @@ def docs(session: nox.Session) -> None:
     extra_installs = ["sphinx-autobuild"] if args.serve else []
 
     session.install("-e.[docs,pyproject]", *extra_installs)
+    session.run("pip", "list")
     session.chdir("docs")
 
     if args.builder == "linkcheck":

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -186,10 +186,11 @@
       "properties": {
         "mode": {
           "enum": [
-            "redirect"
+            "redirect",
+            "inplace"
           ],
           "default": "redirect",
-          "description": "Select the editable mode to use. Currently only \"redirect\" is supported."
+          "description": "Select the editable mode to use. Can be \"redirect\" (default) or \"inplace\"."
         },
         "verbose": {
           "type": "boolean",

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -189,9 +189,9 @@ class BackportSettings:
 
 @dataclasses.dataclass
 class EditableSettings:
-    mode: Literal["redirect"] = "redirect"
+    mode: Literal["redirect", "inplace"] = "redirect"
     """
-    Select the editable mode to use. Currently only "redirect" is supported.
+    Select the editable mode to use. Can be "redirect" (default) or "inplace".
     """
 
     verbose: bool = True

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -197,6 +197,19 @@ class SettingsReader:
                 )
                 raise CMakeConfigError(msg)
 
+        if self.settings.editable.mode == "inplace":
+            if self.settings.editable.rebuild:
+                rich_print(
+                    "[red][bold]ERROR:[/bold] editable rebuild is incompatible with inplace mode"
+                )
+                raise SystemExit(7)
+
+            if self.settings.build_dir:
+                rich_print(
+                    "[red][bold]ERROR:[/bold] build-dir must be empty for editable inplace mode"
+                )
+                raise SystemExit(7)
+
         if self.settings.editable.rebuild and not self.settings.build_dir:
             rich_print(
                 "[red][bold]ERROR:[/bold] editable mode with rebuild requires build_dir"

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -14,6 +14,10 @@ install(
   DESTINATION ${SKBUILD_PROJECT_NAME}
   COMPONENT PythonModule)
 
+set_target_properties(
+  _module PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                     "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}")
+
 # Testing artifacts
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated.txt "Testing")
 install(

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -14,9 +14,11 @@ install(
   DESTINATION ${SKBUILD_PROJECT_NAME}
   COMPONENT PythonModule)
 
-if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}" AND DEFINED SKBUILD)
-  # Editable in-place builds. THe empty generator expression ensures multi-config
-  # enerators keeps us from having to set LIBRARY_OUTPUT_DIRECTORY_<CONFIG> too.
+if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}"
+   AND DEFINED SKBUILD)
+  # Editable in-place builds. THe empty generator expression ensures
+  # multi-config enerators keeps us from having to set
+  # LIBRARY_OUTPUT_DIRECTORY_<CONFIG> too.
   set_target_properties(
     _module PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                        "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}$<0:>")

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -14,9 +14,13 @@ install(
   DESTINATION ${SKBUILD_PROJECT_NAME}
   COMPONENT PythonModule)
 
-set_target_properties(
-  _module PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-                     "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}$<0:>")
+if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}" AND DEFINED SKBUILD)
+  # Editable in-place builds. THe empty generator expression ensures multi-config
+  # enerators keeps us from having to set LIBRARY_OUTPUT_DIRECTORY_<CONFIG> too.
+  set_target_properties(
+    _module PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                       "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}$<0:>")
+endif()
 
 # Testing artifacts
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated.txt "Testing")

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -16,7 +16,7 @@ install(
 
 set_target_properties(
   _module PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-                     "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}")
+                     "${CMAKE_BINARY_DIR}/src/${SKBUILD_PROJECT_NAME}$<0:>")
 
 # Testing artifacts
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated.txt "Testing")

--- a/tests/test_pyproject_pep660.py
+++ b/tests/test_pyproject_pep660.py
@@ -1,11 +1,17 @@
 import sys
 import sysconfig
+import typing
 import zipfile
 from pathlib import Path
 
 import pytest
 
 from scikit_build_core.build import build_editable
+
+
+@pytest.fixture(params=["redirect", "inplace"])
+def editable_mode(request: pytest.FixtureRequest) -> str:
+    return typing.cast(str, request.param)
 
 
 # TODO: figure out why gmake is reporting no rule to make simple_pure.cpp
@@ -17,9 +23,9 @@ from scikit_build_core.build import build_editable
     reason="No idea why this fails on Cygwin",
 )
 @pytest.mark.usefixtures("package_simplest_c")
-def test_pep660_wheel():
+def test_pep660_wheel(editable_mode: str):
     dist = Path("dist")
-    out = build_editable("dist")
+    out = build_editable("dist", {"editable.mode": editable_mode})
     (wheel,) = dist.glob("simplest-0.0.1-*.whl")
     assert wheel == dist / out
 
@@ -29,10 +35,14 @@ def test_pep660_wheel():
             file_names = [p.name for p in p.iterdir()]
             metadata = p.joinpath("simplest-0.0.1.dist-info/METADATA").read_text()
 
-        assert len(file_names) == 4
+        assert len(file_names) == 4 if editable_mode == "redirect" else 2
         assert "simplest-0.0.1.dist-info" in file_names
-        assert "simplest" in file_names
-        assert "_simplest_editable.py" in file_names
+        if editable_mode == "redirect":
+            assert "simplest" in file_names
+            assert "_simplest_editable.py" in file_names
+        else:
+            assert "simplest" not in file_names
+            assert "_simplest_editable.py" not in file_names
         assert "_simplest_editable.pth" in file_names
 
         assert "Metadata-Version: 2.1" in metadata
@@ -43,16 +53,23 @@ def test_pep660_wheel():
 @pytest.mark.compile()
 @pytest.mark.configure()
 @pytest.mark.integration()
-@pytest.mark.parametrize("isolate", [True, False])
+@pytest.mark.parametrize("isolate", [True, False], ids=["isolated", "not_isolated"])
 @pytest.mark.usefixtures("package_simplest_c")
-def test_pep660_pip_isolated(isolated, isolate):
+def test_pep660_pip_isolated(isolated, isolate, editable_mode: str):
     isolate_args = ["--no-build-isolation"] if not isolate else []
     isolated.install("pip>=23")
     if not isolate:
         isolated.install("scikit-build-core[pyproject]")
 
+    build_dir = "" if editable_mode == "inplace" else "build/{wheel_tag}"
+
     isolated.install(
-        "-v", "--config-settings=build-dir=build/{wheel_tag}", *isolate_args, "-e", "."
+        "-v",
+        f"--config-settings=build-dir={build_dir}",
+        f"--config-settings=editable.mode={editable_mode}",
+        *isolate_args,
+        "-e",
+        ".",
     )
 
     value = isolated.execute("import simplest; print(simplest.square(2))")
@@ -67,9 +84,10 @@ def test_pep660_pip_isolated(isolated, isolate):
     python_source = Path("src/simplest").resolve()
     assert any(x.samefile(python_source) for x in locations)
 
-    # Second path is from the CMake install
     cmake_install = isolated.platlib.joinpath("simplest").resolve()
-    assert any(x.samefile(cmake_install) for x in locations)
+    if editable_mode == "redirect":
+        # Second path is from the CMake install
+        assert any(x.samefile(cmake_install) for x in locations)
 
     location = isolated.execute("import simplest; print(simplest.__file__)")
     # The package file is defined in the python source and __file__ must point to it
@@ -78,6 +96,7 @@ def test_pep660_pip_isolated(isolated, isolate):
     location = isolated.execute(
         "import simplest._module; print(simplest._module.__file__)"
     )
+
     if sys.version_info < (3, 8, 7):
         import distutils.sysconfig  # pylint: disable=deprecated-module
 
@@ -85,13 +104,15 @@ def test_pep660_pip_isolated(isolated, isolate):
     else:
         ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 
-    module_file = cmake_install / f"_module{ext_suffix}"
+    module_source = python_source if editable_mode == "inplace" else cmake_install
+    module_file = module_source / f"_module{ext_suffix}"
+
     # Windows FindPython may produce the wrong extension
     if (
         sys.version_info < (3, 8, 7)
         and sys.platform.startswith("win")
         and not module_file.is_file()
     ):
-        module_file = cmake_install / "_module.pyd"
+        module_file = module_source / "_module.pyd"
 
     assert module_file.samefile(Path(location).resolve())


### PR DESCRIPTION
This adds support for editable.mode=inplace, which does an inplace CMake build, along with a simple editable mode .pth file. This has a lot of caveats (just like CMake inplace builds), but works better with some workflows and tools. It's certainly better than copying the output file back into the source, which is what some projects are currently doing. :)
