### PR TITLE
ci: fix spelling for Fedora

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -17,7 +17,7 @@ BuildRequires:  gcc-c++
 BuildRequires:  git
 
 %global _description %{expand:
-A next generation Python CMake adaptor and Python API for plugins
+A next generation Python CMake adapter and Python API for plugins
 }
 
 %description %_description


### PR DESCRIPTION
This should fix the failing tests, I think.
