### PR TITLE
Fix '-' vs '_' in error message

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -566,7 +566,7 @@ Known limitations:
 
 ```console
 # Very experimental rebuild on initial import feature
-$ pip install --no-build-isolation --config-settings=editable.rebuild=true --config-settings=build-dir=/path/to/my/build/dir -ve.
+$ pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=build -ve.
 ```
 
 Due to the length of this line already being long, you do not need to set the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -566,7 +566,7 @@ Known limitations:
 
 ```console
 # Very experimental rebuild on initial import feature
-$ pip install --no-build-isolation --config-settings=editable.rebuild=true -ve.
+$ pip install --no-build-isolation --config-settings=editable.rebuild=true --config-settings=build-dir=/path/to/my/build/dir -ve.
 ```
 
 Due to the length of this line already being long, you do not need to set the

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -277,7 +277,7 @@ class SettingsReader:
 
         if self.settings.editable.rebuild and not self.settings.build_dir:
             rich_print(
-                "[red][bold]ERROR:[/bold] editable mode with rebuild requires build_dir"
+                "[red][bold]ERROR:[/bold] editable mode with rebuild requires build-dir"
             )
             raise SystemExit(7)
 


### PR DESCRIPTION
The necessary setting is `build-dir` not `build_dir`