### PR TITLE
[Do not merge] Try python 3.13 on fedora

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -11,6 +11,7 @@ Source:         %{pypi_source scikit_build_core}
 
 BuildRequires:  python3-devel
 # Testing dependences
+BuildRequires:  python3-freethreading
 BuildRequires:  cmake
 BuildRequires:  ninja-build
 BuildRequires:  gcc

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,11 +50,17 @@ jobs:
     branch: main
   - <<: *copr_build
     trigger: pull_request
-    project: scikit-build-core
+    project: scikit-build-core-python-3.13
+    additional_repos:
+      - copr://@python/python3.13
+    targets:
+      - fedora-rawhide-x86_64
     update_release: true
     release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
   - <<: *tests
     trigger: pull_request
+    targets:
+      - fedora-rawhide-x86_64
   - job: propose_downstream
     trigger: release
     dist_git_branches:


### PR DESCRIPTION
This is just to track the status of python 3.13. @henryiii I believe you have some additional features like freethreading from there that you want tested?

Blocked by:
- ~~pip [24.0](https://copr.fedorainfracloud.org/coprs/g/python/python3.13/package/python-pip/) < 24.1~b1~~ Submitted a build from [my fork](https://src.fedoraproject.org/fork/lecris/rpms/python-pip/tree/pip-24.1)
- ~~cattrs~~ -> ~~[immutables](https://bugzilla.redhat.com/show_bug.cgi?id=2246142)~~, ~~[sphinx](https://bugzilla.redhat.com/show_bug.cgi?id=2271405)~~