### PR TITLE
feat: support multipart regex

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -561,10 +561,23 @@ provider = "scikit_build_core.metadata.regex"
 input = "src/mypackage/__init__.py"
 ```
 
-You can set a custom regex with `regex=`; use `(?P<value>...)` to capture the
-value you want to use. By default when targeting version, you get a reasonable
-regex for python files,
+You can set a custom regex with `regex=`. By default when targeting version, you
+get a reasonable regex for python files,
 `'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'`.
+You can set `result` to a format string to process the matches; the default is
+`"{value}"`. A more complex example:
+
+```toml
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "src/mypackage/version.hpp"
+regex = '''(?sx)
+\#define \w+ VERSION_MAJOR \w+ (?P<major>\d+) .*?
+\#define \w+ VERSION_MINOR \w+ (?P<minor>\d+) .*?
+\#define \w+ VERSION_PATCH \w+ (?P<patch>\d+)
+'''
+result = "{major}.{minor}.{patch}"
+```
 
 ```{versionadded} 0.5
 

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -14,6 +14,9 @@ def __dir__() -> list[str]:
     return __all__
 
 
+KEYS = {"input", "regex", "result"}
+
+
 def dynamic_metadata(
     field: str,
     settings: Mapping[str, Any],
@@ -22,8 +25,8 @@ def dynamic_metadata(
     if field not in {"version", "description", "requires-python"}:
         msg = "Only string fields supported by this plugin"
         raise RuntimeError(msg)
-    if settings.keys() > {"input", "regex"}:
-        msg = "Only 'input' and 'regex' settings allowed by this plugin"
+    if settings.keys() > KEYS:
+        msg = f"Only {KEYS} settings allowed by this plugin"
         raise RuntimeError(msg)
     if "input" not in settings:
         msg = "Must contain the 'input' setting to perform a regex on"
@@ -31,15 +34,18 @@ def dynamic_metadata(
     if field != "version" and "regex" not in settings:
         msg = "Must contain the 'regex' setting if not getting version"
         raise RuntimeError(msg)
-    if not all(isinstance(x, str) for x in settings.values()):
-        msg = "Must set 'input' and/or 'regex' to strings"
-        raise RuntimeError(msg)
+    for key in KEYS:
+        if key in settings and not isinstance(settings[key], str):
+            msg = f"Setting {key!r} must be a string"
+            raise RuntimeError(msg)
 
     input_filename = settings["input"]
     regex = settings.get(
         "regex",
         r'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2',
     )
+    result = settings.get("result", "{value}")
+    assert isinstance(result, str)
 
     with Path(input_filename).open(encoding="utf-8") as f:
         match = re.search(regex, f.read(), re.MULTILINE)
@@ -48,4 +54,4 @@ def dynamic_metadata(
         msg = f"Couldn't find {regex!r} in {input_filename}"
         raise RuntimeError(msg)
 
-    return match.group("value")
+    return result.format(*match.groups(), **match.groupdict())


### PR DESCRIPTION
First 3 lines of #765. Makes `"{value}"` configurable.