### PR TITLE
ci: Disable rpminspect on rawhide

### DIFF
--- a/.distro/plans/rpminspect.fmf
+++ b/.distro/plans/rpminspect.fmf
@@ -8,3 +8,7 @@ environment:
   # This happens when the released version already contains the package version:
   # https://github.com/packit/tmt-plans/issues/13
   RPMINSPECT_EXCLUDE: metadata,upstream
+adjust:
+  when: distro == fedora-rawhide
+  because: Recently rpminspect fails to get the distro-tag
+  enabled: false

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,14 +33,9 @@ jobs:
     trigger: release
     owner: "@scikit-build"
     project: release
-    # Drop F38 due to dependency
     targets: &targets
-      - fedora-latest-x86_64
-      - fedora-latest-aarch64
-      - fedora-latest-stable-x86_64
-      - fedora-latest-stable-aarch64
-      - fedora-development-x86_64
-      - fedora-development-aarch64
+      - fedora-all-x86_64
+      - fedora-all-aarch64
   - &tests
     job: tests
     trigger: release


### PR DESCRIPTION
Didn't get to investigate why it is failing, but can disable it for a while to make the CI cleaner