### PR TITLE
feat: add messages config for failure/success

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ generate[].template-path = ""
 # files & remember to gitignore the file.
 generate[].location = "install"
 
+# A message to print after a build failure.
+messages.after-failure = ""
+
+# A message to print after a successful build.
+messages.after-success = ""
+
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -672,6 +672,29 @@ On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
 
 :::
 
+## Messages
+
+You can add a message to be printed after a successful or failed build. For example:
+
+```toml
+[tool.scikit-build]
+messages.after-sucesss = "[green]Wheel successfully built"
+messages.after-failure = """
+[red bold]Sorry[/bold], build failed.
+"""
+```
+
+This will be run through Python's formatter, so escape curly brackets. There
+currently are no items provided in the format call, but some may be added in the
+future if requested.
+
+A small mini-language for colorization using `[]` is also provided somewhat
+similar to [Rich](https://rich.readthedocs.io). Supported keywords inside the
+square brackets are `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, and
+`bold`.  These can be reset with a proceeding `/`. `reset` is also supported.
+Unsupported options will be ignored, but keep in mind other keywords from Rich
+might be added in the future.
+
 ## Other options
 
 You can select a custom build dir; by default scikit-build-core will use a

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -37,6 +37,8 @@ def build_wheel(
     except FailedLiveProcessError as err:
         sys.stdout.flush()
         rich_print(f"\n[red bold]*** {' '.join(err.args)}", file=sys.stderr)
+        if err.msg:
+            rich_print(err.msg)
         raise SystemExit(1) from None
 
 
@@ -59,6 +61,8 @@ def build_editable(
     except FailedLiveProcessError as err:
         sys.stdout.flush()
         rich_print(f"\n[red bold]*** {' '.join(err.args)}", file=sys.stderr)
+        if err.msg:
+            rich_print(err.msg)
         raise SystemExit(1) from None
 
 
@@ -91,9 +95,18 @@ def build_sdist(
     sdist_directory: str,
     config_settings: dict[str, list[str] | str] | None = None,
 ) -> str:
+    from .._logging import rich_print
+    from ..errors import FailedLiveProcessError
     from .sdist import build_sdist as skbuild_build_sdist
 
-    return skbuild_build_sdist(sdist_directory, config_settings)
+    try:
+        return skbuild_build_sdist(sdist_directory, config_settings)
+    except FailedLiveProcessError as err:
+        sys.stdout.flush()
+        rich_print(f"\n[red bold]*** {' '.join(err.args)}", file=sys.stderr)
+        if err.msg:
+            rich_print(err.msg)
+        raise SystemExit(1) from None
 
 
 def get_requires_for_build_sdist(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -202,8 +202,8 @@ def _build_wheel_impl(
                 settings=settings_reader.settings,
                 pyproject=pyproject,
             )
-        except FailedLiveProcessError as err:
-            err.msg = settings_reader.settings.messages.after_failure.format()
+        except FailedLiveProcessError as err2:
+            err2.msg = settings_reader.settings.messages.after_failure.format()
             raise
 
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -111,6 +111,7 @@ def _get_packages(
 @dataclasses.dataclass
 class WheelImplReturn:
     wheel_filename: str
+    settings: ScikitBuildSettings
     mapping: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
@@ -146,6 +147,9 @@ def _build_wheel_impl(
     settings_reader.validate_may_exit()
 
     if settings_reader.settings.fail:
+        if settings_reader.settings.messages.after_failure:
+            rich_print(settings_reader.settings.messages.after_failure.format())
+            raise SystemExit(7)
         rich_error("scikit-build-core's fail setting was enabled. Exiting immediately.")
 
     # Warn if cmake or ninja is in build-system.requires
@@ -177,6 +181,7 @@ def _build_wheel_impl(
             pyproject, config_settings or {}, state=state, retry=True
         )
         if "failed" not in settings_reader.overrides:
+            err.msg = settings_reader.settings.messages.after_failure.format()
             raise
 
         rich_print(
@@ -187,15 +192,19 @@ def _build_wheel_impl(
 
         settings_reader.validate_may_exit()
 
-        return _build_wheel_impl_impl(
-            wheel_directory,
-            metadata_directory,
-            exit_after_config=exit_after_config,
-            editable=editable,
-            state=state,
-            settings=settings_reader.settings,
-            pyproject=pyproject,
-        )
+        try:
+            return _build_wheel_impl_impl(
+                wheel_directory,
+                metadata_directory,
+                exit_after_config=exit_after_config,
+                editable=editable,
+                state=state,
+                settings=settings_reader.settings,
+                pyproject=pyproject,
+            )
+        except FailedLiveProcessError as err:
+            err.msg = settings_reader.settings.messages.after_failure.format()
+            raise
 
 
 def _build_wheel_impl_impl(
@@ -343,7 +352,7 @@ def _build_wheel_impl_impl(
                 if not path.parent.is_dir():
                     path.parent.mkdir(exist_ok=True, parents=True)
                 path.write_bytes(data)
-            return WheelImplReturn(wheel_filename=dist_info.name)
+            return WheelImplReturn(wheel_filename=dist_info.name, settings=settings)
 
         for gen in settings.generate:
             contents = generate_file_contents(gen, metadata)
@@ -390,7 +399,7 @@ def _build_wheel_impl_impl(
             )
 
             if exit_after_config:
-                return WheelImplReturn("")
+                return WheelImplReturn("", settings=settings)
 
             default_gen = (
                 "MSVC"
@@ -486,4 +495,8 @@ def _build_wheel_impl_impl(
 
     wheel_filename: str = wheel.wheelpath.name
     rich_print(f"[green]***[/green] [bold]Created[/bold] {wheel_filename}...")
-    return WheelImplReturn(wheel_filename=wheel_filename, mapping=mapping)
+    if settings.messages.after_success:
+        rich_print(settings.messages.after_success.format())
+    return WheelImplReturn(
+        wheel_filename=wheel_filename, mapping=mapping, settings=settings
+    )

--- a/src/scikit_build_core/errors.py
+++ b/src/scikit_build_core/errors.py
@@ -76,6 +76,10 @@ class FailedLiveProcessError(Exception):
     Exception for when output was not being redirected.
     """
 
+    def __init__(self, *args: object, msg: str = "") -> None:
+        super().__init__(*args)
+        self.msg = msg
+
 
 class CMakeAccessError(FailedProcessError):
     """

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -360,6 +360,22 @@
         ]
       }
     },
+    "messages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "after-failure": {
+          "type": "string",
+          "default": "",
+          "description": "A message to print after a build failure."
+        },
+        "after-success": {
+          "type": "string",
+          "default": "",
+          "description": "A message to print after a successful build."
+        }
+      }
+    },
     "metadata": {
       "type": "object",
       "description": "List dynamic metadata fields and hook locations in this table.",
@@ -564,6 +580,9 @@
           },
           "generate": {
             "$ref": "#/properties/generate"
+          },
+          "messages": {
+            "$ref": "#/properties/messages"
           },
           "metadata": {
             "$ref": "#/properties/metadata"

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -9,12 +9,13 @@ from .._compat.typing import Annotated, Literal
 
 __all__ = [
     "BackportSettings",
+    "BuildSettings",
     "CMakeSettings",
     "EditableSettings",
     "GenerateSettings",
     "InstallSettings",
-    "BuildSettings",
     "LoggingSettings",
+    "MessagesSettings",
     "NinjaSettings",
     "SDistSettings",
     "ScikitBuildSettings",
@@ -294,6 +295,23 @@ class GenerateSettings:
 
 
 @dataclasses.dataclass
+class MessagesSettings:
+    """
+    Settings for messages.
+    """
+
+    after_failure: str = ""
+    """
+    A message to print after a build failure.
+    """
+
+    after_success: str = ""
+    """
+    A message to print after a successful build.
+    """
+
+
+@dataclasses.dataclass
 class ScikitBuildSettings:
     cmake: CMakeSettings = dataclasses.field(default_factory=CMakeSettings)
     ninja: NinjaSettings = dataclasses.field(default_factory=NinjaSettings)
@@ -305,6 +323,7 @@ class ScikitBuildSettings:
     build: BuildSettings = dataclasses.field(default_factory=BuildSettings)
     install: InstallSettings = dataclasses.field(default_factory=InstallSettings)
     generate: List[GenerateSettings] = dataclasses.field(default_factory=list)
+    messages: MessagesSettings = dataclasses.field(default_factory=MessagesSettings)
 
     metadata: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
     """

--- a/tests/packages/abi3_pyproject_ext/pyproject.toml
+++ b/tests/packages/abi3_pyproject_ext/pyproject.toml
@@ -8,3 +8,4 @@ version = "0.0.1"
 
 [tool.scikit-build]
 wheel.py-api = "cp37"
+messages.after-success = "This is a message after success"

--- a/tests/test_broken_fallback.py
+++ b/tests/test_broken_fallback.py
@@ -50,3 +50,22 @@ def test_fail_setting(
     assert exc.value.code == 7
     out, _ = capsys.readouterr()
     assert "fail setting was enabled" in out
+
+
+@pytest.mark.usefixtures("broken_fallback")
+def test_fail_setting_msg(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.setenv("FAIL_NOW", "1")
+    monkeypatch.setenv(
+        "SKBUILD_MESSAGES_AFTER_FAILURE", "This is a test failure message"
+    )
+
+    assert get_requires_for_build_wheel({}) == []
+    with pytest.raises(SystemExit) as exc:
+        build_wheel("dist")
+
+    assert exc.value.code == 7
+    out, _ = capsys.readouterr()
+    assert "This is a test failure message" in out
+    assert "fail setting was enabled" not in out

--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -19,7 +19,7 @@ SYSCONFIGPLAT = sysconfig.get_platform()
     sysconfig.get_platform().startswith(("msys", "mingw")),
     reason="abi3 FindPython on MSYS/MinGW reports not found",
 )
-def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
+def test_abi3_wheel(tmp_path, monkeypatch, virtualenv, capsys):
     dist = tmp_path / "dist"
     dist.mkdir()
     monkeypatch.chdir(ABI_PKG)
@@ -29,6 +29,8 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
         shutil.rmtree("build")
 
     out = build_wheel(str(dist))
+    stdout, stderr = capsys.readouterr()
+    assert "This is a message after success" in stdout
     (wheel,) = dist.glob("abi3_example-0.0.1-*.whl")
     assert wheel == dist / out
     abi3 = sys.implementation.name == "cpython" and not sysconfig.get_config_var(

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -68,6 +68,8 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.install.strip
     assert settings.generate == []
     assert not settings.fail
+    assert settings.messages.after_failure == ""
+    assert settings.messages.after_success == ""
 
 
 def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -106,6 +108,12 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SKBUILD_INSTALL_COMPONENTS", "a;b;c")
     monkeypatch.setenv("SKBUILD_INSTALL_STRIP", "False")
     monkeypatch.setenv("SKBUILD_FAIL", "1")
+    monkeypatch.setenv(
+        "SKBUILD_MESSAGES_AFTER_FAILURE", "This is a test failure message"
+    )
+    monkeypatch.setenv(
+        "SKBUILD_MESSAGES_AFTER_SUCCESS", "This is a test success message"
+    )
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
@@ -149,6 +157,8 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.install.components == ["a", "b", "c"]
     assert not settings.install.strip
     assert settings.fail
+    assert settings.messages.after_failure == "This is a test failure message"
+    assert settings.messages.after_success == "This is a test success message"
 
 
 @pytest.mark.parametrize("prefix", [True, False], ids=["skbuild", "noprefix"])
@@ -196,6 +206,8 @@ def test_skbuild_settings_config_settings(
         "install.components": ["a", "b", "c"],
         "install.strip": "True",
         "fail": "1",
+        "messages.after-failure": "This is a test failure message",
+        "messages.after-success": "This is a test success message",
     }
 
     if prefix:
@@ -238,6 +250,8 @@ def test_skbuild_settings_config_settings(
     assert settings.install.components == ["a", "b", "c"]
     assert settings.install.strip
     assert settings.fail
+    assert settings.messages.after_failure == "This is a test failure message"
+    assert settings.messages.after_success == "This is a test success message"
 
 
 def test_skbuild_settings_pyproject_toml(
@@ -284,6 +298,8 @@ def test_skbuild_settings_pyproject_toml(
             install.components = ["a", "b", "c"]
             install.strip = true
             fail = true
+            messages.after-failure = "This is a test failure message"
+            messages.after-success = "This is a test success message"
             [[tool.scikit-build.generate]]
             path = "a/b/c"
             template = "hello"
@@ -341,6 +357,8 @@ def test_skbuild_settings_pyproject_toml(
         ),
     ]
     assert settings.fail
+    assert settings.messages.after_failure == "This is a test failure message"
+    assert settings.messages.after_success == "This is a test success message"
 
 
 def test_skbuild_settings_pyproject_toml_broken(


### PR DESCRIPTION
See #112.

This includes `.format()` so that items can be added here later in a backward-compatible way.
