### PR TITLE
feat: Preserve additivity of `cmake.define` across `overrides` tables

### DIFF
--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -436,6 +436,63 @@
               }
             ]
           },
+          "inherit": {
+            "type": "object",
+            "properties": {
+              "cmake": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "define": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "targets": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "sdist": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "include": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "exclude": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "wheel": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "packages": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "license-files": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "exclude": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "install": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "components": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
           "cmake": {
             "$ref": "#/properties/cmake"
           },
@@ -546,6 +603,14 @@
           "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0."
         }
       }
+    },
+    "inherit": {
+      "enum": [
+        "none",
+        "append",
+        "prepend"
+      ],
+      "default": "none"
     }
   }
 }

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -263,11 +263,11 @@ class SettingsReader:
                             )
                             tool_skb[key] = inner
                     else:
-                        if isinstance(inherit_override, dict):
-                            assert not inherit_override
-                            inherit_override = "none"
+                        inherit_override_tmp = inherit_override or "none"
+                        if isinstance(inherit_override_tmp, dict):
+                            assert not inherit_override_tmp
                         tool_skb[key] = inherit_join(
-                            value, tool_skb.get(key, None), inherit_override
+                            value, tool_skb.get(key, None), inherit_override_tmp
                         )
 
         prefixed = {

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -232,12 +232,20 @@ class SettingsReader:
                     if isinstance(value, dict):
                         for key2, value2 in value.items():
                             inner = tool_skb.get(key, {})
-                            if key == "cmake" and key2 == "define":
-                                inner.setdefault("define", {})
-                                inner["define"].update(value2)
-                            else:
-                                inner[key2] = value2
+                            inner[key2] = value2
                             tool_skb[key] = inner
+                    elif key.startswith("+"):
+                        levels = key[1:].split(".")
+                        if levels[0] == "cmake":
+                            cmake = tool_skb.setdefault("cmake", {})
+                            if levels[1] == "args":
+                                args = cmake.setdefault("args", [])
+                                args += value
+                            elif levels[1] == "define":
+                                define = cmake.setdefault("define", {})
+                                define[levels[2]] = value
+                        else:
+                            raise RuntimeError("Only `cmake.args` and `cmake.define` support additive changes.")
                     else:
                         tool_skb[key] = value
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -245,7 +245,9 @@ class SettingsReader:
                                 define = cmake.setdefault("define", {})
                                 define[levels[2]] = value
                         else:
-                            raise RuntimeError("Only `cmake.args` and `cmake.define` support additive changes.")
+                            raise RuntimeError(
+                                "Only `cmake.args` and `cmake.define` support additive changes."
+                            )
                     else:
                         tool_skb[key] = value
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -232,7 +232,11 @@ class SettingsReader:
                     if isinstance(value, dict):
                         for key2, value2 in value.items():
                             inner = tool_skb.get(key, {})
-                            inner[key2] = value2
+                            if key == "cmake" and key2 == "define":
+                                inner.setdefault("define", {})
+                                inner["define"].update(value2)
+                            else:
+                                inner[key2] = value2
                             tool_skb[key] = inner
                     else:
                         tool_skb[key] = value

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -127,6 +127,26 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
             },
         },
     }
+    schema["$defs"]["inherit"] = {
+        "enum": ["none", "append", "prepend"],
+        "default": "none",
+    }
+
+    inherit_props: dict[str, Any] = {
+        k: {
+            kk: {"$ref": "#/$defs/inherit"}
+            for kk, vv in v["properties"].items()
+            if vv.get("type", "") in {"object", "array"}
+        }
+        for k, v in schema["properties"].items()
+        if v.get("type", "") == "object"
+    }
+    inherit_props = {
+        k: {"type": "object", "additionalProperties": False, "properties": v}
+        for k, v in inherit_props.items()
+        if v
+    }
+
     schema["properties"]["overrides"] = {
         "type": "array",
         "description": "A list of overrides to apply to the settings, based on the `if` selector.",
@@ -146,6 +166,11 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
                             "additionalProperties": False,
                         },
                     ]
+                },
+                "inherit": {
+                    "type": "object",
+                    "properties": inherit_props,
+                    "additionalProperties": False,
                 },
                 **props,
             },


### PR DESCRIPTION
This light-weight PR adds a special rule when overriding `cmake.define`, so that additivity is retained and orthogonal CMake defines are accommodated. Consider the following TOML excerpt:

```toml
[[tool.scikit-build.overrides]]
if.env.SET_FOO = "ON"
cmake.define.FOO = "1"

[[tool.scikit-build.overrides]]
if.env.SET_BAR = "ON"
cmake.define.BAR = "1"
```

As of now, this would result in `cmake.define` being `{"BAR": "1"}`. With the PR, `cmake.define` will be `{"FOO": 1, "BAR": "1"}`.