### PR TITLE
fix: logger set to DEBUG

### DIFF
--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -14,10 +14,8 @@ def __dir__() -> list[str]:
     return __all__
 
 
-raw_logger = logging.getLogger(
-    "scikit_build_core"
-)  # TODO: maybe should be scikit-build?
-raw_logger.setLevel(logging.DEBUG)  # TODO: configure
+# TODO: maybe should be scikit-build?
+raw_logger = logging.getLogger("scikit_build_core")
 
 
 class FStringMessage:

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -14,7 +14,6 @@ def __dir__() -> list[str]:
     return __all__
 
 
-# TODO: maybe should be scikit-build?
 raw_logger = logging.getLogger("scikit_build_core")
 
 

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -7,7 +7,7 @@ import re
 import sys
 from typing import Any
 
-__all__ = ["ScikitBuildLogger", "logger", "raw_logger", "rich_print"]
+__all__ = ["ScikitBuildLogger", "logger", "raw_logger", "rich_print", "LEVEL_VALUE"]
 
 
 def __dir__() -> list[str]:
@@ -15,6 +15,16 @@ def __dir__() -> list[str]:
 
 
 raw_logger = logging.getLogger("scikit_build_core")
+
+
+LEVEL_VALUE = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
 
 
 class FStringMessage:

--- a/src/scikit_build_core/build/_init.py
+++ b/src/scikit_build_core/build/_init.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 
-from .._logging import logger
+from .._logging import LEVEL_VALUE, logger
 
 __all__ = ["setup_logging"]
 
@@ -14,14 +14,7 @@ def __dir__() -> list[str]:
 
 @functools.lru_cache(1)
 def setup_logging(log_level: str) -> None:
-    level_value = {
-        "CRITICAL": logging.CRITICAL,
-        "ERROR": logging.ERROR,
-        "WARNING": logging.WARNING,
-        "INFO": logging.INFO,
-        "DEBUG": logging.DEBUG,
-        "NOTSET": logging.NOTSET,
-    }[log_level]
+    level_value = LEVEL_VALUE[log_level]
 
     ch = logging.StreamHandler()
     ch.setLevel(level_value)

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import shutil
 import sys
 from pathlib import Path
@@ -10,7 +9,7 @@ import setuptools
 import setuptools.errors
 from packaging.version import Version
 
-from .._logging import raw_logger
+from .._logging import LEVEL_VALUE, raw_logger
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
 from ..cmake import CMake, CMaker
@@ -215,14 +214,7 @@ def _cmake_extension(dist: Distribution) -> None:
 
     # Setup logging
     settings = SettingsReader.from_file("pyproject.toml").settings
-    level_value = {
-        "CRITICAL": logging.CRITICAL,
-        "ERROR": logging.ERROR,
-        "WARNING": logging.WARNING,
-        "INFO": logging.INFO,
-        "DEBUG": logging.DEBUG,
-        "NOTSET": logging.NOTSET,
-    }[settings.logging.level]
+    level_value = LEVEL_VALUE[settings.logging.level]
     raw_logger.setLevel(level_value)
 
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import logging
 import shutil
 import sys
@@ -33,11 +32,6 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
-
-
-@functools.lru_cache(maxsize=None)
-def _get_settings() -> ScikitBuildSettings:
-    return SettingsReader.from_file("pyproject.toml").settings
 
 
 def _validate_settings(settings: ScikitBuildSettings) -> None:
@@ -101,7 +95,7 @@ class BuildCMake(setuptools.Command):
         assert self.build_temp is not None
         assert self.plat_name is not None
 
-        settings = _get_settings()
+        settings = SettingsReader.from_file("pyproject.toml").settings
         _validate_settings(settings)
 
         build_tmp_folder = Path(self.build_temp)
@@ -220,7 +214,7 @@ def _cmake_extension(dist: Distribution) -> None:
         dist.ext_modules = getattr(dist, "ext_modules", []) or EvilList()
 
     # Setup logging
-    settings = _get_settings()
+    settings = SettingsReader.from_file("pyproject.toml").settings
     level_value = {
         "CRITICAL": logging.CRITICAL,
         "ERROR": logging.ERROR,


### PR DESCRIPTION
Causes too much logging in test output if user sets it higher than DEBUG. I think this was just to help the sdtputools backend.