### PR TITLE
tests: fix setuptools on Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,11 @@ docs = [
     "pathspec >=0.10.1",
     "pyproject-metadata >=0.5",
     "setuptools",
-    "sphinx",
+    "sphinx >=7.0",
+    "sphinx-autodoc-typehints",
     "sphinx-copybutton",
     "sphinx-inline-tabs",
     "sphinx-jsonschema",
-    "sphinx-autodoc-typehints",
 ]
 
 [project.urls]

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -277,6 +277,8 @@ class SettingsReader:
         verify_conf: bool = True,
         env: Mapping[str, str] | None = None,
     ) -> None:
+        self.state = state
+
         pyproject = copy.deepcopy(pyproject)
         process_overides(pyproject.get("tool", {}).get("scikit-build", {}), state, env)
         toml_srcs = [TOMLSource("tool", "scikit-build", settings=pyproject)]

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -30,13 +30,14 @@ def test_pep517_sdist():
     out = build_sdist("dist")
 
     (sdist,) = dist.iterdir()
-    assert sdist.name == "cmake-example-0.0.1.tar.gz"
+    assert sdist.name in {"cmake-example-0.0.1.tar.gz", "cmake_example-0.0.1.tar.gz"}
     assert sdist == dist / out
+    cmake_example = sdist.name[:13]
 
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())
         assert file_names == {
-            f"cmake-example-0.0.1/{x}"
+            f"{cmake_example}-0.0.1/{x}"
             for x in (
                 # TODO: "CMakeLists.txt",
                 "PKG-INFO",
@@ -54,8 +55,8 @@ def test_pep517_sdist():
                 "LICENSE",
                 # TODO: "src/main.cpp",
             )
-        } | {"cmake-example-0.0.1"}
-        pkg_info = f.extractfile("cmake-example-0.0.1/PKG-INFO")
+        } | {f"{cmake_example}-0.0.1"}
+        pkg_info = f.extractfile(f"{cmake_example}-0.0.1/PKG-INFO")
         assert pkg_info
         pkg_info_contents = set(pkg_info.read().decode().strip().splitlines())
         assert metadata_set <= pkg_info_contents


### PR DESCRIPTION
This started happening recently, so protect ourselves from normalization here.
