### PR TITLE
feat: support namespaced config settings

### DIFF
--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -179,9 +179,16 @@ class SettingsReader:
                     else:
                         tool_skb[key] = value
 
+        prefixed = {
+            k: v for k, v in config_settings.items() if k.startswith("skbuild.")
+        }
+        remaining = {
+            k: v for k, v in config_settings.items() if not k.startswith("skbuild.")
+        }
         self.sources = SourceChain(
             EnvSource("SKBUILD"),
-            ConfSource(settings=config_settings, verify=verify_conf),
+            ConfSource("skbuild", settings=prefixed, verify=verify_conf),
+            ConfSource(settings=remaining, verify=verify_conf),
             TOMLSource("tool", "scikit-build", settings=pyproject),
             prefixes=["tool", "scikit-build"],
         )
@@ -240,8 +247,10 @@ class SettingsReader:
         return result
 
     def print_suggestions(self) -> None:
-        for index in (1, 2):
-            name = {1: "config-settings", 2: "pyproject.toml"}[index]
+        for index in (1, 2, 3):
+            name = {1: "config-settings", 2: "config-settings", 3: "pyproject.toml"}[
+                index
+            ]
             suggestions_dict = self.suggestions(index)
             if suggestions_dict:
                 rich_print(f"[red][bold]ERROR:[/bold] Unrecognized options in {name}:")

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -137,7 +137,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 @pytest.mark.parametrize("prefix", [True, False], ids=["skbuild", "noprefix"])
 def test_skbuild_settings_config_settings(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: str
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: bool
 ):
     monkeypatch.setattr(
         scikit_build_core.settings.skbuild_read_settings, "__version__", "0.1.0"
@@ -179,7 +179,7 @@ def test_skbuild_settings_config_settings(
     }
 
     if prefix:
-        config_settings = {f"{prefix}.{k}": v for k, v in config_settings.items()}
+        config_settings = {f"skbuild.{k}": v for k, v in config_settings.items()}
 
     settings_reader = SettingsReader.from_file(pyproject_toml, config_settings)
     settings = settings_reader.settings

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -135,8 +135,9 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert not settings.install.strip
 
 
+@pytest.mark.parametrize("prefix", [True, False], ids=["skbuild", "noprefix"])
 def test_skbuild_settings_config_settings(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: str
 ):
     monkeypatch.setattr(
         scikit_build_core.settings.skbuild_read_settings, "__version__", "0.1.0"
@@ -176,6 +177,9 @@ def test_skbuild_settings_config_settings(
         "install.components": ["a", "b", "c"],
         "install.strip": "True",
     }
+
+    if prefix:
+        config_settings = {f"{prefix}.{k}": v for k, v in config_settings.items()}
 
     settings_reader = SettingsReader.from_file(pyproject_toml, config_settings)
     settings = settings_reader.settings


### PR DESCRIPTION
Support namespaced config settings, `skbuild.X` now also works instead of just `X`.
