### PR TITLE
doc: Clarify requirement for using "inplace" editable mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -604,7 +604,8 @@ party tooling might work better with this mode. Scikit-build-core will simply
 install a `.pth` file that points at your source package(s) and do an inplace
 CMake build.
 
-On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
+On the command line, you can pass `-Ceditable.mode=inplace -Cbuild-dir=""` to
+enable this mode.
 
 :::
 


### PR DESCRIPTION
Until #642 is addressed, specifying `-Cbuild-dir=""` is required to avoid "build-dir must be empty for editable inplace mode" error.