### PR TITLE
fix: longer timeout on Windows

### DIFF
--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -32,8 +32,10 @@ __all__ = [
 def __dir__() -> list[str]:
     return __all__
 
+
 # Make sure we don't wait forever for programs to respond
 TIMEOUT = 10 if sys.platform.startswith("win") else 4
+
 
 class Program(NamedTuple):
     path: Path


### PR DESCRIPTION
Make sure this doesn't trigger unless it's locked up. Windows can take more than 2 seconds to respond in our CI.