### PR TITLE
fix: Files included twice when they match `include_spec`

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -59,6 +59,7 @@ def each_unignored_file(
             # Always include something included
             if include_spec.match_file(p):
                 yield p
+                continue
 
             # Ignore from global ignore
             if exclude_spec.match_file(p):


### PR DESCRIPTION
Currently if a file matches the explicit `sdist.include` it is included twice in the source distribution.

This causes an error with some package managers such as `uv` (See https://github.com/abetlen/llama-cpp-python/issues/1670#issuecomment-2284603172).