### PR TITLE
fix: empty build arguments in multi-target build

### DIFF
--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -238,7 +238,7 @@ class CMaker:
         targets: Sequence[str] = (),
         verbose: bool = False,
     ) -> None:
-        local_args = self._compute_build_args(verbose=verbose)
+        local_args = list(self._compute_build_args(verbose=verbose))
         if not targets:
             self._build(*local_args, *build_args)
             return


### PR DESCRIPTION
This commit fixes an issue when building a package with multiple targets.

**[Bug]** To give an example:

```toml
cmake.targets = ["target_A", "target_B", "target_C"]
```

In this case, scikit-build-core generates a sequence of build commands:

```bash
cmake --target target_A --config Release
cmake --target target_B
cmake --target target_C
```

Note that `--config Release` is lost since the second target.

**[Cause]** This originates from the case where `local_args` in `CMaker.build` in `cmake.py` is a generator rather than a list/tuple, and it becomes empty after being passed to `self._build` in [line 247](https://github.com/scikit-build/scikit-build-core/blob/83afeb2cad1f9f0168d92df6b9b0f9d43abd53a4/src/scikit_build_core/cmake.py#L247).

**[Fix]** This PR proactively converts `local_args` to a Python list before feeding it to `self._build`.