### PR TITLE
fix: don't generate entrypoints.txt if none set

### DIFF
--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -135,10 +135,15 @@ class WheelWriter:
             msg = "Cannot have METADATA, WHEEL, RECORD, or entry_points.txt in metadata_dir"
             raise ValueError(msg)
 
+        entry_points_txt = entry_points.getvalue().encode("utf-8")
+        entry_points_dict = (
+            {"entry_points.txt": entry_points_txt} if entry_points_txt else {}
+        )
+
         return {
             "METADATA": bytes(rfc822),
             "WHEEL": self.wheel_metadata.as_bytes(),
-            "entry_points.txt": entry_points.getvalue().encode("utf-8"),
+            **entry_points_dict,
             **extra_metadata,
         }
 

--- a/tests/test_prepare_metadata.py
+++ b/tests/test_prepare_metadata.py
@@ -42,7 +42,7 @@ def test_prepare_metadata_for_build(fp, editable):
         == metadata.strip()
     )
 
-    assert len(list(Path("simple/simplest-0.0.1.dist-info").iterdir())) == 3
+    assert len(list(Path("simple/simplest-0.0.1.dist-info").iterdir())) == 2
     assert len(list(Path("simple").iterdir())) == 1
 
 

--- a/tests/test_simplest_c.py
+++ b/tests/test_simplest_c.py
@@ -147,7 +147,6 @@ def test_pep517_wheel_incexl(tmp_path, monkeypatch, virtualenv):
         "RECORD",
         "METADATA",
         "WHEEL",
-        "entry_points.txt",
     } == metadata_items
 
     filtered_pkg = {x for x in simplest_pkg if not x.startswith("_module")}

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -48,7 +48,6 @@ def test_wheel_writer_simple(tmp_path, monkeypatch):
     assert dist_info == {
         "METADATA": b"Metadata-Version: 2.1\nName: something\nVersion: 1.2.3\n",
         "WHEEL": b"Wheel-Version: 1.0\nGenerator: scikit-build-core 1.2.3\nRoot-Is-Purelib: false\nTag: py3-none-any\n\n",
-        "entry_points.txt": b"",
     }
 
     platlib = tmp_path / "platlib"
@@ -62,16 +61,11 @@ def test_wheel_writer_simple(tmp_path, monkeypatch):
         assert zf.namelist() == [
             "something-1.2.3.dist-info/METADATA",
             "something-1.2.3.dist-info/WHEEL",
-            "something-1.2.3.dist-info/entry_points.txt",
             "something-1.2.3.dist-info/RECORD",
         ]
 
         assert zf.read("something-1.2.3.dist-info/METADATA") == dist_info["METADATA"]
         assert zf.read("something-1.2.3.dist-info/WHEEL") == dist_info["WHEEL"]
-        assert (
-            zf.read("something-1.2.3.dist-info/entry_points.txt")
-            == dist_info["entry_points.txt"]
-        )
 
         for info in zf.infolist():
             assert info.external_attr == (0o664 | stat.S_IFREG) << 16


### PR DESCRIPTION
Not needed unless entrypoints is non-empty.
