### PR TITLE
ci: use macos-13 and 14 explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "pypy-3.9", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest, macos-13]
         cmake-version: ["3.15.x"]
 
         include:
@@ -74,8 +74,11 @@ jobs:
             runs-on: ubuntu-latest
             cmake-version: "3.20.x"
           - python-version: "3.9"
-            runs-on: macos-latest
+            runs-on: macos-13
             cmake-version: "3.18.x"
+          - python-version: "3.12"
+            runs-on: macos-14
+            cmake-version: "3.29.x"
           - python-version: "3.10"
             runs-on: ubuntu-latest
             cmake-version: "3.22.x"
@@ -139,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.11"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -287,7 +290,7 @@ jobs:
 
       - uses: yezz123/setup-uv@v4
 
-      - uses: wntrblm/nox@2024.03.02
+      - uses: wntrblm/nox@2024.04.15
         with:
           python-versions: "3.11"
 


### PR DESCRIPTION
No Python 3.9 and below on macos-14, and min tests don't work on Apple Silicon either.
