### PR TITLE
fix: avoid providing prepare-metadata methods if rebuild is True

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -212,6 +212,10 @@ wheel.cmake = false
 
 :::
 
+If this override is present in your pyproject.toml file, scikit-build-core will not
+provide the `prepare_metadata_*` hooks, as it can't know without building if the build
+will fail.
+
 ## Any matching condition
 
 If you use `if.any` instead of `if`, then the override is true if any one of the

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -78,9 +78,7 @@ def _has_safe_metadata() -> bool:
     overrides = pyproject.get("tool", {}).get("scikit-build", {}).get("overrides", [])
     for override in overrides:
         if_override = override.get("if", {})
-        if if_override.get("failed", False) or if_override.get("any", {}).get(
-            "failed", False
-        ):
+        if "failed" in if_override or "failed" in if_override.get("any", {}):
             return False
 
     return True


### PR DESCRIPTION
Reported in https://github.com/rapidfuzz/RapidFuzz/pull/397.

This avoids declaring the optional hooks if there's a good chance it can't be computed reliably. Having an override with `failed` can't be computed without trying to build.