### PR TITLE
chore: pin pylint for now

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,8 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install("-e.[dev,test,test-meta]", "pylint")
+    session.install("-e.[dev,test,test-meta]", "pylint==3.1.*")
+    session.run("pylint", "--version")
     session.run("pylint", "scikit_build_core", *session.posargs)
 
 


### PR DESCRIPTION
Pylint 3.2.0 reports an error in a .pyi file that 3.1.* didn't; we are ignoring pyi files since 3.0 since pylint doesn't handle them, but pylint is now ignoring the ignore. https://github.com/pylint-dev/pylint/issues/9623 (See boost-histogram if you want see how many errors pylint can spew about pyi files! We just have one.)
