### PR TITLE
fix: use correct settings key to remove parts of the version in regex metadata plugin

### DIFF
--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -46,7 +46,7 @@ def dynamic_metadata(
     )
     result = settings.get("result", "{value}")
     assert isinstance(result, str)
-    remove = settings.get("result", "")
+    remove = settings.get("remove", "")
 
     with Path(input_filename).open(encoding="utf-8") as f:
         match = re.search(regex, f.read(), re.MULTILINE)

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -346,4 +346,4 @@ def test_regex_remove(
         },
     )
 
-    assert version == "1.2.3dev1" if dev else "1.2.3"
+    assert version == ("1.2.3dev1" if dev else "1.2.3")


### PR DESCRIPTION
Hello together.

I've been trying to use the `remove` settings key for the `regex` metadata plugin and noticed, that it has been non-functional for me. To me, it looks like the plugin acquires the wrong value from the settings dictionary (`result` instead of `remove`). This PR intends to change this to what I believe is correct.