### PR TITLE
Strip whitespace around generator so that it's passed through correctly

### DIFF
--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -195,7 +195,7 @@ class CMaker:
         """
         generators = [g for g in args if g.startswith("-G")]
         if generators:
-            return generators[-1][2:]
+            return generators[-1][2:].strip()
         return self.env.get("CMAKE_GENERATOR", None)
 
     def configure(


### PR DESCRIPTION
It looks like without this change, the leading whitespace with something like `-G 'Unix Makefiles'` being converted to ` 'Unix Makefiles'` makes CMake misinterpret this and not realize a generator is being provided.