### PR TITLE
fix: editable install should ignore build-dir

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -595,8 +595,9 @@ artifacts, etc. Also, to make your binaries importable, you should set
 all possible `*_<CONFIG>` variations) to make sure they are placed inside your
 source directory inside the Python packages; this will be run from the build
 directory, rather than installed. This will also not support automatic rebuilds.
-The build directory setting must be empty/unset to use this. You can detect this
-mode by checking for an in-place build and checking `SKBUILD` being set.
+The build directory setting will be ignored if you use this and perform an
+editable install. You can detect this mode by checking for an in-place build and
+checking `SKBUILD` being set.
 
 With all the caveats, this is very logically simple (one directory) and a near
 identical replacement for `python setup.py build_ext --inplace`. Some third
@@ -604,8 +605,7 @@ party tooling might work better with this mode. Scikit-build-core will simply
 install a `.pth` file that points at your source package(s) and do an inplace
 CMake build.
 
-On the command line, you can pass `-Ceditable.mode=inplace -Cbuild-dir=""` to
-enable this mode.
+On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
 
 :::
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -177,19 +177,22 @@ def _build_wheel_impl(
         )
 
         # A build dir can be specified, otherwise use a temporary directory
-        build_dir = (
-            Path(
-                settings.build_dir.format(
-                    cache_tag=sys.implementation.cache_tag,
-                    wheel_tag=str(tags),
-                    build_type=settings.cmake.build_type,
-                    state=state,
+        if cmake is not None and editable and settings.editable.mode == "inplace":
+            build_dir = settings.cmake.source_dir
+        else:
+            build_dir = (
+                Path(
+                    settings.build_dir.format(
+                        cache_tag=sys.implementation.cache_tag,
+                        wheel_tag=str(tags),
+                        build_type=settings.cmake.build_type,
+                        state=state,
+                    )
                 )
+                if settings.build_dir
+                else build_tmp_folder / "build"
             )
-            if settings.build_dir
-            else build_tmp_folder / "build"
-        )
-        logger.info("Build directory: {}", build_dir.resolve())
+            logger.info("Build directory: {}", build_dir.resolve())
 
         wheel_dirs = {
             targetlib: wheel_dir / targetlib,
@@ -279,8 +282,6 @@ def _build_wheel_impl(
         install_options = []
 
         if cmake is not None:
-            if editable and settings.editable.mode == "inplace":
-                build_dir = settings.cmake.source_dir
             config = CMaker(
                 cmake,
                 source_dir=settings.cmake.source_dir,

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -262,24 +262,18 @@ class SettingsReader:
                 )
                 raise CMakeConfigError(msg)
 
-        if self.settings.editable.mode == "inplace":
-            if self.settings.editable.rebuild:
+        if self.settings.editable.rebuild:
+            if self.settings.editable.mode == "inplace":
                 rich_print(
                     "[red][bold]ERROR:[/bold] editable rebuild is incompatible with inplace mode"
                 )
                 raise SystemExit(7)
 
-            if self.settings.build_dir:
+            if not self.settings.build_dir:
                 rich_print(
-                    "[red][bold]ERROR:[/bold] build-dir must be empty for editable inplace mode"
+                    "[red][bold]ERROR:[/bold] editable mode with rebuild requires build-dir"
                 )
                 raise SystemExit(7)
-
-        if self.settings.editable.rebuild and not self.settings.build_dir:
-            rich_print(
-                "[red][bold]ERROR:[/bold] editable mode with rebuild requires build-dir"
-            )
-            raise SystemExit(7)
 
         install_policy = (
             self.settings.minimum_version is None


### PR DESCRIPTION
This ignores the build-dir setting when making an editable install. It's easier to configure and there's no benefit to the error.
