### PR TITLE
docs: hide deprecated options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,6 @@ print("```\n")
 
 ```toml
 [tool.scikit-build]
-# DEPRECATED in 0.8; use version instead.
-cmake.minimum-version = ""
-
 # The versions of CMake to allow. If CMake is not present on the system or does
 # not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
@@ -181,9 +178,6 @@ cmake.source-dir = "."
 # The build targets to use when building the project. Empty builds the default
 # target.
 cmake.targets = []
-
-# DEPRECATED in 0.8; use version instead.
-ninja.minimum-version = ""
 
 # The versions of Ninja to allow. If Ninja is not present on the system or does
 # not pass this specifier, it will be downloaded via PyPI if possible. An empty

--- a/src/scikit_build_core/settings/skbuild_docs.py
+++ b/src/scikit_build_core/settings/skbuild_docs.py
@@ -13,12 +13,14 @@ def __dir__() -> list[str]:
 
 version = ".".join(__version__.split(".")[:2])
 
+INV = {"cmake.minimum-version", "ninja.minimum-version"}
+
 
 def mk_skbuild_docs() -> str:
     """
     Makes documentation for the skbuild model.
     """
-    items = list(mk_docs(ScikitBuildSettings))
+    items = [x for x in mk_docs(ScikitBuildSettings) if x.name not in INV]
     for item in items:
         if item.name == "minimum-version":
             item.default = f'"{version}"  # current version'


### PR DESCRIPTION
Just kept them around for a bit.
