### PR TITLE
Editable installs now respect the value of wheel.install-dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
           - rich
           - setuptools-scm
           - tomli
-          - types-setuptools>=69.2
+          - types-setuptools~=70.0
 
   - repo: https://github.com/henryiii/check-sdist
     rev: "v1.0.0rc2"

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -35,6 +35,7 @@ def editable_redirect(
     """
     Prepare the contents of the _editable_redirect.py file.
     """
+
     editable_py = resources / "_editable_redirect.py"
     editable_txt: str = editable_py.read_text(encoding="utf-8")
 

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -30,7 +30,7 @@ def editable_redirect(
     verbose: bool,
     build_options: Sequence[str],
     install_options: Sequence[str],
-    install_dir: str | None,
+    install_dir: str,
 ) -> str:
     """
     Prepare the contents of the _editable_redirect.py file.

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -30,11 +30,11 @@ def editable_redirect(
     verbose: bool,
     build_options: Sequence[str],
     install_options: Sequence[str],
+    install_dir: str | None,
 ) -> str:
     """
     Prepare the contents of the _editable_redirect.py file.
     """
-
     editable_py = resources / "_editable_redirect.py"
     editable_txt: str = editable_py.read_text(encoding="utf-8")
 
@@ -46,6 +46,7 @@ def editable_redirect(
         verbose,
         build_options,
         install_options,
+        install_dir,
     )
     arguments_str = ", ".join(repr(x) for x in arguments)
     editable_txt += f"\n\ninstall({arguments_str})\n"

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -67,6 +67,7 @@ def _make_editable(
         verbose=settings.editable.verbose,
         build_options=build_options,
         install_options=install_options,
+        install_dir=settings.wheel.install_dir or None,
     )
 
     wheel.writestr(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -67,7 +67,7 @@ def _make_editable(
         verbose=settings.editable.verbose,
         build_options=build_options,
         install_options=install_options,
-        install_dir=settings.wheel.install_dir or None,
+        install_dir=settings.wheel.install_dir,
     )
 
     wheel.writestr(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -58,7 +58,9 @@ def _make_editable(
 ) -> None:
     modules = mapping_to_modules(mapping, libdir)
     installed = libdir_to_installed(libdir)
-
+    if settings.wheel.install_dir.startswith("/"):
+        msg = "Editable installs cannot rebuild an absolute wheel.install-dir. Use an override to change if needed."
+        raise AssertionError(msg)
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -33,7 +33,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         build_options: list[str],
         install_options: list[str],
         dir: str,
-        install_dir: str | None,
+        install_dir: str,
     ) -> None:
         self.known_source_files = known_source_files
         self.known_wheel_files = known_wheel_files
@@ -43,7 +43,11 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.build_options = build_options
         self.install_options = install_options
         self.dir = dir
-        self.install_dir = install_dir or DIR
+        self.install_dir = (
+            install_dir
+            if os.path.isabs(install_dir)
+            else os.path.join(DIR, install_dir)
+        )
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
         submodule_search_locations: dict[str, set[str]] = {}
@@ -168,7 +172,7 @@ def install(
     verbose: bool = False,
     build_options: list[str] | None = None,
     install_options: list[str] | None = None,
-    install_dir: str | None = None,
+    install_dir: str = "",
 ) -> None:
     """
     Install a meta path finder that redirects imports to the source files, and
@@ -193,6 +197,6 @@ def install(
             build_options or [],
             install_options or [],
             DIR,
-            os.path.join(DIR, install_dir) if install_dir else DIR,
+            install_dir,
         ),
     )

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -33,7 +33,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         build_options: list[str],
         install_options: list[str],
         dir: str,
-        install_dir: str,
+        install_dir: str | None,
     ) -> None:
         self.known_source_files = known_source_files
         self.known_wheel_files = known_wheel_files
@@ -43,7 +43,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.build_options = build_options
         self.install_options = install_options
         self.dir = dir
-        self.install_dir = install_dir
+        self.install_dir = install_dir or DIR
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
         submodule_search_locations: dict[str, set[str]] = {}

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -43,11 +43,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.build_options = build_options
         self.install_options = install_options
         self.dir = dir
-        self.install_dir = (
-            install_dir
-            if os.path.isabs(install_dir)
-            else os.path.join(DIR, install_dir)
-        )
+        self.install_dir = os.path.join(DIR, install_dir)
+
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
         submodule_search_locations: dict[str, set[str]] = {}

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -32,7 +32,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         verbose: bool,
         build_options: list[str],
         install_options: list[str],
-        dir: str = DIR,
+        dir: str,
+        install_dir: str,
     ) -> None:
         self.known_source_files = known_source_files
         self.known_wheel_files = known_wheel_files
@@ -42,6 +43,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.build_options = build_options
         self.install_options = install_options
         self.dir = dir
+        self.install_dir = install_dir
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
         submodule_search_locations: dict[str, set[str]] = {}
@@ -136,7 +138,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         result.check_returncode()
 
         result = subprocess.run(
-            ["cmake", "--install", ".", "--prefix", DIR, *self.install_options],
+            ["cmake", "--install", ".", "--prefix", self.install_dir,
+             *self.install_options],
             cwd=self.path,
             stdout=sys.stderr if verbose else subprocess.PIPE,
             env=env,
@@ -159,6 +162,7 @@ def install(
     verbose: bool = False,
     build_options: list[str] | None = None,
     install_options: list[str] | None = None,
+    install_dir: str | None = None,
 ) -> None:
     """
     Install a meta path finder that redirects imports to the source files, and
@@ -169,6 +173,8 @@ def install(
     :param path: The path to the build directory, or None
     :param verbose: Whether to print the cmake commands (also controlled by the
                     SKBUILD_EDITABLE_VERBOSE environment variable)
+    :param install_dir: The wheel install directory override, if one was
+                        specified
     """
     sys.meta_path.insert(
         0,
@@ -180,5 +186,7 @@ def install(
             verbose,
             build_options or [],
             install_options or [],
+            DIR,
+            os.path.join(DIR, install_dir) if install_dir else DIR,
         ),
     )

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -138,8 +138,14 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         result.check_returncode()
 
         result = subprocess.run(
-            ["cmake", "--install", ".", "--prefix", self.install_dir,
-             *self.install_options],
+            [
+                "cmake",
+                "--install",
+                ".",
+                "--prefix",
+                self.install_dir,
+                *self.install_options,
+            ],
             cwd=self.path,
             stdout=sys.stderr if verbose else subprocess.PIPE,
             env=env,

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -44,7 +44,7 @@ def test_editable_redirect():
         build_options=[],
         install_options=[],
         dir=str(Path("/sitepackages")),
-        install_dir=None,
+        install_dir="",
     )
 
     assert finder.submodule_search_locations == process_dict_set(

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -44,6 +44,7 @@ def test_editable_redirect():
         build_options=[],
         install_options=[],
         dir=str(Path("/sitepackages")),
+        install_dir=None
     )
 
     assert finder.submodule_search_locations == process_dict_set(

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -44,7 +44,7 @@ def test_editable_redirect():
         build_options=[],
         install_options=[],
         dir=str(Path("/sitepackages")),
-        install_dir=None
+        install_dir=None,
     )
 
     assert finder.submodule_search_locations == process_dict_set(

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -181,6 +181,7 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
         verbose=False,
         build_options=[],
         install_options=[],
+        install_dir=None,
     )
 
     site_packages.joinpath("_pkg_editable.py").write_text(editable_txt)

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -181,7 +181,7 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
         verbose=False,
         build_options=[],
         install_options=[],
-        install_dir=None,
+        install_dir="",
     )
 
     site_packages.joinpath("_pkg_editable.py").write_text(editable_txt)


### PR DESCRIPTION
Attempting to fix: https://github.com/scikit-build/scikit-build-core/issues/866

I'm passing down wheel.install-dir to the editable redirect script and appending it to DIR so that rebuilds happen in the correct path. This worked for me in a local testing environment, but I'm not familiar with this codebase, so I don't know if this is an optimal solution.