### PR TITLE
refactor: metadata is part of the build backend

### DIFF
--- a/docs/api/scikit_build_core.build.rst
+++ b/docs/api/scikit_build_core.build.rst
@@ -17,6 +17,14 @@ scikit\_build\_core.build.generate module
    :undoc-members:
    :show-inheritance:
 
+scikit\_build\_core.build.metadata module
+-----------------------------------------
+
+.. automodule:: scikit_build_core.build.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 scikit\_build\_core.build.sdist module
 --------------------------------------
 

--- a/docs/api/scikit_build_core.settings.rst
+++ b/docs/api/scikit_build_core.settings.rst
@@ -25,14 +25,6 @@ scikit\_build\_core.settings.json\_schema module
    :undoc-members:
    :show-inheritance:
 
-scikit\_build\_core.settings.metadata module
---------------------------------------------
-
-.. automodule:: scikit_build_core.settings.metadata
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 scikit\_build\_core.settings.skbuild\_docs module
 -------------------------------------------------
 

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from packaging.version import Version
 from pyproject_metadata import StandardMetadata
 
-from ._load_provider import load_dynamic_metadata
+from ..settings._load_provider import load_dynamic_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -15,11 +15,11 @@ from packaging.version import Version
 from .. import __version__
 from .._compat import tomllib
 from .._logging import rich_print
-from ..settings.metadata import get_standard_metadata
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
 from ._init import setup_logging
 from .generate import generate_file_contents
+from .metadata import get_standard_metadata
 from .wheel import _build_wheel_impl
 
 __all__ = ["build_sdist"]

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -17,7 +17,6 @@ from .._shutil import fix_win_37_all_permissions
 from ..builder.builder import Builder, archs_to_tags, get_archs
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMaker
-from ..settings.metadata import get_standard_metadata
 from ..settings.skbuild_read_settings import SettingsReader
 from ._editable import editable_redirect, libdir_to_installed, mapping_to_modules
 from ._init import setup_logging
@@ -27,6 +26,7 @@ from ._pathutil import (
 from ._scripts import process_script_dir
 from ._wheelfile import WheelMetadata, WheelWriter
 from .generate import generate_file_contents
+from .metadata import get_standard_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -15,9 +15,9 @@ from packaging.version import Version
 
 from scikit_build_core._compat import tomllib
 from scikit_build_core.build import build_wheel
+from scikit_build_core.build.metadata import get_standard_metadata
 from scikit_build_core.builder.get_requires import GetRequires
 from scikit_build_core.metadata import regex
-from scikit_build_core.settings.metadata import get_standard_metadata
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
 


### PR DESCRIPTION
Didn't notice this before, but this should be part of `build`.

