### PR TITLE
docs: fix install strip default

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ editable.rebuild = false
 install.components = []
 
 # Whether to strip the binaries. True for scikit-build-core 0.5+.
-install.strip = false
+install.strip = true
 
 # The path (relative to platlib) for the file to generate.
 generate[].path = ""

--- a/src/scikit_build_core/settings/skbuild_docs.py
+++ b/src/scikit_build_core/settings/skbuild_docs.py
@@ -23,7 +23,7 @@ def mk_skbuild_docs() -> str:
         if item.name == "minimum-version":
             item.default = f'"{version}"  # current version'
         if item.name == "install.strip":
-            item.default = "false"
+            item.default = "true"
         if item.name == "wheel.packages":
             item.default = '["src/<package>", "python/<package>", "<package>"]'
     return "\n".join(str(item) for item in items)


### PR DESCRIPTION
Fix #676.

None was being replaced by `false`.
