### PR TITLE
feat: add `remove=` postprocess to regex

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -565,7 +565,8 @@ You can set a custom regex with `regex=`. By default when targeting version, you
 get a reasonable regex for python files,
 `'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'`.
 You can set `result` to a format string to process the matches; the default is
-`"{value}"`. A more complex example:
+`"{value}"`. You can also specify a regex for `remove=` which will strip any
+matches from the final result. A more complex example:
 
 ```toml
 [tool.scikit-build.metadata.version]
@@ -574,13 +575,22 @@ input = "src/mypackage/version.hpp"
 regex = '''(?sx)
 \#define \w+ VERSION_MAJOR \w+ (?P<major>\d+) .*?
 \#define \w+ VERSION_MINOR \w+ (?P<minor>\d+) .*?
-\#define \w+ VERSION_PATCH \w+ (?P<patch>\d+)
+\#define \w+ VERSION_PATCH \w+ (?P<patch>\d+) .*?
+\#define \w+ VERSION_DEV \w+ (?P<dev>\d+) .*?
 '''
-result = "{major}.{minor}.{patch}"
+result = "{major}.{minor}.{patch}dev{dev}"
+remove = "dev0"
 ```
+
+This will remove the "dev" tag when it is equal to 0.
 
 ```{versionadded} 0.5
 
+```
+
+```{versionchanged} 0.10
+
+Support for `result` and `remove` added.
 ```
 
 :::

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -14,7 +14,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-KEYS = {"input", "regex", "result"}
+KEYS = {"input", "regex", "result", "remove"}
 
 
 def dynamic_metadata(
@@ -46,6 +46,7 @@ def dynamic_metadata(
     )
     result = settings.get("result", "{value}")
     assert isinstance(result, str)
+    remove = settings.get("result", "")
 
     with Path(input_filename).open(encoding="utf-8") as f:
         match = re.search(regex, f.read(), re.MULTILINE)
@@ -54,4 +55,7 @@ def dynamic_metadata(
         msg = f"Couldn't find {regex!r} in {input_filename}"
         raise RuntimeError(msg)
 
-    return result.format(*match.groups(), **match.groupdict())
+    retval = result.format(*match.groups(), **match.groupdict())
+    if remove:
+        retval = re.sub(remove, "", retval)
+    return retval


### PR DESCRIPTION
This adds the ability to post-process regex to remove "dev0" or similar. Closes #765.
