### PR TITLE
fix: do not exit with exec permission error in ninja check

### DIFF
--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -78,7 +78,7 @@ def get_cmake_program(cmake_path: Path) -> Program:
     """
     try:
         result = Run().capture(cmake_path, "--version")
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, PermissionError):
         return Program(cmake_path, None)
 
     try:
@@ -110,7 +110,7 @@ def get_ninja_programs(*, module: bool = True) -> Generator[Program, None, None]
     for ninja_path in _get_ninja_path(module=module):
         try:
             result = Run().capture(ninja_path, "--version")
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, PermissionError):
             yield Program(ninja_path, None)
             continue
 


### PR DESCRIPTION
Also `cmake` check.

As discussed in:

  https://github.com/orgs/scikit-build/discussions/1057

There may be times when we attempt to execute `ninja --version` from the ninja package in /tmp/, which may be mounted `noexec`. This result in a PermissionError.

Carry on so we can inspect other ninja executables available.