### PR TITLE
docs: fix typo in if.platform-system example

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -71,7 +71,7 @@ Example:
 
 ```toml
 [[tool.scikit-build.overrides]]
-if.platform-system = "$darwin"
+if.platform-system = "^darwin"
 cmake.version = ">=3.18"
 ```
 


### PR DESCRIPTION
Wrong regex symbol, seen in https://github.com/orgs/scikit-build/discussions/1115#discussioncomment-10479495