### PR TITLE
fix: Fedora40 sdist hash test

### DIFF
--- a/.distro/F40_sdist_hash.patch
+++ b/.distro/F40_sdist_hash.patch
@@ -1,0 +1,30 @@
+From ef34d34c94127a47cb5f34acbc680473d197e684 Mon Sep 17 00:00:00 2001
+From: Cristian Le <cristian.le@mpsd.mpg.de>
+Date: Tue, 16 Jan 2024 11:42:36 +0100
+Subject: [PATCH] Patch sdist hash for F40
+
+Issue seems to be with a system package rather than python environment
+https://github.com/scikit-build/scikit-build-core/issues/596
+
+Signed-off-by: Cristian Le <cristian.le@mpsd.mpg.de>
+---
+ tests/conftest.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/conftest.py b/tests/conftest.py
+index d46e7f8..14620ea 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -211,8 +211,8 @@ def package_simple_pyproject_ext(
+     package = PackageInfo(
+         "simple_pyproject_ext",
+         "c75641407303f3f3a0fd76d24e3d12447b31286fa5d0f687c0f8f8eb804d839f",
+-        "dc4921bdf694b1b88cb27c8e6128513e174689625447d18c1dd3353348824946",
+-        "2a135ce826265c5c1c73ebcb603989d8e2f4bca4605ad04c6c82871b5f75840e",
++        "9dc70f1bdc99bd477439ec31681eb2eae8cd591412054f168d8ff821ed069435",
++        "ea22e3a447b146790b30ebd4bf5abb80f21e8c24b6ce716798514eb364e992eb",
+         "7558e1db89e62b0941671796e1a35983a0b50a0701736566ca3ae5dd9ba09846",
+     )
+     process_package(package, tmp_path, monkeypatch)
+--
+2.43.0

--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -7,6 +7,8 @@ License:        Apache-2.0
 URL:            https://github.com/scikit-build/scikit-build-core
 Source:         %{pypi_source scikit_build_core}
 
+Patch:          F40_sdist_hash.patch
+
 BuildArch:      noarch
 BuildRequires:  python3-devel
 # Testing dependences
@@ -34,7 +36,10 @@ Suggests:       gcc
 
 
 %prep
-%autosetup -n scikit_build_core-%{version}
+%setup -n scikit_build_core-%{version}
+%if 0%{?fedora} >= 40
+%autopatch -p 1 -m 0
+%endif
 
 
 %generate_buildrequires

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,22 +4,13 @@
 specfile_path: .distro/python-scikit-build-core.spec
 
 files_to_sync:
-  - src: .distro/python-scikit-build-core.spec
-    dest: python-scikit-build-core.spec
-  - .packit.yaml
-  - src: .distro/python-scikit-build-core.rpmlintrc
-    dest: python-scikit-build-core.rpmlintrc
-  # tmt setup
-  - src: .distro/.fmf/
-    dest: .fmf/
-  - src: .distro/plans/
-    dest: plans/
+  - src: .distro/
+    dest: ./
     filters:
-      - "- main.fmf.dist-git"
-      - "- rpminspect.fmf"
-      - "- rpmlint.fmf"
-  - src: .distro/tests/
-    dest: tests/
+      - "- plans/main.fmf.dist-git"
+      - "- plans/rpminspect.fmf"
+      - "- plans/rpmlint.fmf"
+  - .packit.yaml
   - src: .distro/plans/main.fmf.dist-git
     dest: plans/main.fmf
 upstream_package_name: scikit_build_core


### PR DESCRIPTION
For now here I just patch the sdist hash of the test on Fedora 40+. I have checked manually in the container that the sdist is effectively equivalent.

The issue is that F40 and F39 have the same `tar` and `python3.12` versions, and when I tested in the container I have used `pip install -e`, so it should have the dependencies from PyPI and it seems the issue is lower on the system packages

Fixes #596 