### PR TITLE
feat: if.scikit-build-version

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ New features:
 * Adding `if.system-cmake` and `if.cmake-wheel` by @henryiii in #826
 * Add `if.from-sdist` for overrides by @henryiii in #812
 * Add `if.failed` (retry) by @henryiii in #820
+* Add `if.scikit-build-version` by @henryiii in #851
 * Packages can also be specified via a table by @henryiii in #841
 * Move `cmake.targets` and `cmake.verbose` to `build.targets` and `build.verbose` by @henryiii in #793
 * Support multipart regex by @henryiii in #818

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -22,7 +22,7 @@ options, and those will override if all the items in the `if` are true. They
 will match top to bottom, overriding previous matches.
 
 If an override does not match, it's contents are ignored, including invalid
-options. Combined with the `if.version` override, this allows using overrides to
+options. Combined with the `if.scikit-build-version` override, this allows using overrides to
 support a range of scikit-build-core versions that added settings you want to
 use.
 

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -21,6 +21,16 @@ At least one must be provided. Then you can specify any collection of valid
 options, and those will override if all the items in the `if` are true. They
 will match top to bottom, overriding previous matches.
 
+If an override does not match, it's contents are ignored, including invalid
+options. Combined with the `if.version` override, this allows using overrides to
+support a range of scikit-build-core versions that added settings you want to
+use.
+
+### `version` (version)
+
+The version of scikit-build-core itself. Takes a specifier set. If this is
+provided, unknown overrides will not be validated unless it's a match.
+
 ### `python-version` (version)
 
 The two-digit Python version. Takes a specifier set.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -26,7 +26,7 @@ options. Combined with the `if.version` override, this allows using overrides to
 support a range of scikit-build-core versions that added settings you want to
 use.
 
-### `version` (version)
+### `scikit-build-version` (version)
 
 The version of scikit-build-core itself. Takes a specifier set. If this is
 provided, unknown overrides will not be validated unless it's a match.

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -635,6 +635,10 @@
       "minProperties": 1,
       "additionalProperties": false,
       "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version of scikit-build-version. Takes a specifier set."
+        },
         "python-version": {
           "type": "string",
           "description": "The two-digit Python version. Takes a specifier set."

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -635,7 +635,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "properties": {
-        "core-version": {
+        "scikit-build-version": {
           "type": "string",
           "description": "The version of scikit-build-version. Takes a specifier set."
         },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -635,7 +635,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "properties": {
-        "version": {
+        "core-version": {
           "type": "string",
           "description": "The version of scikit-build-version. Takes a specifier set."
         },

--- a/src/scikit_build_core/settings/auto_requires.py
+++ b/src/scikit_build_core/settings/auto_requires.py
@@ -29,13 +29,14 @@ def get_min_requires(package: str, reqlist: Iterable[str]) -> Version | None:
 
     requires = [Requirement(req) for req in reqlist]
 
-    for req in requires:
-        if canonicalize_name(req.name) == norm_package:
-            specset = req.specifier
-            versions = (min_from_spec(v) for v in specset)
-            return min((v for v in versions if v is not None), default=None)
-
-    return None
+    versions = (
+        min_from_spec(v)
+        for req in requires
+        if canonicalize_name(req.name) == norm_package
+        and (req.marker is None or req.marker.evaluate())
+        for v in req.specifier
+    )
+    return min((v for v in versions if v is not None), default=None)
 
 
 def min_from_spec(spec: Specifier) -> Version | None:

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -88,7 +88,7 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
         "minProperties": 1,
         "additionalProperties": False,
         "properties": {
-            "core-version": {
+            "scikit-build-version": {
                 "type": "string",
                 "description": "The version of scikit-build-version. Takes a specifier set.",
             },

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -88,6 +88,10 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
         "minProperties": 1,
         "additionalProperties": False,
         "properties": {
+            "version": {
+                "type": "string",
+                "description": "The version of scikit-build-version. Takes a specifier set.",
+            },
             "python-version": {
                 "type": "string",
                 "description": "The two-digit Python version. Takes a specifier set.",

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -88,7 +88,7 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
         "minProperties": 1,
         "additionalProperties": False,
         "properties": {
-            "version": {
+            "core-version": {
                 "type": "string",
                 "description": "The version of scikit-build-version. Takes a specifier set.",
             },

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -30,6 +30,15 @@ def test_auto_requires_pkg_version(spec: str, version: Version):
     assert get_min_requires("scikit-build-core", reqlist) == version
 
 
+def test_auto_requires_with_marker():
+    reqlist = [
+        "scikit_build_core>=0.1; python_version < '3.7'",
+        "scikit_build_core>=0.2; python_version >= '3.7'",
+    ]
+
+    assert get_min_requires("scikit-build-core", reqlist) == Version("0.2")
+
+
 @pytest.mark.parametrize(
     ("expr", "answer"),
     [

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 import pytest
 
+import scikit_build_core.settings.skbuild_overrides
 from scikit_build_core.settings.skbuild_overrides import regex_match
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
@@ -688,3 +689,98 @@ def test_free_threaded_override(tmp_path: Path):
     settings_reader = SettingsReader.from_file(pyproject_toml, state="wheel")
     settings = settings_reader.settings
     assert settings.wheel.cmake == bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+@pytest.mark.parametrize("version", ["0.9", "0.10"])
+def test_skbuild_overrides_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: str
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_overrides, "__version__", version
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build]
+            wheel.cmake = false
+
+            [[tool.scikit-build.overrides]]
+            if.version = ">=0.10"
+            wheel.cmake = true
+            """
+        )
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, state="wheel")
+    settings = settings_reader.settings
+    if version == "0.10":
+        assert settings.wheel.cmake
+    else:
+        assert not settings.wheel.cmake
+
+
+def test_skbuild_overrides_unmatched_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_overrides, "__version__", "0.10"
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.version = "<0.10"
+            if.is-not-real = true
+            also-not-real = true
+            """
+        )
+    )
+
+    SettingsReader.from_file(pyproject_toml, state="wheel")
+
+
+def test_skbuild_overrides_matched_version_if(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_overrides, "__version__", "0.10"
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.version = ">=0.10"
+            if.is-not-real = true
+            """
+        )
+    )
+
+    with pytest.raises(TypeError, match="is_not_real"):
+        SettingsReader.from_file(pyproject_toml, state="wheel")
+
+
+def test_skbuild_overrides_matched_version_extra(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_overrides, "__version__", "0.10"
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.version = ">=0.10"
+            not-real = true
+            """
+        )
+    )
+
+    settings = SettingsReader.from_file(pyproject_toml, state="wheel")
+    with pytest.raises(SystemExit):
+        settings.validate_may_exit()
+
+    assert "not-real" in capsys.readouterr().out


### PR DESCRIPTION
This adds an `if.scikit-build-version`, and makes sure it can be used to gate features not yet implemented. This should help with #769 by providing a way to support old scikit-build-core's on Python 3.7 even after we drop support.

Also fixes auto minimum-version to respect markers.