### PR TITLE
feat: Rework CMake search path settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ messages.after-failure = ""
 # A message to print after a successful build.
 messages.after-success = ""
 
+# Add the python build environment site_packages folder to the CMake prefix
+# paths.
+search.site-packages = true
+
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
 

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -1,0 +1,184 @@
+# Search paths
+
+Scikit-build-core populates CMake search paths to take into account any other
+CMake project installed in the same environment. In order to take advantage of
+this the dependent project must populate a `cmake.*` entry-point.
+
+## `<PackageName>_ROOT`
+
+This is the recommended interface to be used for importing dependent packages
+using `find_package`. This variable is populated by the dependent project's
+entry-point `cmake.root`.
+
+To configure the `cmake.root` entry-point to export to other projects, you can
+use the CMake standard install paths in you `CMakeLists.txt` if you use
+`wheel.install-dir` option, e.g.
+
+```{code-block} cmake
+:caption: CMakeLists.txt
+:emphasize-lines: 14-16
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+write_basic_package_version_file(
+    MyProjectConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(
+    cmake/MyProjectConfig.cmake.in
+    MyProjectConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MyProject
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/MyProjectConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MyProjectConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MyProject
+)
+```
+
+```{code-block} toml
+:caption: pyproject.toml
+:emphasize-lines: 2,5
+
+[tool.scikit-build]
+wheel.install-dir = "myproject"
+
+[project.entry-points."cmake.root"]
+MyProject = "myproject"
+```
+
+With this any consuming project that depends on this would automatically work
+with `find_package(MyProject)` as long as it is in the `build-system.requires`
+list.
+
+````{tab} pyproject.toml
+
+```toml
+[tool.scikit-build.search]
+ignore_entry_point = ["MyProject"]
+[tool.scikit-build.search.roots]
+OtherProject = "/path/to/other_project"
+```
+
+````
+
+`````{tab} config-settings
+
+
+````{tab} pip
+
+```console
+$ pip install . -v --config-settings=search.ignore_entry_point="MyProject" --config-settings=search.roots.OtherProject="/path/to/other_project"
+```
+
+````
+
+````{tab} build
+
+```console
+$ pipx run build --wheel -Csearch.ignore_entry_point="MyProject" -Csearch.roots.OtherProject="/path/to/other_project"
+```
+
+````
+
+````{tab} cibuildwheel
+
+```toml
+[tool.cibuildwheel.config-settings]
+"search.ignore_entry_point" = ["MyProject"]
+"search.roots.OtherProject" = "/path/to/other_project"
+```
+
+````
+
+`````
+
+````{tab} Environment
+
+
+```yaml
+SKBUILD_SEARCH_IGNORE_ENTRY_POINT: "MyProject"
+SKBUILD_SEARCH_ROOTS_OtherProject: "/path/to/other_project"
+```
+
+````
+
+## `CMAKE_PREFIX_PATH`
+
+Another common search path that scikit-build-core populates is the
+`CMAKE_PREFIX_PATH` which is a common catch-all for all CMake search paths, e.g.
+`find_package`, `find_program`, `find_path`. This is populated by default with
+the `site-packages` folder where the project will be installed or the build
+isolation's `site-packages` folder. This default can be disabled by setting
+
+```toml
+[tool.scikit-build.search]
+search.use-site-packages = false
+```
+
+Additionally, scikit-build-core reads the entry-point `cmake.prefix` of the
+dependent projects, which is similarly export as
+
+```toml
+[project.entry-points."cmake.prefix"]
+MyProject = "myproject"
+```
+
+````{tab} pyproject.toml
+
+```toml
+[tool.scikit-build.search]
+ignore_entry_point = ["MyProject"]
+prefixes = ["/path/to/prefixA", "/path/to/prefixB"]
+```
+
+````
+
+`````{tab} config-settings
+
+
+````{tab} pip
+
+```console
+$ pip install . -v --config-settings=search.ignore_entry_point="MyProject" --config-settings=search.prefixes="/path/to/prefixA;/path/to/prefixB"
+```
+
+````
+
+````{tab} build
+
+```console
+$ pipx run build --wheel -Csearch.ignore_entry_point="MyProject" -Csearch.prefixes="/path/to/prefixA;/path/to/prefixB"
+```
+
+````
+
+````{tab} cibuildwheel
+
+```toml
+[tool.cibuildwheel.config-settings]
+"search.ignore_entry_point" = ["MyProject"]
+"search.prefixes" = ["/path/to/prefixA", "/path/to/prefixB"]
+```
+
+````
+
+`````
+
+````{tab} Environment
+
+
+```yaml
+SKBUILD_SEARCH_IGNORE_ENTRY_POINT: "MyProject"
+SKBUILD_SEARCH_PREFIXES: "/path/to/prefixA;/path/to/prefixB"
+```
+
+````
+
+## `CMAKE_MODULE_PATH`
+
+Scikit-build-core also populates `CMAKE_MODULE_PATH` variable used to search for
+CMake modules using the `include()` command (if the `.cmake` suffix is omitted).
+
+[`CMAKE_PREFIX_PATH`]: #cmake-prefix-path

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -77,15 +77,13 @@ succeed.
 
 ## Finding other packages
 
-Scikit-build-core includes the site-packages directory in CMake's search path,
-so packages can provide a find package config with a name matching the package
-name - such as the `pybind11` package.
+Scikit-build-core includes various pythonic paths to the CMake search paths by
+default so that usually you only need to include the dependent project inside
+the `build-system.requires` section. Note that `cmake` and `ninja` should not be
+included in that section.
 
-Third party packages can declare entry-points `cmake.module` and `cmake.prefix`,
-and the specified module will be added to `CMAKE_MODULE_PATH` and
-`CMAKE_PREFIX_PATH`, respectively. Currently, the key is not used, but
-eventually there might be a way to request or exclude certain entry-points by
-key.
+See [search paths section](../configuration/search_paths.md) for more details on
+how the search paths are constructed.
 
 ## Install directories
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ configuration/index
 configuration/overrides
 configuration/dynamic
 configuration/formatted
+configuration/search_paths
 ```
 
 ```{toctree}

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -149,12 +149,13 @@ class Builder:
 
         # Add site-packages to the prefix path for CMake
         site_packages = Path(sysconfig.get_path("purelib"))
-        self.config.prefix_dirs.append(site_packages)
-        logger.debug("SITE_PACKAGES: {}", site_packages)
-        if site_packages != DIR.parent.parent:
-            self.config.prefix_dirs.append(DIR.parent.parent)
-            logger.debug("Extra SITE_PACKAGES: {}", DIR.parent.parent)
-            logger.debug("PATH: {}", sys.path)
+        if self.settings.search.site_packages:
+            self.config.prefix_dirs.append(site_packages)
+            logger.debug("SITE_PACKAGES: {}", site_packages)
+            if site_packages != DIR.parent.parent:
+                self.config.prefix_dirs.append(DIR.parent.parent)
+                logger.debug("Extra SITE_PACKAGES: {}", DIR.parent.parent)
+                logger.debug("PATH: {}", sys.path)
 
         # Add the FindPython backport if needed
         if self.config.cmake.version < self.settings.backport.find_python:

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -407,6 +407,17 @@
         }
       }
     },
+    "search": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "site-packages": {
+          "type": "boolean",
+          "default": true,
+          "description": "Add the python build environment site_packages folder to the CMake prefix paths."
+        }
+      }
+    },
     "metadata": {
       "type": "object",
       "description": "List dynamic metadata fields and hook locations in this table.",
@@ -617,6 +628,9 @@
           },
           "messages": {
             "$ref": "#/properties/messages"
+          },
+          "search": {
+            "$ref": "#/properties/search"
           },
           "metadata": {
             "$ref": "#/properties/metadata"

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -20,6 +20,7 @@ __all__ = [
     "NinjaSettings",
     "SDistSettings",
     "ScikitBuildSettings",
+    "SearchSettings",
     "WheelSettings",
 ]
 
@@ -100,6 +101,14 @@ class CMakeSettings:
     targets: Optional[List[str]] = None
     """
     DEPRECATED in 0.10; use build.targets instead.
+    """
+
+
+@dataclasses.dataclass
+class SearchSettings:
+    site_packages: bool = True
+    """
+    Add the python build environment site_packages folder to the CMake prefix paths.
     """
 
 
@@ -355,6 +364,7 @@ class ScikitBuildSettings:
     install: InstallSettings = dataclasses.field(default_factory=InstallSettings)
     generate: List[GenerateSettings] = dataclasses.field(default_factory=list)
     messages: MessagesSettings = dataclasses.field(default_factory=MessagesSettings)
+    search: SearchSettings = dataclasses.field(default_factory=SearchSettings)
 
     metadata: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
     """

--- a/tests/packages/custom_cmake/CMakeLists.txt
+++ b/tests/packages/custom_cmake/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   VERSION 2.3.4)
 
 find_package(ExamplePkg REQUIRED)
-
+find_package(ExampleRoot REQUIRED)
 include(ExampleInclude)
 
 if(NOT EXAMPLE_INCLUDE_FOUND)

--- a/tests/packages/custom_cmake/extern/custom_cmake_testing_stuff/cmake_root/ExampleRootConfig.cmake
+++ b/tests/packages/custom_cmake/extern/custom_cmake_testing_stuff/cmake_root/ExampleRootConfig.cmake
@@ -1,0 +1,3 @@
+set(ExampleRoot_FOUND
+    TRUE
+    CACHE BOOL "ExampleRoot found" FORCE)

--- a/tests/packages/custom_cmake/extern/pyproject.toml
+++ b/tests/packages/custom_cmake/extern/pyproject.toml
@@ -11,3 +11,6 @@ any = "custom_cmake_testing_stuff.cmake_modules"
 
 [project.entry-points."cmake.prefix"]
 any = "custom_cmake_testing_stuff.cmake_prefix"
+
+[project.entry-points."cmake.root"]
+ExampleRoot = "custom_cmake_testing_stuff.cmake_root"

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -395,7 +395,7 @@ def test_skbuild_settings_pyproject_toml_broken(
         == """\
       ERROR: Unrecognized options in pyproject.toml:
         tool.scikit-build.cmake.verison -> Did you mean: tool.scikit-build.cmake.version, tool.scikit-build.cmake.verbose, tool.scikit-build.cmake.define?
-        tool.scikit-build.logger -> Did you mean: tool.scikit-build.logging, tool.scikit-build.generate, tool.scikit-build.fail?
+        tool.scikit-build.logger -> Did you mean: tool.scikit-build.logging, tool.scikit-build.generate, tool.scikit-build.search?
       """.split()
     )
 


### PR DESCRIPTION
- [x] Gate the install path's site-packages by an option
- [x] Add logic for `entry_points(group="cmake.root")`:
- [x] Documentation
    - Add a new page on all the search logics
    - Encourage the usage of `cmake.root` over `cmake.prefix`
- [x] Tests

Closes #831 
Closes #885
Relates to #860 (still keeping it open because it doesn't address the specific issue)