### PR TITLE
Fix crash when building inside a submodule

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 __all__ = ["each_unignored_file"]
 
 EXCLUDE_LINES = [
-    ".git/",
+    ".git",
     ".tox/",
     ".nox/",
     ".egg-info/",
@@ -39,7 +39,8 @@ def each_unignored_file(
     exclude_lines = EXCLUDE_LINES + list(exclude)
 
     for gi in [Path(".git/info/exclude"), Path(".gitignore")]:
-        with contextlib.suppress(FileNotFoundError), gi.open(encoding="utf-8") as f:
+        ignore_errs = [FileNotFoundError, NotADirectoryError]
+        with contextlib.suppress(*ignore_errs), gi.open(encoding="utf-8") as f:
             exclude_lines += f.readlines()
 
     nested_excludes = {

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -65,3 +65,16 @@ def test_on_each_with_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         nested_dir / "not_ignored.txt",
         nested_dir / ".gitignore",
     }
+
+
+def test_dot_git_is_a_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test that each_unignored_file() does not crash when .git is a file (e.g.,
+    if the build is being run in a submodule)
+    """
+    monkeypatch.chdir(tmp_path)
+    # Create a file named .git
+    git = Path(".git")
+    git.write_text("gitdir: ../../.git/modules/foo")
+    # If this throws an exception, the test will fail
+    assert list(each_unignored_file(Path())) == []


### PR DESCRIPTION
If .git is a file instead of a directory (such as when you are building in a submodule), scikit-build-core will currently crash because a NotADirectoryError is thrown instead of a FileNotFoundError. This PR accounts for the resulting exception (NotADirectoryError) instead of crashing.

Another option instead of hardcoding this list would be to catch the more general `OSError`. However, I did not do that, because I am worried about silently swallowing too broad of a class of exceptions.

I wrote a unit test and also tested the fix [against the project][1] where I encountered this.

[1]: https://github.com/scikit-build/scikit-build-core/blob/main/.github/CONTRIBUTING.md#testing-a-project-with-a-branch--main

(By the way, this project is very helpful, thank you. The fact that I encountered this issue only a couple of hours after the release of 0.10.0 tells you how often I use it!)