### PR TITLE
Bump Ruff to 0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: "^tests"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.0
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,6 @@ extend-select = [
 ]
 ignore = [
     "PLE1205", # Format check doesn't work with our custom logger
-    "PT004",   # Incorrect, just usefixtures instead.
     "PT013",   # It's correct to import classes for typing!
     "RUF009",  # Too easy to get a false positive
     "PYI025",  # Wants Set to be renamed AbstractSet
@@ -268,8 +267,6 @@ ignore = [
     "PLR09",   # Too many ...
     "PLR2004", # Magic value used in comparison
     "PLC0415", # Import should be at top of file
-    "ANN101",  # Missing type annotation for `self` in method
-    "ANN102",  # Missing type annotation for `cls` in classmethod
     "ANN401",  # Disallow dynamically typed expressions
     "S101",    # Use of assert detected
     "S603",    # subprocess untrusted input

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -21,7 +21,7 @@ if typing.TYPE_CHECKING:
     else:
         from importlib.metadata import EntryPoints
 
-__all__ = ["entry_points", "PathDistribution", "version"]
+__all__ = ["PathDistribution", "entry_points", "version"]
 
 
 def entry_points(*, group: str) -> EntryPoints:

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -23,14 +23,14 @@ else:
 from . import __version__
 
 __all__ = [
+    "LEVEL_VALUE",
     "ScikitBuildLogger",
+    "Style",
     "logger",
     "raw_logger",
+    "rich_error",
     "rich_print",
     "rich_warning",
-    "rich_error",
-    "LEVEL_VALUE",
-    "Style",
 ]
 
 

--- a/src/scikit_build_core/ast/ast.py
+++ b/src/scikit_build_core/ast/ast.py
@@ -11,7 +11,7 @@ from .tokenizer import Token, TokenType, tokenize
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-__all__ = ["Node", "Block", "parse"]
+__all__ = ["Block", "Node", "parse"]
 
 
 def __dir__() -> list[str]:
@@ -20,7 +20,7 @@ def __dir__() -> list[str]:
 
 @dataclasses.dataclass(frozen=True)
 class Node:
-    __slots__ = ("name", "value", "start", "stop")
+    __slots__ = ("name", "start", "stop", "value")
 
     name: str
     value: str

--- a/src/scikit_build_core/ast/tokenizer.py
+++ b/src/scikit_build_core/ast/tokenizer.py
@@ -45,7 +45,7 @@ class TokenType(enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class Token:
-    __slots__ = ("type", "start", "stop", "value")
+    __slots__ = ("start", "stop", "type", "value")
 
     type: TokenType
     start: int

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -110,8 +110,8 @@ if _has_safe_metadata():
         ).wheel_filename  # actually returns the dist-info directory
 
     __all__ += [
-        "prepare_metadata_for_build_wheel",
         "prepare_metadata_for_build_editable",
+        "prepare_metadata_for_build_wheel",
     ]
 
 

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -103,10 +103,8 @@ class GetRequires:
             return
 
         # On Windows MSVC, Ninja is not default
-        if (
-            self.settings.fail
-            or sysconfig.get_platform().startswith("win")
-            and use_ninja is None
+        if self.settings.fail or (
+            sysconfig.get_platform().startswith("win") and use_ninja is None
         ):
             return
 


### PR DESCRIPTION
Hi! I just released Ruff 0.8.0. This release removes a few rules that had been deprecated for a few releases, so Ruff 0.8.0 would have started emitting warnings when linting `scikit-build-core` due to the fact that you have some of these now-removed rules explicitly ignored in your Ruff config.

This PR gets rid of the removed rules from your Ruff config. There's also some additional changes made here due to some rule stabilisations in this release -- let me know if these are unwelcome, and I can add them to the `tool.ruff.lint.ignore` list:
- Several files have had minor changes made due to the stabilisations of [`unsorted-dunder-all`](https://docs.astral.sh/ruff/rules/unsorted-dunder-all/) (`RUF022`) and [`unsorted-dunder-slots`](https://docs.astral.sh/ruff/rules/unsorted-dunder-slots/) (`RUF023`)
- `src/scikit_build_core/builder/get_requires.py` has been changed slightly due to the stabilisation of [`parenthesize-chained-operators`](https://docs.astral.sh/ruff/rules/parenthesize-chained-operators/) (`RUF021`)