### PR TITLE
improve version regex to capture typed version attributes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,7 +564,7 @@ input = "src/mypackage/__init__.py"
 You can set a custom regex with `regex=`; use `(?P<value>...)` to capture the
 value you want to use. By default when targeting version, you get a reasonable
 regex for python files,
-`'(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'`.
+`'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'`.
 
 ```{versionadded} 0.5
 

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -37,7 +37,7 @@ def dynamic_metadata(
 
     input_filename = settings["input"]
     regex = settings.get(
-        "regex", r'(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
+        "regex", r'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'
     )
 
     with Path(input_filename).open(encoding="utf-8") as f:

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -37,7 +37,8 @@ def dynamic_metadata(
 
     input_filename = settings["input"]
     regex = settings.get(
-        "regex", r'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'
+        "regex",
+        r'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2',
     )
 
     with Path(input_filename).open(encoding="utf-8") as f:


### PR DESCRIPTION
This allows capturing the version when typing the version attribute using `__version__: str = "1.0.1"` as well.