### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, windows-latest]
+        runs-on: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos