### PR TITLE
feat: add fail setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ minimum-version = "0.9"  # current version
 # The build directory. Defaults to a temporary directory, but can be set.
 build-dir = ""
 
+# Immediately fail the build. This is only useful in overrides.
+fail = false
+
 ```
 
 <!-- [[[end]]] -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -708,6 +708,10 @@ only be used if you enable them:
 experimental = true
 ```
 
+You can also fail the build with `fail = true`. This is useful with overrides if
+you want to make a specific configuration fail. If this is set, extra
+dependencies like `"cmake"` will not be requested.
+
 ## Overrides
 
 The overrides system allows you to customize for a wide variety of situations.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,9 @@
+"""
+Scikit-build-core's nox configuration.
+
+Use `-t gen` to run all the generation jobs.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -80,7 +86,7 @@ def _run_tests(
     session.run("pytest", *run_args, *posargs, env=env)
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, tags=["gen"])
 def generate_schema(session: nox.Session) -> None:
     """
     (Re)generate src/scikit_build_core/resources/scikit-build.schema.json from model.
@@ -102,7 +108,7 @@ def tests(session: nox.Session) -> None:
     _run_tests(session, extras=["test-meta,test-numpy,test-schema,test-hatchling"])
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, tags=["gen"])
 def readme(session: nox.Session) -> None:
     """
     Update the readme with cog. Pass --check to check instead.
@@ -160,7 +166,7 @@ def docs(session: nox.Session) -> None:
         session.run("sphinx-build", "--keep-going", *shared_args)
 
 
-@nox.session
+@nox.session(tags=["gen"])
 def build_api_docs(session: nox.Session) -> None:
     """
     Build (regenerate) API docs.

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -33,6 +33,7 @@ def entry_points(*, group: str) -> EntryPoints:
     if sys.version_info < (3, 8) and hasattr(epg, "select"):
         return epg.select(group=group)  # type: ignore[no-any-return, no-untyped-call]
 
+    # pylint: disable-next=no-member
     return epg.get(group, [])
 
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -15,7 +15,7 @@ from packaging.utils import canonicalize_name
 from .. import __version__
 from .._compat import tomllib
 from .._compat.typing import Literal, assert_never
-from .._logging import LEVEL_VALUE, logger, rich_print
+from .._logging import LEVEL_VALUE, logger, rich_error, rich_print
 from .._shutil import fix_win_37_all_permissions
 from ..builder.builder import Builder, archs_to_tags, get_archs
 from ..builder.wheel_tag import WheelTag
@@ -144,6 +144,9 @@ def _build_wheel_impl(
     setup_logging(settings_reader.settings.logging.level)
 
     settings_reader.validate_may_exit()
+
+    if settings_reader.settings.fail:
+        rich_error("scikit-build-core's fail setting was enabled. Exiting immediately.")
 
     # Warn if cmake or ninja is in build-system.requires
     requirements = [

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -64,7 +64,7 @@ class GetRequires:
         return cls(_load_scikit_build_settings(config_settings))
 
     def cmake(self) -> Generator[str, None, None]:
-        if os.environ.get("CMAKE_EXECUTABLE", ""):
+        if self.settings.fail or os.environ.get("CMAKE_EXECUTABLE", ""):
             return
 
         cmake_verset = self.settings.cmake.version
@@ -83,8 +83,10 @@ class GetRequires:
 
     def ninja(self) -> Generator[str, None, None]:
         # On Windows MSVC, Ninja is not default
-        if sysconfig.get_platform().startswith("win") and "Ninja" not in os.environ.get(
-            "CMAKE_GENERATOR", ""
+        if (
+            self.settings.fail
+            or sysconfig.get_platform().startswith("win")
+            and "Ninja" not in os.environ.get("CMAKE_GENERATOR", "")
         ):
             return
 
@@ -121,6 +123,9 @@ class GetRequires:
         yield f"ninja{ninja_verset}"
 
     def dynamic_metadata(self) -> Generator[str, None, None]:
+        if self.settings.fail:
+            return
+
         for dynamic_metadata in self.settings.metadata.values():
             if "provider" in dynamic_metadata:
                 config = dynamic_metadata.copy()

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -431,6 +431,11 @@
       "default": "",
       "description": "The build directory. Defaults to a temporary directory, but can be set."
     },
+    "fail": {
+      "type": "boolean",
+      "default": false,
+      "description": "Immediately fail the build. This is only useful in overrides."
+    },
     "overrides": {
       "type": "array",
       "description": "A list of overrides to apply to the settings, based on the `if` selector.",
@@ -574,6 +579,9 @@
           },
           "build-dir": {
             "$ref": "#/properties/build-dir"
+          },
+          "fail": {
+            "$ref": "#/properties/fail"
           }
         }
       }

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -331,3 +331,8 @@ class ScikitBuildSettings:
     """
     The build directory. Defaults to a temporary directory, but can be set.
     """
+
+    fail: bool = False
+    """
+    Immediately fail the build. This is only useful in overrides.
+    """

--- a/tests/packages/broken_fallback/pyproject.toml
+++ b/tests/packages/broken_fallback/pyproject.toml
@@ -12,3 +12,7 @@ wheel.license-files = []
 [[tool.scikit-build.overrides]]
 if.failed = true
 wheel.cmake = false
+
+[[tool.scikit-build.overrides]]
+if.env.FAIL_NOW = true
+fail = true

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -67,6 +67,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.install.components == []
     assert settings.install.strip
     assert settings.generate == []
+    assert not settings.fail
 
 
 def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -104,6 +105,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SKBUILD_BUILD_TOOL_ARGS", "a;b")
     monkeypatch.setenv("SKBUILD_INSTALL_COMPONENTS", "a;b;c")
     monkeypatch.setenv("SKBUILD_INSTALL_STRIP", "False")
+    monkeypatch.setenv("SKBUILD_FAIL", "1")
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -146,6 +148,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.build.tool_args == ["a", "b"]
     assert settings.install.components == ["a", "b", "c"]
     assert not settings.install.strip
+    assert settings.fail
 
 
 @pytest.mark.parametrize("prefix", [True, False], ids=["skbuild", "noprefix"])
@@ -192,6 +195,7 @@ def test_skbuild_settings_config_settings(
         "build.tool-args": ["a", "b"],
         "install.components": ["a", "b", "c"],
         "install.strip": "True",
+        "fail": "1",
     }
 
     if prefix:
@@ -233,6 +237,7 @@ def test_skbuild_settings_config_settings(
     assert settings.build.tool_args == ["a", "b"]
     assert settings.install.components == ["a", "b", "c"]
     assert settings.install.strip
+    assert settings.fail
 
 
 def test_skbuild_settings_pyproject_toml(
@@ -278,6 +283,7 @@ def test_skbuild_settings_pyproject_toml(
             build.tool-args = ["a", "b"]
             install.components = ["a", "b", "c"]
             install.strip = true
+            fail = true
             [[tool.scikit-build.generate]]
             path = "a/b/c"
             template = "hello"
@@ -334,6 +340,7 @@ def test_skbuild_settings_pyproject_toml(
             path=Path("d/e/f"), template_path=Path("g/h/i"), location="build"
         ),
     ]
+    assert settings.fail
 
 
 def test_skbuild_settings_pyproject_toml_broken(
@@ -375,7 +382,7 @@ def test_skbuild_settings_pyproject_toml_broken(
         == """\
       ERROR: Unrecognized options in pyproject.toml:
         tool.scikit-build.cmake.verison -> Did you mean: tool.scikit-build.cmake.version, tool.scikit-build.cmake.verbose, tool.scikit-build.cmake.define?
-        tool.scikit-build.logger -> Did you mean: tool.scikit-build.logging, tool.scikit-build.generate, tool.scikit-build.wheel?
+        tool.scikit-build.logger -> Did you mean: tool.scikit-build.logging, tool.scikit-build.generate, tool.scikit-build.fail?
       """.split()
     )
 


### PR DESCRIPTION
Adding a `fail = true` setting. One possible use:

```toml
[[tool.scikit-build.overrides]]
if.python-version = ">=3.13"
fail = true
```

This will be nicer once we allow customizing the error message.

See #112.
