### PR TITLE
feat: Setting CMake variables though environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -386,6 +386,14 @@ SKBUILD_CMAKE_DEFINE: SOME_DEFINE=ON
 
 ````
 
+You can also (`pyproject.toml` only) specify a dict, with `env=` to load a
+define from an environment variable, with optional `default=`.
+
+```toml
+[tool.scikit-build.cmake.define]
+SOME_DEFINE = {env="SOME_DEFINE", default="EMPTY"}
+```
+
 You can also manually specify the exact CMake args. Beyond the normal
 `SKBUILD_CMAKE_ARGS`, the `CMAKE_ARGS` space-separated environment variable is
 also supported (with some filtering for options scikit-build-core doesn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "importlib-resources >=1.3; python_version<'3.9'",
     "packaging >=20.9",
     "tomli >=1.1; python_version<'3.11'",
-    "typing-extensions >=3.10.0; python_version<'3.8'",
+    "typing-extensions >=3.10.0; python_version<'3.9'",
 ]
 # Note: for building wheels and sdists, there are also additional dependencies
 # in the pyproject extra. And cmake and possibly ninja if those are not already

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -7,11 +7,14 @@ if sys.version_info < (3, 8):
     from typing_extensions import (
         Literal,
         Protocol,
-        get_args,
-        get_origin,
     )
 else:
-    from typing import Literal, Protocol, get_args, get_origin
+    from typing import Literal, Protocol
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated, get_args, get_origin
+else:
+    from typing import Annotated, get_args, get_origin
 
 if sys.version_info < (3, 11):
     if typing.TYPE_CHECKING:
@@ -26,7 +29,15 @@ if sys.version_info < (3, 11):
 else:
     from typing import Self, assert_never
 
-__all__ = ["Protocol", "Literal", "Self", "get_origin", "get_args", "assert_never"]
+__all__ = [
+    "Annotated",
+    "Protocol",
+    "Literal",
+    "Self",
+    "get_origin",
+    "get_args",
+    "assert_never",
+]
 
 
 def __dir__() -> list[str]:

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -32,10 +32,37 @@
             ".+": {
               "oneOf": [
                 {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
                 },
                 {
-                  "type": "boolean"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "env"
+                  ],
+                  "properties": {
+                    "env": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "default": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -73,6 +74,18 @@ class CMakeSettings:
     The build targets to use when building the project. Empty builds the
     default target.
     """
+
+    def __post_init__(self) -> None:
+        # read define values from environment
+        for key, value in self.define.items():
+            if (
+                isinstance(value, str)
+                and value.startswith("{env.")
+                and value.endswith("}")
+            ):
+                env_name = value[5:-1]
+                env_value = os.environ.get(env_name, "")
+                self.define[key] = env_value
 
 
 @dataclasses.dataclass

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,12 +1,11 @@
 import dataclasses
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from .._compat.typing import Literal
+from .._compat.typing import Annotated, Literal
 
 __all__ = [
     "BackportSettings",
@@ -46,9 +45,9 @@ class CMakeSettings:
     in config or envvar will override toml. See also ``cmake.define``.
     """
 
-    define: Dict[
-        str, Union[str, bool, Dict[str, Union[str, bool]]]
-    ] = dataclasses.field(default_factory=dict)
+    define: Annotated[Dict[str, Union[str, bool]], "EnvVar"] = dataclasses.field(
+        default_factory=dict
+    )
     """
     A table of defines to pass to CMake when configuring the project. Additive.
     """
@@ -76,20 +75,6 @@ class CMakeSettings:
     The build targets to use when building the project. Empty builds the
     default target.
     """
-
-    def __post_init__(self) -> None:
-        # read define values from environment
-        for key, value in self.define.items():
-            if isinstance(value, dict):
-                env = value.get("env", "")
-                if env == "":
-                    error_msg = (
-                        f"Dictionary for `cmake.define.{key}` must include the key `env`, "
-                        f"whose value must be a non-empty string."
-                    )
-                    raise KeyError(error_msg)
-                default = value.get("default", "")
-                self.define[key] = os.environ.get(env, default)  # type: ignore[arg-type]
 
 
 @dataclasses.dataclass

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -436,7 +436,9 @@ class TOMLSource:
             return {k: cls.convert(v, _get_inner_type(target)) for k, v in item.items()}
         if raw_target is Any:
             return item
-        if raw_target is Union and type(item) in get_args(target):
+        if raw_target is Union and type(item) in tuple(
+            _get_target_raw_type(arg) for arg in get_args(target)
+        ):
             return item
         if raw_target is Literal:
             if item not in get_args(_process_union(target)):

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -37,6 +37,7 @@ When setting up your dataclasses, these types are handled:
 - ``List[T]``: A list of items. `;` separated supported in EnvVar/config forms. T can be a dataclass (TOML only).
 - ``Dict[str, T]``: A table of items. TOML supports a layer of nesting. Any is supported as an item type.
 - ``Literal[...]``: A list of strings, the result must be in the list.
+- ``Annotated[Dict[...], "EnvVar"]``: A dict of items, where each item can be a string or a dict with "env" and "default" keys.
 
 These are supported for JSON schema generation for the TOML, as well.
 
@@ -51,7 +52,7 @@ import typing
 from typing import Any, TypeVar, Union
 
 from .._compat.builtins import ExceptionGroup
-from .._compat.typing import Literal, Protocol, get_args, get_origin
+from .._compat.typing import Annotated, Literal, Protocol, get_args, get_origin
 
 if typing.TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
@@ -69,6 +70,10 @@ def _dig_strict(__dict: Mapping[str, Any], *names: str) -> Any:
     for name in names:
         __dict = __dict[name]
     return __dict
+
+
+def _process_bool(value: str) -> bool:
+    return value.strip().lower() not in {"0", "false", "off", "no", ""}
 
 
 def _dig_not_strict(__dict: Mapping[str, Any], *names: str) -> Any:
@@ -104,13 +109,26 @@ def _process_union(target: type[Any]) -> Any:
     return target
 
 
+def _process_annotated(target: type[Any]) -> tuple[Any, tuple[Any, ...]]:
+    """
+    Splits annotated into raw type and annotations. If not annotated, the annotations will be empty.
+    """
+
+    origin = get_origin(target)
+    if origin is Annotated:
+        return get_args(target)[0], get_args(target)[1:]
+
+    return target, ()
+
+
 def _get_target_raw_type(target: type[Any]) -> Any:
     """
     Takes a type like ``Optional[str]`` and returns str, or ``Optional[Dict[str,
     int]]`` and returns dict. Returns Union for a Union with more than one
-    non-none type. Literal is also a valid return.
+    non-none type. Literal is also a valid return. Works through Annotated.
     """
 
+    target, _ = _process_annotated(target)
     target = _process_union(target)
     origin = get_origin(target)
     return origin or target
@@ -142,6 +160,20 @@ def _nested_dataclass_to_names(__target: type[Any], *inner: str) -> Iterator[lis
             yield from _nested_dataclass_to_names(field.type, *inner, field.name)
     else:
         yield list(inner)
+
+
+def _dict_with_envvar(target: Any) -> Any:
+    """
+    This produces values. Supports "env" and "default" keys.
+    """
+    if not isinstance(target, dict):
+        return target
+    env = target["env"]
+    default = target.get("default", None)
+    value = os.environ.get(env, default)
+    if isinstance(default, bool) and isinstance(value, str):
+        return _process_bool(value)
+    return value
 
 
 class Source(Protocol):
@@ -214,6 +246,7 @@ class EnvSource:
 
     @classmethod
     def convert(cls, item: str, target: type[Any]) -> object:
+        target, _ = _process_annotated(target)
         raw_target = _get_target_raw_type(target)
         if dataclasses.is_dataclass(raw_target):
             msg = f"Array of dataclasses are not supported in configuration settings ({raw_target})"
@@ -227,7 +260,7 @@ class EnvSource:
             return {k: cls.convert(v, _get_inner_type(target)) for k, v in items}
 
         if raw_target is bool:
-            return item.strip().lower() not in {"0", "false", "off", "no", ""}
+            return _process_bool(item)
 
         if raw_target is Union and str in get_args(target):
             return item
@@ -329,6 +362,7 @@ class ConfSource:
     def convert(
         cls, item: str | list[str] | dict[str, str], target: type[Any]
     ) -> object:
+        target, _ = _process_annotated(target)
         raw_target = _get_target_raw_type(target)
         if dataclasses.is_dataclass(raw_target):
             msg = f"Array of dataclasses are not supported in configuration settings ({raw_target})"
@@ -349,7 +383,7 @@ class ConfSource:
             msg = f"Expected {target}, got {type(item).__name__}"
             raise TypeError(msg)
         if raw_target is bool:
-            return item.strip().lower() not in {"0", "false", "off", "no", ""}
+            return _process_bool(item)
         if raw_target is Union and str in get_args(target):
             return item
         if raw_target is Literal:
@@ -414,6 +448,7 @@ class TOMLSource:
 
     @classmethod
     def convert(cls, item: Any, target: type[Any]) -> object:
+        target, annotations = _process_annotated(target)
         raw_target = _get_target_raw_type(target)
         if dataclasses.is_dataclass(raw_target):
             fields = dataclasses.fields(raw_target)
@@ -433,12 +468,16 @@ class TOMLSource:
             if not isinstance(item, dict):
                 msg = f"Expected {target}, got {type(item).__name__}"
                 raise TypeError(msg)
+            if annotations == ("EnvVar",):
+                return {
+                    k: cls.convert(_dict_with_envvar(v), _get_inner_type(target))
+                    for k, v in item.items()
+                    if _dict_with_envvar(v) is not None
+                }
             return {k: cls.convert(v, _get_inner_type(target)) for k, v in item.items()}
         if raw_target is Any:
             return item
-        if raw_target is Union and type(item) in tuple(
-            _get_target_raw_type(arg) for arg in get_args(target)
-        ):
+        if raw_target is Union and type(item) in get_args(target):
             return item
         if raw_target is Literal:
             if item not in get_args(_process_union(target)):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -61,6 +61,8 @@ def test_valid_schemas_files(filepath: Path) -> None:
         {"metadata": {"version": {"provider-path": True}}},
         {"metadata": {"version": {"provider": 2}}},
         {"metadata": {"invalid": {"provider": "correct"}}},
+        {"cmake": {"define": {"FOO": {"env": ""}}}},
+        {"cmake": {"define": {"FOO": {"default": False}}}},
     ],
 )
 def test_invalid_schemas(addition: dict[str, Any]) -> None:
@@ -100,6 +102,9 @@ def test_invalid_schemas(addition: dict[str, Any]) -> None:
         },
         {"metadata": {"version": {"provider-path": "string"}}},
         {"metadata": {"description": {"anything": True}}},
+        {"cmake": {"define": {"FOO": "BAR"}}},
+        {"cmake": {"define": {"FOO": {"env": "FOO"}}}},
+        {"cmake": {"define": {"FOO": {"env": "FOO", "default": False}}}},
     ],
 )
 def test_valid_schemas(addition: dict[str, Any]) -> None:


### PR DESCRIPTION
This PR allows reading environment variables to define CMake variable. This is especially useful when the set of valid values which a CMake variable can assume is either not known a priori, or is not finite, and so `overrides` is not really helpful. 

Simple example:

```toml
[tool.scikit-build]
cmake.define.FOO = {env = "FOO"}
```

Bumps `typing_extensions` to being required for Python 3.9+.