### PR TITLE
fix: Ignore pre-installed self-package from prefix_path

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -138,6 +138,10 @@ class Builder:
             self.config.prefix_dirs.append(DIR.parent.parent)
             logger.debug("Extra SITE_PACKAGES: {}", site_packages)
 
+        # Add site-packages to ignore prefix root
+        # TODO: Should we try to add the installation wheel.install-dir + wheel.packages here?
+        self.config.ignore_prefix_dirs.append(site_packages)
+
         # Add the FindPython backport if needed
         if self.config.cmake.version < self.settings.backport.find_python:
             fp_dir = Path(find_python.__file__).parent.resolve()
@@ -158,6 +162,7 @@ class Builder:
         if name is not None:
             canonical_name = name.replace("-", "_").replace(".", "_")
             cache_config["SKBUILD_PROJECT_NAME"] = canonical_name
+            self.config.canonical_name = canonical_name
         if version is not None:
             cache_config["SKBUILD_PROJECT_VERSION"] = ".".join(
                 str(v) for v in version.release


### PR DESCRIPTION
Context:
- This came up when working on https://github.com/spglib/spglib/pull/520
- Upstream CMake issue https://gitlab.kitware.com/cmake/cmake/-/issues/26213

---

I am opening to brainstorm some ideas on how to implement.

TODO:
- [ ] Expose the `ignore_prefix_path` as a configure variable
- [ ] Do not use `canonical_name` as self project name, instead find out the path from installed python files, entry-point etc.
- [ ] How to deal when the project shared the CMake install path with another project?
- [ ] Figure out why `CMAKE_IGNORE_PREFIX_PATH` does not works as intended
- [ ] Write tests

---

About `CMAKE_IGNORE_PREFIX_PATH` not working as intended. From what I've tested, if I put the path as `site-packages/spglib`, then this does not work, it still continues to find the pre-installed package files, but if I remove the `spglib` path and make it point to effectively the same folder as `CMAKE_PREFIX_PATH`, it does work. This seems like a bug in CMake that it doesn't resolve itself when `CMAKE_IGNORE_PREFIX_PATH` is a child of `CMAKE_PREFIX_PATH`, which as much as I think about it, it should be this way right?

Here is what I managed to track down from upstream:
1. [Parse `CMAKE_IGNORE_PREFIX_PATH`](https://gitlab.kitware.com/cmake/cmake/-/blob/88e90fcd2056f14531db33f15980431cbbdf39fe/Source/cmFindCommon.cxx#L351-L367)
2. [Pass `CMAKE_IGNORE_PREFIX_PATH` to construct search path list](https://gitlab.kitware.com/cmake/cmake/-/blob/88e90fcd2056f14531db33f15980431cbbdf39fe/Source/cmFindCommon.cxx#L451-L455)
3. [Logic for filtering search paths](https://gitlab.kitware.com/cmake/cmake/-/blob/88e90fcd2056f14531db33f15980431cbbdf39fe/Source/cmSearchPath.cxx#L26-L40)