### PR TITLE
docs: Fix instructions to check if `Development.SABIModule` was requested

### DIFF
--- a/docs/cmakelists.md
+++ b/docs/cmakelists.md
@@ -36,7 +36,8 @@ related to making Python extension modules.
 
 If you are making a Limited API / Stable ABI package, you'll need the
 `Development.SABIModule` component instead (CMake 3.26+). You can use the
-`Python_Development.SABIModule_FOUND` variable to check to see if it was requested.
+`Python_Development.SABIModule_FOUND` variable to check to see if it was
+requested.
 
 <!-- prettier-ignore-start -->
 :::{warning}

--- a/docs/cmakelists.md
+++ b/docs/cmakelists.md
@@ -36,7 +36,7 @@ related to making Python extension modules.
 
 If you are making a Limited API / Stable ABI package, you'll need the
 `Development.SABIModule` component instead (CMake 3.26+). You can use the
-`Python_Development.SABIModule_FOUND` variable to check to see if it was
+`SKBUILD_SABI_COMPONENT` variable to check to see if it was
 requested.
 
 <!-- prettier-ignore-start -->

--- a/docs/cmakelists.md
+++ b/docs/cmakelists.md
@@ -36,7 +36,7 @@ related to making Python extension modules.
 
 If you are making a Limited API / Stable ABI package, you'll need the
 `Development.SABIModule` component instead (CMake 3.26+). You can use the
-`SKBUILD_LIMITED_API` variable to check to see if it was requested.
+`Python_Development.SABIModule_FOUND` variable to check to see if it was requested.
 
 <!-- prettier-ignore-start -->
 :::{warning}

--- a/docs/cmakelists.md
+++ b/docs/cmakelists.md
@@ -36,8 +36,7 @@ related to making Python extension modules.
 
 If you are making a Limited API / Stable ABI package, you'll need the
 `Development.SABIModule` component instead (CMake 3.26+). You can use the
-`SKBUILD_SABI_COMPONENT` variable to check to see if it was
-requested.
+`SKBUILD_SABI_COMPONENT` variable to check to see if it was requested.
 
 <!-- prettier-ignore-start -->
 :::{warning}


### PR DESCRIPTION
This fixes instructions originally introduced in 48a879b ("docs: some updates (#334)", 2023-05-23)