### PR TITLE
ci: tmt tests improvements

### DIFF
--- a/.distro/plans/examples.fmf
+++ b/.distro/plans/examples.fmf
@@ -1,5 +1,4 @@
-summary:
-  Documentation examples
+summary: Documentation examples
 discover+:
   how: fmf
   filter: "tag: examples"

--- a/.distro/plans/smoke.fmf
+++ b/.distro/plans/smoke.fmf
@@ -1,3 +1,6 @@
+/:
+  inherit: false
+
 summary:
   Basic smoke tests
 discover:

--- a/.distro/plans/smoke.fmf
+++ b/.distro/plans/smoke.fmf
@@ -1,8 +1,7 @@
 /:
   inherit: false
 
-summary:
-  Basic smoke tests
+summary: Basic smoke tests
 discover:
   how: fmf
   filter: "tag: smoke"

--- a/.distro/tests/smoke.fmf
+++ b/.distro/tests/smoke.fmf
@@ -5,4 +5,5 @@ path: /
 
 # Define tests
 /version:
+  summary: Read version
   test: python3 -c "import scikit_build_core; print(scikit_build_core.__version__)"

--- a/docs/examples/downstream/nanobind_example/main.fmf
+++ b/docs/examples/downstream/nanobind_example/main.fmf
@@ -1,5 +1,4 @@
-summary:
-  Nanobind downstream example
+summary: Nanobind downstream example
 adjust:
   enabled: false
   because: Nanobind is not yet packaged on Fedora

--- a/docs/examples/downstream/nanobind_example/main.fmf
+++ b/docs/examples/downstream/nanobind_example/main.fmf
@@ -3,4 +3,4 @@ adjust:
   enabled: false
   because: Nanobind is not yet packaged on Fedora
 #require+:
-#  - python3-nanobind
+#  - python3dist(nanobind)

--- a/docs/examples/downstream/pybind11_example/main.fmf
+++ b/docs/examples/downstream/pybind11_example/main.fmf
@@ -1,5 +1,4 @@
-summary:
-  Pybind downstream example
+summary: Pybind downstream example
 require+:
   - gcc-c++
   - pybind11-devel

--- a/docs/examples/downstream/pybind11_example/main.fmf
+++ b/docs/examples/downstream/pybind11_example/main.fmf
@@ -1,4 +1,4 @@
 summary: Pybind downstream example
 require+:
   - gcc-c++
-  - pybind11-devel
+  - python3dist(pybind11)

--- a/docs/examples/getting_started/abi3/main.fmf
+++ b/docs/examples/getting_started/abi3/main.fmf
@@ -1,2 +1,1 @@
-summary:
-  Abi3 example project
+summary: Abi3 example project

--- a/docs/examples/getting_started/c/main.fmf
+++ b/docs/examples/getting_started/c/main.fmf
@@ -1,2 +1,1 @@
-summary:
-  C example project
+summary: C example project

--- a/docs/examples/getting_started/cython/main.fmf
+++ b/docs/examples/getting_started/cython/main.fmf
@@ -1,4 +1,3 @@
-summary:
-  Cython example project
+summary: Cython example project
 require+:
   - python3-cython

--- a/docs/examples/getting_started/cython/main.fmf
+++ b/docs/examples/getting_started/cython/main.fmf
@@ -1,3 +1,3 @@
 summary: Cython example project
 require+:
-  - python3-cython
+  - python3dist(cython)

--- a/docs/examples/getting_started/fortran/main.fmf
+++ b/docs/examples/getting_started/fortran/main.fmf
@@ -1,5 +1,5 @@
 summary: F2PY example project
 require+:
   - gcc-gfortran
-  - python3-numpy
+  - python3dist(numpy)
   - python3-numpy-f2py

--- a/docs/examples/getting_started/fortran/main.fmf
+++ b/docs/examples/getting_started/fortran/main.fmf
@@ -1,5 +1,4 @@
-summary:
-  F2PY example project
+summary: F2PY example project
 require+:
   - gcc-gfortran
   - python3-numpy

--- a/docs/examples/getting_started/nanobind/main.fmf
+++ b/docs/examples/getting_started/nanobind/main.fmf
@@ -3,4 +3,4 @@ adjust:
   enabled: false
   because: Nanobind is not yet packaged on Fedora
 #require+:
-#  - python3-nanobind
+#  - python3dist(nanobind)

--- a/docs/examples/getting_started/nanobind/main.fmf
+++ b/docs/examples/getting_started/nanobind/main.fmf
@@ -1,5 +1,4 @@
-summary:
-  Nanobind example project
+summary: Nanobind example project
 adjust:
   enabled: false
   because: Nanobind is not yet packaged on Fedora

--- a/docs/examples/getting_started/pybind11/main.fmf
+++ b/docs/examples/getting_started/pybind11/main.fmf
@@ -1,5 +1,4 @@
-summary:
-  Pybind example project
+summary: Pybind example project
 require+:
   - gcc-c++
   - pybind11-devel

--- a/docs/examples/getting_started/pybind11/main.fmf
+++ b/docs/examples/getting_started/pybind11/main.fmf
@@ -1,4 +1,4 @@
 summary: Pybind example project
 require+:
   - gcc-c++
-  - pybind11-devel
+  - python3dist(pybind11)

--- a/docs/examples/getting_started/swig/main.fmf
+++ b/docs/examples/getting_started/swig/main.fmf
@@ -1,4 +1,3 @@
-summary:
-  Swig example project
+summary: Swig example project
 require+:
   - swig

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -12,13 +12,15 @@ rlJournalStart
         fi
         rlRun "pushd $tmp"
         rlRun "tree" 0 "Show directory tree"
+        rlRun "python3 -m venv .venv --system-site-packages" 0 "Create venv with system packages"
+        rlRun "source .venv/bin/activate" 0 "Activate venv"
         rlRun "set -o pipefail"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "pip install --user . --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
+        rlRun "pip install . -v --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
         if [ "${HAS_PYTEST}" == True ]; then
-          rlRun "pytest" 0 "Run built-in pytest"
+          rlRun "python3 -m pytest" 0 "Run built-in pytest"
         else
           rlRun "python3 test.py" 0 "Test project is installed correctly"
         fi

--- a/docs/examples/test.sh
+++ b/docs/examples/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "pip install . -v --config-settings=cmake.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
+        rlRun "pip install . -v --config-settings=build.verbose=true --no-index --no-build-isolation" 0 "Build the python project"
         if [ "${HAS_PYTEST}" == True ]; then
           rlRun "python3 -m pytest" 0 "Run built-in pytest"
         else


### PR DESCRIPTION
- hotfix for #799 (doesn't need new release, I've already pushed the changes downstream)
- reformat the fmf files to look more like yaml
- install doc examples in their own `venv`