### PR TITLE
fix: improve error message when metadata.version.provider not set

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -142,7 +142,7 @@ def _build_wheel_impl(
     metadata = get_standard_metadata(pyproject, settings)
 
     if metadata.version is None:
-        msg = "project.version is not statically specified, must be present currently"
+        msg = "project.version is not specified, must be statically present or tool.scikit-build metadata.version.provider configured when dynamic"
         raise AssertionError(msg)
 
     normalized_name = metadata.name.replace("-", "_").replace(".", "_")


### PR DESCRIPTION
When using setuptools_scm to obtain the version dynamic and

```toml
[tool.scikit-build]
metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
```

is not set in pyproject.toml, the error message suggested that only a
static version is supported. Modify the error message to indicate both
are supported and suggest a fix in the dynamic case.
