### PR TITLE
doc: Warning about using `cmake.args` for defines

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,6 +403,13 @@ support overriding).
 
 ```
 
+:::{warning}
+
+Setting defines through `cmake.args` in `pyproject.toml` is discouraged because
+this cannot be later altered via command line. Use `cmake.define` instead.
+
+:::
+
 You can also specify this using `CMAKE_ARGS`, space separated:
 
 ```yaml


### PR DESCRIPTION
Just learned this the hard way