### PR TITLE
docs: use modern cmake/ninja version setting in Fortran example

### DIFF
--- a/docs/examples/getting_started/fortran/pyproject.toml
+++ b/docs/examples/getting_started/fortran/pyproject.toml
@@ -8,5 +8,5 @@ version = "0.0.1"
 dependencies = ["numpy"]
 
 [tool.scikit-build]
-ninja.minimum-version = "1.10"
-cmake.minimum-version = "3.17.2"
+ninja.version = ">=1.10"
+cmake.version = ">=3.17.2"


### PR DESCRIPTION
Fixing the example.
