### PR TITLE
fix: Use cmake -E capabilities instead of cmake --version

### DIFF
--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -32,8 +32,8 @@ def configure_args(config: CMaker, *, init: bool = False) -> Generator[str, None
 
 @pytest.mark.configure()
 def test_init_cache(fp, tmp_path):
-    fp.register([fp.program("cmake"), "--version"], stdout="3.14.0")
-    fp.register([fp.program("cmake3"), "--version"], stdout="3.14.0")
+    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
 
     config = CMaker(
         CMake.default_search(),
@@ -66,8 +66,8 @@ set(SKBUILD_PATH [===[{source_dir_str}]===] CACHE PATH "" FORCE)
 @pytest.mark.configure()
 def test_too_old(fp, monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    fp.register([fp.program("cmake"), "--version"], stdout="3.14.0")
-    fp.register([fp.program("cmake3"), "--version"], stdout="3.14.0")
+    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
 
     with pytest.raises(CMakeNotFoundError) as excinfo:
         CMake.default_search(version=SpecifierSet(">=3.15"))
@@ -76,8 +76,8 @@ def test_too_old(fp, monkeypatch):
 
 @pytest.mark.configure()
 def test_cmake_args(tmp_path, fp):
-    fp.register([fp.program("cmake"), "--version"], stdout="3.15.0")
-    fp.register([fp.program("cmake3"), "--version"], stdout="3.15.0")
+    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
+    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
 
     config = CMaker(
         CMake.default_search(),
@@ -99,8 +99,8 @@ def test_cmake_args(tmp_path, fp):
 
 @pytest.mark.configure()
 def test_cmake_paths(tmp_path, fp):
-    fp.register([fp.program("cmake"), "--version"], stdout="3.15.0")
-    fp.register([fp.program("cmake3"), "--version"], stdout="3.15.0")
+    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
+    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
 
     config = CMaker(
         CMake.default_search(),
@@ -124,7 +124,7 @@ def test_cmake_paths(tmp_path, fp):
 def test_get_cmake_via_envvar(monkeypatch: pytest.MonkeyPatch, fp):
     monkeypatch.setattr("shutil.which", lambda x: x)
     cmake_path = Path("some-prog")
-    fp.register([cmake_path, "--version"], stdout="cmake version 3.20.0\n")
+    fp.register([cmake_path, "-E", "capabilities"], stdout='{"version":{"string":"3.20.0"}}')
     monkeypatch.setenv("CMAKE_EXECUTABLE", str(cmake_path))
     result = CMake.default_search(env=os.environ)
     assert result.cmake_path == cmake_path

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -32,8 +32,14 @@ def configure_args(config: CMaker, *, init: bool = False) -> Generator[str, None
 
 @pytest.mark.configure()
 def test_init_cache(fp, tmp_path):
-    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
-    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [fp.program("cmake"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
+    fp.register(
+        [fp.program("cmake3"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
 
     config = CMaker(
         CMake.default_search(),
@@ -66,8 +72,14 @@ set(SKBUILD_PATH [===[{source_dir_str}]===] CACHE PATH "" FORCE)
 @pytest.mark.configure()
 def test_too_old(fp, monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
-    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [fp.program("cmake"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
+    fp.register(
+        [fp.program("cmake3"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
 
     with pytest.raises(CMakeNotFoundError) as excinfo:
         CMake.default_search(version=SpecifierSet(">=3.15"))
@@ -76,8 +88,14 @@ def test_too_old(fp, monkeypatch):
 
 @pytest.mark.configure()
 def test_cmake_args(tmp_path, fp):
-    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
-    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
+    fp.register(
+        [fp.program("cmake"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
+    fp.register(
+        [fp.program("cmake3"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
 
     config = CMaker(
         CMake.default_search(),
@@ -99,8 +117,14 @@ def test_cmake_args(tmp_path, fp):
 
 @pytest.mark.configure()
 def test_cmake_paths(tmp_path, fp):
-    fp.register([fp.program("cmake"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
-    fp.register([fp.program("cmake3"), "-E", "capabilities"], stdout='{"version":{"string":"3.15.0"}}')
+    fp.register(
+        [fp.program("cmake"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
+    fp.register(
+        [fp.program("cmake3"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
 
     config = CMaker(
         CMake.default_search(),
@@ -124,7 +148,9 @@ def test_cmake_paths(tmp_path, fp):
 def test_get_cmake_via_envvar(monkeypatch: pytest.MonkeyPatch, fp):
     monkeypatch.setattr("shutil.which", lambda x: x)
     cmake_path = Path("some-prog")
-    fp.register([cmake_path, "-E", "capabilities"], stdout='{"version":{"string":"3.20.0"}}')
+    fp.register(
+        [cmake_path, "-E", "capabilities"], stdout='{"version":{"string":"3.20.0"}}'
+    )
     monkeypatch.setenv("CMAKE_EXECUTABLE", str(cmake_path))
     result = CMake.default_search(env=os.environ)
     assert result.cmake_path == cmake_path

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -48,19 +48,19 @@ def protect_get_requires(fp, monkeypatch):
 
 
 def test_get_requires_parts(fp):
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(GetRequires().cmake()) == {"cmake>=3.15"}
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_parts_uneeded(fp):
-    fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
     assert set(GetRequires().cmake()) == set()
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_parts_settings(fp):
-    fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
     config = {"cmake.version": ">=3.20"}
     assert set(GetRequires(config).cmake()) == {"cmake>=3.20"}
     assert set(GetRequires(config).ninja()) == {*ninja}
@@ -74,7 +74,7 @@ def test_get_requires_parts_pyproject(fp, monkeypatch, tmp_path):
         version = ">=3.21"
         """
     )
-    fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
     assert set(GetRequires().ninja()) == {*ninja}
@@ -90,42 +90,42 @@ def test_get_requires_parts_pyproject_old(fp, monkeypatch, tmp_path):
         cmake.minimum-version = "3.21"
         """
     )
-    fp.register([Path("cmake/path"), "--version"], stdout="3.18.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_for_build_sdist(fp):
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_sdist({})) == {"pathspec", "pyproject_metadata"}
 
 
 def test_get_requires_for_build_sdist_cmake(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_sdist({"sdist.cmake": "True"})) == expected
 
 
 def test_get_requires_for_build_wheel(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_wheel({})) == expected
 
 
 def test_get_requires_for_build_wheel_pure(fp):
     expected = {"pathspec", "pyproject_metadata"}
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_wheel({"wheel.cmake": "False"})) == expected
 
 
 def test_get_requires_for_build_editable(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_editable({})) == expected
 
 
 def test_get_requires_for_build_editable_pure(fp):
     expected = {"pathspec", "pyproject_metadata"}
-    fp.register([Path("cmake/path"), "--version"], stdout="3.14.0")
+    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
     assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == expected

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -48,19 +48,28 @@ def protect_get_requires(fp, monkeypatch):
 
 
 def test_get_requires_parts(fp):
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(GetRequires().cmake()) == {"cmake>=3.15"}
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_parts_uneeded(fp):
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.18.0"}}',
+    )
     assert set(GetRequires().cmake()) == set()
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_parts_settings(fp):
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.18.0"}}',
+    )
     config = {"cmake.version": ">=3.20"}
     assert set(GetRequires(config).cmake()) == {"cmake>=3.20"}
     assert set(GetRequires(config).ninja()) == {*ninja}
@@ -74,7 +83,10 @@ def test_get_requires_parts_pyproject(fp, monkeypatch, tmp_path):
         version = ">=3.21"
         """
     )
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.18.0"}}',
+    )
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
     assert set(GetRequires().ninja()) == {*ninja}
@@ -90,42 +102,63 @@ def test_get_requires_parts_pyproject_old(fp, monkeypatch, tmp_path):
         cmake.minimum-version = "3.21"
         """
     )
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.18.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.18.0"}}',
+    )
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
     assert set(GetRequires().ninja()) == {*ninja}
 
 
 def test_get_requires_for_build_sdist(fp):
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_sdist({})) == {"pathspec", "pyproject_metadata"}
 
 
 def test_get_requires_for_build_sdist_cmake(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_sdist({"sdist.cmake": "True"})) == expected
 
 
 def test_get_requires_for_build_wheel(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_wheel({})) == expected
 
 
 def test_get_requires_for_build_wheel_pure(fp):
     expected = {"pathspec", "pyproject_metadata"}
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_wheel({"wheel.cmake": "False"})) == expected
 
 
 def test_get_requires_for_build_editable(fp):
     expected = {"pathspec", "pyproject_metadata", "cmake>=3.15", *ninja}
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_editable({})) == expected
 
 
 def test_get_requires_for_build_editable_pure(fp):
     expected = {"pathspec", "pyproject_metadata"}
-    fp.register([Path("cmake/path"), "-E", "capabilities"], stdout='{"version":{"string":"3.14.0"}}')
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
     assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == expected

--- a/tests/test_prepare_metadata.py
+++ b/tests/test_prepare_metadata.py
@@ -17,8 +17,8 @@ from scikit_build_core.build import (
 def test_prepare_metadata_for_build(fp, editable):
     # Old versions of packaging call mac_ver via subprocess
     fp.pass_command([sys.executable, fp.any()])
-    fp.pass_command([fp.program("cmake"), "--version"])
-    fp.pass_command([fp.program("cmake3"), "--version"])
+    fp.pass_command([fp.program("cmake"), "-E", "capabilities"])
+    fp.pass_command([fp.program("cmake3"), "-E", "capabilities"])
 
     if editable:
         assert (

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -101,7 +101,9 @@ def test_get_cmake_programs_malformed(monkeypatch, fp, caplog):
     assert len(programs) == 2
 
     fp.register([cmake_path, "-E", "capabilities"], stdout="scrambled output\n")
-    fp.register([cmake3_path, "-E", "capabilities"], stdout='{"version":{"string":"3.17.3"}}')
+    fp.register(
+        [cmake3_path, "-E", "capabilities"], stdout='{"version":{"string":"3.17.3"}}'
+    )
     programs = list(get_cmake_programs(module=False))
 
     best_none = best_program(programs, version=None)


### PR DESCRIPTION
cmake -E capabilities produces a machine-readable version, and is the intended way for programs to get the CMake version.