### PR TITLE
fix: include license file entry in search

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -219,7 +219,10 @@ def _build_wheel_impl(
             license_file_globs.append(str(metadata.license.file))
 
         license_files = {
-            x: x.read_bytes() for y in license_file_globs for x in Path().glob(y) if x.is_file()
+            x: x.read_bytes()
+            for y in license_file_globs
+            for x in Path().glob(y)
+            if x.is_file()
         }
         if settings.wheel.license_files and not license_files:
             logger.warning(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -219,7 +219,7 @@ def _build_wheel_impl(
             license_file_globs.append(str(metadata.license.file))
 
         license_files = {
-            x: x.read_bytes() for y in license_file_globs for x in Path().glob(y)
+            x: x.read_bytes() for y in license_file_globs for x in Path().glob(y) if x.is_file()
         }
         if settings.wheel.license_files and not license_files:
             logger.warning(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -213,10 +213,13 @@ def _build_wheel_impl(
         else:
             install_dir = wheel_dirs[targetlib] / settings.wheel.install_dir
 
+        # Include the metadata license.file entry if provided
+        license_file_globs = list(settings.wheel.license_files)
+        if metadata.license and metadata.license.file:
+            license_file_globs.append(str(metadata.license.file))
+
         license_files = {
-            x: x.read_bytes()
-            for y in settings.wheel.license_files
-            for x in Path().glob(y)
+            x: x.read_bytes() for y in license_file_globs for x in Path().glob(y)
         }
         if settings.wheel.license_files and not license_files:
             logger.warning(


### PR DESCRIPTION
This would help https://github.com/scikit-build/scikit-build-core/issues/571 not have shown an error (but in that case, multiple licenses is actually desired, and the custom `tool.scikit-build` setting should be used until PEP 639 goes somewhere).

Also fixes #571 by filtering out directory matches.
