### PR TITLE
feat: cmake.version and ninja.version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Included modules:
 ## Basic CMake usage
 
 ```python
-cmake = CMake.default_search(minimum_version="3.15")
+cmake = CMake.default_search(version=">=3.15")
 config = CMaker(
     cmake,
     source_dir=source_dir,
@@ -208,8 +208,8 @@ from scikit_build_core.settings.skbuild_settings import SettingsReader
 
 settings_reader = SettingsReader.from_file("pyproject.toml", config_settings)
 setting = settings_reader.settings
-assert settings.cmake.minimum_version == "3.15"
-assert settings.ninja.minimum_version == "1.5"
+assert str(settings.cmake.version) == ">=3.15"
+assert str(settings.ninja.version) == ">=1.5"
 ```
 
 ## Builders

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-        exclude: ^(LICENSE$|src/scikit_build_core/resources/find_python)
+        exclude: ^(LICENSE$|src/scikit_build_core/resources/find_python|tests/test_skbuild_settings.py$)
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6

--- a/README.md
+++ b/README.md
@@ -150,10 +150,13 @@ print("```\n")
 
 ```toml
 [tool.scikit-build]
-# The minimum version of CMake to use. If CMake is not present on the system or
-# is older than this, it will be downloaded via PyPI if possible. An empty
+# DEPRECATED in 0.8; use version instead.
+cmake.minimum-version = ""
+
+# The versions of CMake to allow. If CMake is not present on the system or does
+# not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
-cmake.minimum-version = "3.15"
+cmake.version = ">=3.15"
 
 # A list of args to pass to CMake when configuring the project. Setting this in
 # config or envvar will override toml. See also ``cmake.define``.
@@ -177,10 +180,13 @@ cmake.source-dir = "."
 # target.
 cmake.targets = []
 
-# The minimum version of Ninja to use. If Ninja is not present on the system or
-# is older than this, it will be downloaded via PyPI if possible. An empty
+# DEPRECATED in 0.8; use version instead.
+ninja.minimum-version = ""
+
+# The versions of Ninja to allow. If Ninja is not present on the system or does
+# not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
-ninja.minimum-version = "1.5"
+ninja.version = ">=1.5"
 
 # If CMake is not present on the system or is older required, it will be
 # downloaded via PyPI if possible. An empty string will disable this check.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,8 @@ The following behaviors are affected by `minimum-version`:
 - `minimum-version` 0.5+ (or unset) provides the original name in metadata and
   properly normalized SDist names.
 - `minimum-version` 0.5+ (or unset) strips binaries by default.
+- `minimum-version` 0.8+ (or unset) `cmake.minimum-version` and
+  `ninja.minimum-version` are replaced with `cmake.version` and `ninja.version`.
 
 :::
 
@@ -117,8 +119,8 @@ For example, to require a recent CMake and Ninja:
 
 ```toml
 [tool.scikit-build]
-cmake.minimum-version = "3.26.1"
-ninja.minimum-version = "1.11"
+cmake.version = ">=3.26.1"
+ninja.version = ">=1.11"
 ```
 
 You can also enforce ninja to be required even if make is present on Unix:
@@ -136,6 +138,12 @@ would turn it off).
 ```toml
 [tool.scikit-build]
 backport.find-python = "3.15"
+```
+
+```{versionadded} 0.8
+These used to be called `cmake.minimum-version` and `ninja.minimum-version`, and
+only took a single value. Now they are full specifier sets, allowing for more
+complex version requirements, like `>=3.15,!=3.18.0`.
 ```
 
 ## Configuring source file inclusion
@@ -647,7 +655,7 @@ will match top to bottom, overriding previous matches. For example:
 ```toml
 [[tool.scikit-build.overrides]]
 if.sys-platform = "darwin"
-cmake.minimum-version = "3.18"
+cmake.version = ">=3.18"
 ```
 
 If you use `if.any` instead of `if`, then the override is true if any one of the

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -148,7 +148,7 @@ def _build_wheel_impl(
     normalized_name = metadata.name.replace("-", "_").replace(".", "_")
 
     if settings.wheel.cmake:
-        cmake = CMake.default_search(minimum_version=settings.cmake.minimum_version)
+        cmake = CMake.default_search(version=settings.cmake.version)
         cmake_msg = [f"using [blue]CMake {cmake.version}[/blue]"]
     else:
         cmake = None

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -107,9 +107,7 @@ def set_environment_for_gen(
         return {}
 
     if (generator or "Ninja") == "Ninja":
-        ninja = best_program(
-            get_ninja_programs(), minimum_version=ninja_settings.minimum_version
-        )
+        ninja = best_program(get_ninja_programs(), version=ninja_settings.version)
 
         if ninja is not None:
             env.setdefault("CMAKE_GENERATOR", "Ninja")

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -59,19 +59,17 @@ class GetRequires:
         return self._settings
 
     def cmake(self) -> Generator[str, None, None]:
-        cmake_min = self.settings.cmake.minimum_version
+        cmake_verset = self.settings.cmake.version
 
         # If the module is already installed (via caching the build
         # environment, for example), we will use that
         if importlib.util.find_spec("cmake") is not None:
-            yield f"cmake>={cmake_min}"
+            yield f"cmake{cmake_verset}"
             return
 
-        cmake = best_program(
-            get_cmake_programs(module=False), minimum_version=cmake_min
-        )
+        cmake = best_program(get_cmake_programs(module=False), version=cmake_verset)
         if cmake is None:
-            yield f"cmake>={cmake_min}"
+            yield f"cmake{cmake_verset}"
             return
         logger.debug("Found system CMake: {} - not requiring PyPI package", cmake)
 
@@ -90,17 +88,15 @@ class GetRequires:
         if os.environ.get("CMAKE_MAKE_PROGRAM", ""):
             return
 
-        ninja_min = self.settings.ninja.minimum_version
+        ninja_verset = self.settings.ninja.version
 
         # If the module is already installed (via caching the build
         # environment, for example), we will use that
         if importlib.util.find_spec("ninja") is not None:
-            yield f"ninja>={ninja_min}"
+            yield f"ninja{ninja_verset}"
             return
 
-        ninja = best_program(
-            get_ninja_programs(module=False), minimum_version=ninja_min
-        )
+        ninja = best_program(get_ninja_programs(module=False), version=ninja_verset)
         if ninja is not None:
             logger.debug("Found system Ninja: {} - not requiring PyPI package", ninja)
             return
@@ -114,7 +110,7 @@ class GetRequires:
                 "Found system Make & not on known platform - not requiring PyPI package for Ninja"
             )
             return
-        yield f"ninja>={ninja_min}"
+        yield f"ninja{ninja_verset}"
 
     def dynamic_metadata(self) -> Generator[str, None, None]:
         for dynamic_metadata in self.settings.metadata.values():

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -21,6 +21,7 @@ from .program_search import best_program, get_cmake_programs
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
+    from packaging.specifiers import SpecifierSet
     from packaging.version import Version
 
     from ._compat.typing import Self
@@ -42,13 +43,13 @@ class CMake:
 
     @classmethod
     def default_search(
-        cls, *, minimum_version: Version | None = None, module: bool = True
+        cls, *, version: SpecifierSet | None = None, module: bool = True
     ) -> Self:
         candidates = get_cmake_programs(module=module)
-        cmake_program = best_program(candidates, minimum_version=minimum_version)
+        cmake_program = best_program(candidates, version=version)
 
         if cmake_program is None:
-            msg = f"Could not find CMake with version >= {minimum_version}"
+            msg = f"Could not find CMake with version {version}"
             raise CMakeNotFoundError(msg)
         if cmake_program.version is None:
             msg = "CMake version undetermined @ {program.path}"

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -14,6 +14,8 @@ from ._shutil import Run
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
+    from packaging.specifiers import SpecifierSet
+
 __all__ = ["get_cmake_programs", "get_ninja_programs", "best_program", "Program"]
 
 
@@ -122,16 +124,16 @@ def get_make_programs() -> Generator[Path, None, None]:
 
 
 def best_program(
-    programs: Iterable[Program], *, minimum_version: Version | None
+    programs: Iterable[Program], *, version: SpecifierSet | None
 ) -> Program | None:
     """
     Select the first program entry that is of a supported version, or None if not found.
     """
 
     for program in programs:
-        if minimum_version is None:
+        if version is None:
             return program
-        if program.version is not None and program.version >= minimum_version:
+        if program.version is not None and version.contains(program.version):
             return program
 
     return None

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -11,8 +11,13 @@
       "properties": {
         "minimum-version": {
           "type": "string",
-          "default": "3.15",
-          "description": "The minimum version of CMake to use. If CMake is not present on the system or is older than this, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "DEPRECATED in 0.8; use version instead.",
+          "deprecated": true
+        },
+        "version": {
+          "type": "string",
+          "default": ">=3.15",
+          "description": "The versions of CMake to allow. If CMake is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check."
         },
         "args": {
           "type": "array",
@@ -67,8 +72,13 @@
       "properties": {
         "minimum-version": {
           "type": "string",
-          "default": "1.5",
-          "description": "The minimum version of Ninja to use. If Ninja is not present on the system or is older than this, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "DEPRECATED in 0.8; use version instead.",
+          "deprecated": true
+        },
+        "version": {
+          "type": "string",
+          "default": ">=1.5",
+          "description": "The versions of Ninja to allow. If Ninja is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check."
         },
         "make-fallback": {
           "type": "boolean",

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -8,6 +8,7 @@ import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from .._compat.typing import get_args, get_origin
@@ -80,7 +81,7 @@ def mk_docs(dc: type[object], prefix: str = "") -> Generator[DCDoc, None, None]:
         if field.default is not dataclasses.MISSING and field.default is not None:
             default = repr(
                 str(field.default)
-                if isinstance(field.default, (Path, Version))
+                if isinstance(field.default, (Path, Version, SpecifierSet))
                 else field.default
             )
         elif field.default_factory is not dataclasses.MISSING:

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -2,6 +2,7 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from .._compat.typing import Literal
@@ -26,10 +27,15 @@ def __dir__() -> List[str]:
 
 @dataclasses.dataclass
 class CMakeSettings:
-    minimum_version: Version = Version("3.15")
+    minimum_version: Optional[Version] = None
     """
-    The minimum version of CMake to use. If CMake is not present on the system
-    or is older than this, it will be downloaded via PyPI if possible. An empty
+    DEPRECATED in 0.8; use version instead.
+    """
+
+    version: SpecifierSet = SpecifierSet(">=3.15")
+    """
+    The versions of CMake to allow. If CMake is not present on the system or does
+    not pass this specifier, it will be downloaded via PyPI if possible. An empty
     string will disable this check.
     """
 
@@ -71,10 +77,15 @@ class CMakeSettings:
 
 @dataclasses.dataclass
 class NinjaSettings:
-    minimum_version: Version = Version("1.5")
+    minimum_version: Optional[Version] = None
     """
-    The minimum version of Ninja to use. If Ninja is not present on the system
-    or is older than this, it will be downloaded via PyPI if possible. An empty
+    DEPRECATED in 0.8; use version instead.
+    """
+
+    version: SpecifierSet = SpecifierSet(">=1.5")
+    """
+    The versions of Ninja to allow. If Ninja is not present on the system or does
+    not pass this specifier, it will be downloaded via PyPI if possible. An empty
     string will disable this check.
     """
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -114,7 +114,7 @@ class BuildCMake(setuptools.Command):
 
         settings = SettingsReader.from_file("pyproject.toml", {}).settings
 
-        cmake = CMake.default_search(minimum_version=settings.cmake.minimum_version)
+        cmake = CMake.default_search(version=settings.cmake.version)
 
         config = CMaker(
             cmake,

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 from scikit_build_core.cmake import CMake, CMaker
 from scikit_build_core.errors import CMakeNotFoundError
@@ -68,8 +68,8 @@ def test_too_old(fp, monkeypatch):
     fp.register([fp.program("cmake3"), "--version"], stdout="3.14.0")
 
     with pytest.raises(CMakeNotFoundError) as excinfo:
-        CMake.default_search(minimum_version=Version("3.15"))
-    assert "Could not find CMake with version >= 3.15" in excinfo.value.args[0]
+        CMake.default_search(version=SpecifierSet(">=3.15"))
+    assert "Could not find CMake with version >=3.15" in excinfo.value.args[0]
 
 
 @pytest.mark.configure()

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -6,7 +6,7 @@ import sysconfig
 from pathlib import Path
 
 import pytest
-from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 from scikit_build_core.cmake import CMake, CMaker
 from scikit_build_core.file_api._cattrs_converter import (
@@ -37,7 +37,7 @@ def prepare_env_or_skip() -> None:
 def test_cattrs_comparison(tmp_path):
     build_dir = tmp_path / "build"
 
-    cmake = CMake.default_search(minimum_version=Version("3.15"))
+    cmake = CMake.default_search(version=SpecifierSet(">=3.15"))
     config = CMaker(
         cmake,
         source_dir=DIR / "packages/simple_pure",
@@ -67,7 +67,7 @@ def test_no_index(tmp_path):
 def test_simple_pure(tmp_path):
     build_dir = tmp_path / "build"
 
-    cmake = CMake.default_search(minimum_version=Version("3.15"))
+    cmake = CMake.default_search(version=SpecifierSet(">=3.15"))
     config = CMaker(
         cmake,
         source_dir=DIR / "packages/simple_pure",

--- a/tests/test_fortran.py
+++ b/tests/test_fortran.py
@@ -5,7 +5,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
-from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 from scikit_build_core.build import build_wheel
 from scikit_build_core.program_search import (
@@ -20,8 +20,8 @@ DIR = Path(__file__).parent.resolve()
 FORTRAN_EXAMPLE = DIR / "packages/fortran_example"
 
 
-cmake_info = best_program(get_cmake_programs(), minimum_version=Version("3.17.2"))
-ninja_info = best_program(get_ninja_programs(), minimum_version=Version("1.10"))
+cmake_info = best_program(get_cmake_programs(), version=SpecifierSet(">=3.17.2"))
+ninja_info = best_program(get_ninja_programs(), version=SpecifierSet(">=1.10"))
 
 
 @pytest.mark.compile()

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -61,7 +61,7 @@ def test_get_requires_parts_uneeded(fp):
 
 def test_get_requires_parts_settings(fp):
     fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
-    config = {"cmake.minimum-version": "3.20"}
+    config = {"cmake.version": ">=3.20"}
     assert set(GetRequires(config).cmake()) == {"cmake>=3.20"}
     assert set(GetRequires(config).ninja()) == {*ninja}
 
@@ -71,7 +71,23 @@ def test_get_requires_parts_pyproject(fp, monkeypatch, tmp_path):
     tmp_path.joinpath("pyproject.toml").write_text(
         """
         [tool.scikit-build.cmake]
-        minimum-version = "3.21"
+        version = ">=3.21"
+        """
+    )
+    fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
+
+    assert set(GetRequires().cmake()) == {"cmake>=3.21"}
+    assert set(GetRequires().ninja()) == {*ninja}
+
+
+def test_get_requires_parts_pyproject_old(fp, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+        
+        [tool.scikit-build]
+        minimum-version = "0.0"
+        cmake.minimum-version = "3.21"
         """
     )
     fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 import pytest
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from scikit_build_core.program_search import (
@@ -55,11 +56,11 @@ def test_get_cmake_programs_all(monkeypatch, fp):
     assert programs[1].path.name == "cmake"
     assert programs[1].version == Version("3.20.0")
 
-    best1 = best_program(programs, minimum_version=None)
+    best1 = best_program(programs, version=None)
     assert best1
     assert best1.path.name == "cmake3"
 
-    best2 = best_program(programs, minimum_version=Version("3.20.0"))
+    best2 = best_program(programs, version=SpecifierSet(">=3.20.0"))
     assert best2
     assert best2.path.name == "cmake"
 
@@ -77,11 +78,11 @@ def test_get_ninja_programs_all(monkeypatch, fp):
     assert programs[1].path.name == "ninja"
     assert programs[1].version == Version("1.10.1")
 
-    best1 = best_program(programs, minimum_version=None)
+    best1 = best_program(programs, version=None)
     assert best1
     assert best1.path.name == "ninja-build"
 
-    best2 = best_program(programs, minimum_version=Version("1.9"))
+    best2 = best_program(programs, version=SpecifierSet(">=1.9"))
     assert best2
     assert best2.path.name == "ninja"
 
@@ -98,13 +99,13 @@ def test_get_cmake_programs_malformed(monkeypatch, fp, caplog):
     assert "Could not determine CMake version" in str(caplog.records[0].msg)
     assert len(programs) == 2
 
-    best_none = best_program(programs, minimum_version=None)
+    best_none = best_program(programs, version=None)
     assert best_none
     assert best_none.path.name == "cmake3"
 
-    best_3_15 = best_program(programs, minimum_version=Version("3.15"))
+    best_3_15 = best_program(programs, version=SpecifierSet(">=3.15"))
     assert best_3_15
     assert best_3_15.path.name == "cmake3"
 
-    best_3_20 = best_program(programs, minimum_version=Version("3.20"))
+    best_3_20 = best_program(programs, version=SpecifierSet(">=3.20"))
     assert best_3_20 is None

--- a/tests/test_simple_pure.py
+++ b/tests/test_simple_pure.py
@@ -8,7 +8,7 @@ import sysconfig
 from pathlib import Path
 
 import pytest
-from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 from scikit_build_core.cmake import CMake, CMaker
 
@@ -39,7 +39,7 @@ def config(tmp_path_factory):
 
     build_dir = tmp_path / "build"
 
-    cmake = CMake.default_search(minimum_version=Version("3.15"))
+    cmake = CMake.default_search(version=SpecifierSet(">=3.15"))
     config = CMaker(
         cmake,
         source_dir=DIR / "packages/simple_pure",
@@ -107,7 +107,7 @@ def test_variable_defined(tmp_path, capfd):
 
     build_dir = tmp_path / "build"
 
-    cmake = CMake.default_search(minimum_version=Version("3.15"))
+    cmake = CMake.default_search(version=SpecifierSet(">=3.15"))
     config = CMaker(
         cmake,
         source_dir=DIR / "packages/simple_pure",


### PR DESCRIPTION
Close #583.

If `tool.scikit-build.minimum-version` is set, then this will require the correct setting here. If it's unset, it will just produce a warning if the old form is used (for now).

This is also an API change, but I think that's fine for a 0.x release unless someone needs back-compat, which I can add if needed.