### PR TITLE
fix: always require pathspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,7 @@ version = "0.0.1"
 ```
 
 You can (and should) specify the rest of the entries in `project`, but these are
-the minimum to get started. You can also `scikit-build-core[pyproject]` to
-pre-load some dependencies if you want; in some cases this might be marginally
-faster.
+the minimum to get started.
 
 An example `CMakeLists.txt`:
 

--- a/docs/examples/downstream/nanobind_example/CMakeLists.txt
+++ b/docs/examples/downstream/nanobind_example/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-   $ pip install nanobind scikit-build-core[pyproject]
+   $ pip install nanobind scikit-build-core
    $ pip install --no-build-isolation -ve .
   =====================================================================
   You may optionally add -Ceditable.rebuild=true to auto-rebuild when

--- a/noxfile.py
+++ b/noxfile.py
@@ -134,7 +134,7 @@ def docs(session: nox.Session) -> None:
 
     serve = args.builder == "html" and session.interactive
     extra_installs = ["sphinx-autobuild"] if serve else []
-    session.install("-e.[docs,pyproject]", *extra_installs)
+    session.install("-e.[docs]", *extra_installs)
 
     session.chdir("docs")
 
@@ -229,7 +229,7 @@ def downstream(session: nox.Session) -> None:
     proj_dir = tmp_dir / "_".join(args.project.split("/"))
 
     session.install("build", "hatch-vcs", "hatchling")
-    session.install(".[pyproject]", "--no-build-isolation")
+    session.install(".", "--no-build-isolation")
 
     if proj_dir.is_dir():
         session.chdir(proj_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
 [project.optional-dependencies]
 pyproject = [
     "pathspec >=0.10.1",
-    "pyproject-metadata >=0.6.1",
 ]
 test = [
     "build >=0.8",
@@ -55,7 +54,6 @@ test = [
     "pathspec >=0.10.1",
     "pip >=22",
     "pybind11 >=2.11",
-    "pyproject-metadata >=0.5",
     "pytest >=7.0",  # 7.2+ recommended for better tracebacks with ExceptionGroup
     "pytest-subprocess >=1.5",
     'setuptools >=43; python_version<"3.9"',
@@ -97,7 +95,6 @@ docs = [
     "hatchling",
     "myst-parser >=0.13",
     "pathspec >=0.10.1",
-    "pyproject-metadata >=0.5",
     "setuptools",
     "sphinx >=7.0",
     "sphinx-autodoc-typehints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "importlib-metadata >=4.13; python_version<'3.8'",
     "importlib-resources >=1.3; python_version<'3.9'",
     "packaging >=21.3",
+    "pathspec >=0.10.1",
     "tomli >=1.2.2; python_version<'3.11'",
     "typing-extensions >=3.10.0; python_version<'3.9'",
 ]
@@ -46,12 +47,10 @@ dependencies = [
 
 [project.optional-dependencies]
 pyproject = [
-    "pathspec >=0.10.1",
 ]
 test = [
     "build >=0.8",
     "cattrs >=22.2.0",
-    "pathspec >=0.10.1",
     "pip >=22",
     "pybind11 >=2.11",
     "pytest >=7.0",  # 7.2+ recommended for better tracebacks with ExceptionGroup
@@ -94,7 +93,6 @@ docs = [
     "furo",
     "hatchling",
     "myst-parser >=0.13",
-    "pathspec >=0.10.1",
     "setuptools",
     "sphinx >=7.0",
     "sphinx-autodoc-typehints",

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -109,7 +109,6 @@ def get_requires_for_build_sdist(
     )
 
     return [
-        "pathspec",
         *cmake_requires,
         *requires.dynamic_metadata(),
     ]
@@ -128,7 +127,6 @@ def get_requires_for_build_wheel(
     )
 
     return [
-        "pathspec",
         *cmake_requires,
         *requires.dynamic_metadata(),
     ]
@@ -147,7 +145,6 @@ def get_requires_for_build_editable(
     )
 
     return [
-        "pathspec",
         *cmake_requires,
         *requires.dynamic_metadata(),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
             "wheel",
             "--wheel-dir",
             str(wheelhouse),
-            f"{BASE}[pyproject]",
+            f"{BASE}",
         ],
         check=True,
     )
@@ -208,10 +208,10 @@ def package_simple_pyproject_ext(
 ) -> PackageInfo:
     package = PackageInfo(
         "simple_pyproject_ext",
-        "6c5bb5f1b6c44f3aab37fc8f768004f644c24001ad0304759a69b754ca6ad46d",
-        "ba13e4195ae6333459412bc802ba8c02c231cf1c5ee143f6a3392786d80a49b4",
-        "f1a6050eae910de7cd86830ba97af5e74ff953f9acc2adab47aa9cdf2a3eca91",
-        "b861db81fd1de6dee4a0d6574af27af54424fbccce12b018644d1db136f218ac",
+        "5544d96810ce60ac40baf28cf8caf2e1e7e1fa7439b283d3fb52cdc1f87f12ac",
+        "aaa15c185dc3fbc301dc2fca937cc935442c38e55bc400fbefd424bd6ce92adb",
+        "ee3a564a37c42df3abdcee3862175baceeb6f6eff0b29931681b424ec5d96067",
+        "4c1d402621e7f00fce4ce5afdb73a9ba4cc25cd4bb57619113432841f779dd68",
     )
     process_package(package, tmp_path, monkeypatch)
     return package

--- a/tests/packages/sdist_config/pyproject.toml
+++ b/tests/packages/sdist_config/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]"]
+requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/tests/packages/simple_purelib_package/pyproject.toml
+++ b/tests/packages/simple_purelib_package/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]"]
+requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/tests/packages/simple_pyproject_ext/pyproject.toml
+++ b/tests/packages/simple_pyproject_ext/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core[pyproject]",
+    "scikit_build_core",
     "pybind11",
 ]
 build-backend = "scikit_build_core.build"

--- a/tests/packages/simple_pyproject_source_dir/pyproject.toml
+++ b/tests/packages/simple_pyproject_source_dir/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core[pyproject]",
+    "scikit_build_core",
     "pybind11",
 ]
 build-backend = "scikit_build_core.build"

--- a/tests/test_custom_modules.py
+++ b/tests/test_custom_modules.py
@@ -10,7 +10,7 @@ PROJECT_DIR = DIR / "packages" / "custom_cmake"
 
 
 def test_ep(isolated):
-    isolated.install("hatchling", "scikit-build-core[pyproject]")
+    isolated.install("hatchling", "scikit-build-core")
     isolated.install(PROJECT_DIR / "extern", isolated=False)
     isolated.install(PROJECT_DIR, "-v", isolated=False)
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -28,7 +28,7 @@ def test_navigate_editable(isolated, isolate, package):
     isolate_args = ["--no-build-isolation"] if not isolate else []
     isolated.install("pip>=23")
     if not isolate:
-        isolated.install("scikit-build-core[pyproject]")
+        isolated.install("scikit-build-core")
 
     if package:
         init_py = Path("python/shared_pkg/data/__init__.py")
@@ -73,7 +73,7 @@ def test_cython_pxd(monkeypatch, tmp_path, editable, editable_mode, isolated):
     tmp_path1.mkdir()
     process_package(package1, tmp_path1, monkeypatch)
 
-    isolated.install("pip>23", "cython", "scikit-build-core[pyproject]")
+    isolated.install("pip>23", "cython", "scikit-build-core")
 
     isolated.install(
         "-v",

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -116,11 +116,11 @@ def test_get_requires_for_build_sdist(fp):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    assert set(get_requires_for_build_sdist({})) == {"pathspec"}
+    assert set(get_requires_for_build_sdist({})) == set()
 
 
 def test_get_requires_for_build_sdist_cmake(fp):
-    expected = {"pathspec", "cmake>=3.15", *ninja}
+    expected = {"cmake>=3.15", *ninja}
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
@@ -129,7 +129,7 @@ def test_get_requires_for_build_sdist_cmake(fp):
 
 
 def test_get_requires_for_build_wheel(fp):
-    expected = {"pathspec", "cmake>=3.15", *ninja}
+    expected = {"cmake>=3.15", *ninja}
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
@@ -138,16 +138,15 @@ def test_get_requires_for_build_wheel(fp):
 
 
 def test_get_requires_for_build_wheel_pure(fp):
-    expected = {"pathspec"}
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    assert set(get_requires_for_build_wheel({"wheel.cmake": "False"})) == expected
+    assert set(get_requires_for_build_wheel({"wheel.cmake": "False"})) == set()
 
 
 def test_get_requires_for_build_editable(fp):
-    expected = {"pathspec", "cmake>=3.15", *ninja}
+    expected = {"cmake>=3.15", *ninja}
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
@@ -156,9 +155,8 @@ def test_get_requires_for_build_editable(fp):
 
 
 def test_get_requires_for_build_editable_pure(fp):
-    expected = {"pathspec"}
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == expected
+    assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == set()

--- a/tests/test_pyproject_pep660.py
+++ b/tests/test_pyproject_pep660.py
@@ -59,7 +59,7 @@ def test_pep660_pip_isolated(isolated, isolate, editable_mode: str):
     isolate_args = ["--no-build-isolation"] if not isolate else []
     isolated.install("pip>=23")
     if not isolate:
-        isolated.install("scikit-build-core[pyproject]")
+        isolated.install("scikit-build-core")
 
     build_dir = "" if editable_mode == "inplace" else "build/{wheel_tag}"
 


### PR DESCRIPTION
This adds `pathspec` as a required dependency. It makes the native backend easier to use, and is already there for hatchling, so it's really only an extra dependency for custom plugins and setuptools, so I think it's a valid tradeoff now that pyproject-metadata is vendored. 

Closes #280.

- **chore: remove a few unused pyproject-metadata's**
- **fix: always require pathspec**
