### PR TITLE
tests: try comparing uncompressed files

### DIFF
--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -143,7 +143,9 @@ def build_sdist(
     sdist_dir.mkdir(parents=True, exist_ok=True)
     with contextlib.ExitStack() as stack:
         gzip_container = stack.enter_context(
-            gzip.GzipFile(sdist_dir / filename, mode="wb", mtime=timestamp)
+            gzip.GzipFile(
+                sdist_dir / filename, mode="wb", compresslevel=9, mtime=timestamp
+            )
         )
         tar = stack.enter_context(
             tarfile.TarFile(fileobj=gzip_container, mode="w", format=tarfile.PAX_FORMAT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,10 +210,10 @@ def package_simple_pyproject_ext(
 ) -> PackageInfo:
     package = PackageInfo(
         "simple_pyproject_ext",
-        "c75641407303f3f3a0fd76d24e3d12447b31286fa5d0f687c0f8f8eb804d839f",
-        "dc4921bdf694b1b88cb27c8e6128513e174689625447d18c1dd3353348824946",
-        "2a135ce826265c5c1c73ebcb603989d8e2f4bca4605ad04c6c82871b5f75840e",
-        "7558e1db89e62b0941671796e1a35983a0b50a0701736566ca3ae5dd9ba09846",
+        "6c5bb5f1b6c44f3aab37fc8f768004f644c24001ad0304759a69b754ca6ad46d",
+        "ba13e4195ae6333459412bc802ba8c02c231cf1c5ee143f6a3392786d80a49b4",
+        "f1a6050eae910de7cd86830ba97af5e74ff953f9acc2adab47aa9cdf2a3eca91",
+        "b861db81fd1de6dee4a0d6574af27af54424fbccce12b018644d1db136f218ac",
     )
     process_package(package, tmp_path, monkeypatch)
     return package

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -1,3 +1,4 @@
+import gzip
 import hashlib
 import shutil
 import sys
@@ -37,6 +38,11 @@ mark_hashes_different = pytest.mark.xfail(
 )
 
 
+def compute_uncompressed_hash(inp: Path):
+    with gzip.open(inp, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
 @pytest.mark.usefixtures("package_simple_pyproject_ext")
 def test_pep517_sdist():
     dist = Path("dist")
@@ -71,7 +77,7 @@ def test_pep517_sdist_hash(monkeypatch, package_simple_pyproject_ext):
     dist = Path("dist")
     out = build_sdist("dist")
     sdist = dist / out
-    hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    hash = compute_uncompressed_hash(sdist)
     assert hash == package_simple_pyproject_ext.sdist_hash
 
 
@@ -139,7 +145,7 @@ def test_pep517_sdist_time_hash_set_epoch(
 
     out = build_sdist(str(dist), {"sdist.reproducible": "true"})
     sdist = dist / out
-    hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    hash = compute_uncompressed_hash(sdist)
     assert hash == package_simple_pyproject_ext.sdist_dated_hash
 
 

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -1,3 +1,4 @@
+import gzip
 import hashlib
 import shutil
 import sys
@@ -15,6 +16,11 @@ def cleanup_overwrite():
     yield overwrite
     if overwrite.exists():
         overwrite.unlink()
+
+
+def compute_uncompressed_hash(inp: Path):
+    with gzip.open(inp, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
 
 
 @pytest.mark.network()
@@ -37,7 +43,7 @@ def test_pep518_sdist(isolated, package_simple_pyproject_ext):
     assert sdist.name == "cmake_example-0.0.1.tar.gz"
 
     if not sys.platform.startswith(("win", "cygwin")):
-        hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+        hash = compute_uncompressed_hash(sdist)
         assert hash == package_simple_pyproject_ext.sdist_hash
 
     with tarfile.open(sdist) as f:


### PR DESCRIPTION
Testing this to see if it fixes #596, alternative to #609. The SDists linked seem identical except for minor compression differences, and this might depend on exact zlib versions, so if we can compare uncompressed hashes, that's good enough. (If this works, we should probably check the headers too)
