### PR TITLE
fix: path_to_module to handle hidden files (e.g. .clang-tidy) correctly

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -70,6 +70,7 @@ def libdir_to_installed(libdir: Path) -> dict[str, str]:
     Convert a mapping of files to modules to a mapping of modules to installed files.
     """
     return {
-        path_to_module(v.relative_to(libdir)): str(v.relative_to(libdir))
+        path_to_module(pth): str(pth)
         for v in scantree(libdir)
+        if is_valid_module(pth := v.relative_to(libdir))
     }

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,7 +28,7 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    path = path.with_name(path.name.split(".", 1)[0])
+    path = path.with_name(path.stem)
     if path.name == "__init__":
         path = path.parent
     return ".".join(path.parts)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,10 +28,7 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    if path.name.startswith("."):
-        path = path.with_name(path.name.split(".", 2)[1])
-    else:
-        path = path.with_name(path.name.split(".", 1)[0])
+    path = path.with_name(path.name.split(".", 1)[0])
     if path.name == "__init__":
         path = path.parent
     return ".".join(path.parts)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,7 +28,10 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    path = path.with_name(path.stem)
+    if path.name.startswith('.'):
+        path = path.with_name(path.name.split(".", 2)[1])
+    else:
+        path = path.with_name(path.name.split(".", 1)[0])
     if path.name == "__init__":
         path = path.parent
     return ".".join(path.parts)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,7 +28,9 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    path = path.with_name(path.name.split(".", 1)[0])
+    name, _, _ = path.name.partition(".")
+    assert name, f"Empty name should be filtered by is_valid_module first, got {path}"
+    path = path.with_name(name)
     if path.name == "__init__":
         path = path.parent
     return ".".join(path.parts)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,7 +28,7 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    if path.name.startswith('.'):
+    if path.name.startswith("."):
         path = path.with_name(path.name.split(".", 2)[1])
     else:
         path = path.with_name(path.name.split(".", 1)[0])

--- a/tests/packages/navigate_editable/CMakeLists.txt
+++ b/tests/packages/navigate_editable/CMakeLists.txt
@@ -12,10 +12,13 @@ python_add_library(c_module MODULE src/shared_pkg/c_module.c WITH_SOABI)
 set(CMakeVar "Some_value_C")
 configure_file(src/shared_pkg/data/generated.txt.in
                shared_pkg/data/c_generated.txt)
+configure_file(src/shared_pkg/data/generated.txt.in shared_pkg/data/.hidden)
 
 install(
   TARGETS c_module
   DESTINATION shared_pkg/
   COMPONENT PythonModule)
 install(FILES ${PROJECT_BINARY_DIR}/shared_pkg/data/c_generated.txt
+        DESTINATION shared_pkg/data/)
+install(FILES ${PROJECT_BINARY_DIR}/shared_pkg/data/.hidden
         DESTINATION shared_pkg/data/)


### PR DESCRIPTION
It works fine with normal install `pip install .` but not for editable install `pip install -e .`

I got the error below without this fix because it can't handle hidden file's extension corretly:
```
    File "/opt/miniconda3/envs/pyapl/lib/python3.12/site-packages/scikit_build_core/build/_pathutil.py", line 31, in path_to_module
      path = path.with_name(path.name.split(".", 1)[0])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/miniconda3/envs/pyapl/lib/python3.12/pathlib.py", line 634, in with_name
      raise ValueError("Invalid name %r" % (name))
  ValueError: Invalid name ''
```
For example, if it's `.clang-tidy`, the original splitting `path.name.split(".", 1)[0]` results empty string.