### PR TITLE
ci: Fedora CI maintenance

### DIFF
--- a/.distro/plans/rpmlint.fmf
+++ b/.distro/plans/rpmlint.fmf
@@ -1,5 +1,15 @@
-plan:
-  import:
-    url: https://github.com/packit/tmt-plans
-    ref: main
-    name: /plans/rpmlint
+prepare:
+  - how: shell
+    script: cp ./*.rpmlintrc $TMT_PLAN_DATA/
+discover:
+  how: fmf
+  filter: "tag: rpmlint"
+  url: https://github.com/packit/tmt-plans
+  ref: main
+execute:
+  how: tmt
+
+adjust:
+  when: distro < fedora-39
+  because: Rpmlint does not have spellcheck
+  enabled: false

--- a/.distro/python-scikit-build-core.rpmlintrc
+++ b/.distro/python-scikit-build-core.rpmlintrc
@@ -1,0 +1,3 @@
+addFilter("python.?-scikit-build-core\+pyproject.* spelling-error \('[Mm]etapackage")
+addFilter("python.?-scikit-build-core\+.* no-documentation")
+addFilter("python.?-scikit-build-core.* files-duplicate .*__init__.py .*")

--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -34,7 +34,20 @@ BuildArch:      noarch
 %description -n python3-scikit-build-core %_description
 
 
-%pyproject_extras_subpkg -n python3-scikit-build-core pyproject
+# Add %%pyproject_extras_subpkg results manually because BuildArch: noarch is not injected
+# https://src.fedoraproject.org/rpms/python-rpm-macros/pull-request/174
+# %%pyproject_extras_subpkg -n python3-scikit-build-core pyproject
+
+%package -n python3-scikit-build-core+pyproject
+Summary: Metapackage for python3-scikit-build-core: pyproject extras
+Requires: python3-scikit-build-core = %{?epoch:%{epoch}:}%{version}-%{release}
+BuildArch:      noarch
+%description -n python3-scikit-build-core+pyproject
+This is a metapackage bringing in pyproject extras requires for
+python3-scikit-build-core.
+It makes sure the dependencies are installed.
+
+%files -n python3-scikit-build-core+pyproject -f %{_pyproject_ghost_distinfo}
 
 
 %prep

--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           python-scikit-build-core
 Version:        0.0.0
 Release:        %autorelease
@@ -7,7 +9,6 @@ License:        Apache-2.0
 URL:            https://github.com/scikit-build/scikit-build-core
 Source:         %{pypi_source scikit_build_core}
 
-BuildArch:      noarch
 BuildRequires:  python3-devel
 # Testing dependences
 BuildRequires:  cmake
@@ -29,6 +30,7 @@ Recommends:     (ninja-build or make)
 Recommends:     python3-scikit-build-core+pyproject = %{version}-%{release}
 Suggests:       ninja-build
 Suggests:       gcc
+BuildArch:      noarch
 %description -n python3-scikit-build-core %_description
 
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,43 +28,33 @@ update_release: false
 upstream_tag_template: v{version}
 
 jobs:
-  - job: copr_build
-    trigger: pull_request
-    owner: "@scikit-build"
-    project: scikit-build-core
-    update_release: true
-    release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
-    targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-  - job: tests
-    trigger: pull_request
-    targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-    fmf_path: .distro
-  - job: copr_build
-    trigger: commit
-    branch: main
-    owner: "@scikit-build"
-    project: nightly
-    targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-  - job: tests
-    trigger: commit
-    branch: main
-    targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-    fmf_path: .distro
-  - job: copr_build
+  - &copr_build
+    job: copr_build
     trigger: release
     owner: "@scikit-build"
     project: release
-    targets:
+    targets: &targets
       - fedora-all-x86_64
       - fedora-all-aarch64
+  - &tests
+    job: tests
+    trigger: release
+    targets: *targets
+    fmf_path: .distro
+  - <<: *copr_build
+    trigger: commit
+    branch: main
+    project: nightly
+  - <<: *tests
+    trigger: commit
+    branch: main
+  - <<: *copr_build
+    trigger: pull_request
+    project: scikit-build-core
+    update_release: true
+    release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
+  - <<: *tests
+    trigger: pull_request
   - job: propose_downstream
     trigger: release
     dist_git_branches:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,9 +33,14 @@ jobs:
     trigger: release
     owner: "@scikit-build"
     project: release
+    # Drop F38 due to dependency
     targets: &targets
-      - fedora-all-x86_64
-      - fedora-all-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-development-x86_64
+      - fedora-development-aarch64
   - &tests
     job: tests
     trigger: release


### PR DESCRIPTION
Closes #687

A few maintenance tasks:
- Fix rpmlint failures
- Drop F38 early from the CI
- Simplified the yaml file and maintenance using anchors
- Changed the base package to be `arch`-ful. This guarantees the build and tests are done on all architectures downstream

Will probably patch those for `scikit-build` as well.