### PR TITLE
Make run command logged at info

### DIFF
--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -66,7 +66,7 @@ class Run:
                 logger.debug("RUNENV - changes since last run only:\n  {}", msg)
                 type(self)._prev_env = self.env.copy()
 
-        logger.debug("RUN: {}", " ".join(options))
+        logger.info("RUN: {}", " ".join(options))
 
         return subprocess.run(
             options,


### PR DESCRIPTION
From #629 

Maybe this level should be split for more granularity like:
- `status` for messages that should always be outputted like when it enters a `configure`/`build` stage, etc.
- `info` for tracing basic execution, like in this case what commands are run