### PR TITLE
Initial support for `cmake.preset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ cmake.build-type = "Release"
 # The source directory to use when building the project.
 cmake.source-dir = "."
 
+# Configure preset to use. ``cmake.source-dir`` must still be appropriately defined
+cmake.preset = ""
+
 # The versions of Ninja to allow.
 ninja.version = ">=1.5"
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -200,6 +200,17 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: cmake.preset
+  :type: ``str``
+
+  Configure preset to use. ``cmake.source-dir`` must still be appropriately defined
+  and it must contain a ``CMake(User)Presets.json``. The preset's ``binaryDir`` is
+  ignored and is always overwritten by the ``build-dir`` defined by scikit-build-core.
+  ``cmake.define``, generator values are still passed if defined and take precedence
+  over preset's value according to CMake logic.
+```
+
+```{eval-rst}
 .. confval:: cmake.source-dir
   :type: ``Path``
   :default: "."

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -292,6 +292,7 @@ class Builder:
         cmake_defines.update(self.settings.cmake.define)
 
         self.config.configure(
+            preset=self.settings.cmake.preset,
             defines=cmake_defines,
             cmake_args=[*self.get_cmake_args(), *configure_args],
         )

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -90,6 +90,7 @@ def set_environment_for_gen(
 
     If gen is not None, then that will be the target generator.
     """
+    # TODO: How does make_fallback interact when `preset` is set?
     allow_make_fallback = ninja_settings.make_fallback
 
     if generator:

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -12,11 +12,18 @@ import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from packaging.version import Version
+
 from . import __version__
 from ._compat.builtins import ExceptionGroup
 from ._logging import logger
 from ._shutil import Run
-from .errors import CMakeConfigError, CMakeNotFoundError, FailedLiveProcessError
+from .errors import (
+    CMakeConfigError,
+    CMakeNotFoundError,
+    CMakeVersionError,
+    FailedLiveProcessError,
+)
 from .file_api.query import stateless_query
 from .file_api.reply import load_reply_dir
 from .program_search import Program, best_program, get_cmake_program, get_cmake_programs
@@ -25,7 +32,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Mapping, Sequence
 
     from packaging.specifiers import SpecifierSet
-    from packaging.version import Version
 
     from ._compat.typing import Self
     from .file_api.model.index import Index
@@ -242,11 +248,18 @@ class CMaker:
     def configure(
         self,
         *,
+        preset: str | None = None,
         defines: Mapping[str, str | os.PathLike[str] | bool] | None = None,
         cmake_args: Sequence[str] = (),
     ) -> None:
         _cmake_args = self._compute_cmake_args(defines or {})
         all_args = [*_cmake_args, *cmake_args]
+
+        if preset:
+            if self.cmake.version < Version("3.19"):
+                msg = f"CMake version ({self.cmake.version}) is too old to support presets."
+                raise CMakeVersionError(msg)
+            all_args.append(f"--preset={preset}")
 
         gen = self.get_generator(*all_args)
         if gen:

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -102,6 +102,10 @@
           },
           "description": "DEPRECATED in 0.10; use build.targets instead.",
           "deprecated": true
+        },
+        "preset": {
+          "type": "string",
+          "description": "Configure preset to use. ``cmake.source-dir`` must still be appropriately defined"
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -133,6 +133,15 @@ class CMakeSettings:
     DEPRECATED in 0.10; use build.targets instead.
     """
 
+    preset: Optional[str] = None
+    """
+    Configure preset to use. ``cmake.source-dir`` must still be appropriately defined
+    and it must contain a ``CMake(User)Presets.json``. The preset's ``binaryDir`` is
+    ignored and is always overwritten by the ``build-dir`` defined by scikit-build-core.
+    ``cmake.define``, generator values are still passed if defined and take precedence
+    over preset's value according to CMake logic.
+    """
+
 
 @dataclasses.dataclass
 class SearchSettings:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -285,8 +285,12 @@ class SettingsReader:
                 new_min_cmake = "3.15"
             self.settings.cmake.version = SpecifierSet(f">={new_min_cmake}")
 
+        default_cmake_minimum = "3.15"
+        if self.settings.cmake.preset:
+            default_cmake_minimum = "3.19"
+
         _handle_minimum_version(
-            self.settings.cmake, self.settings.minimum_version, "3.15"
+            self.settings.cmake, self.settings.minimum_version, default_cmake_minimum
         )
         _handle_minimum_version(self.settings.ninja, self.settings.minimum_version)
 

--- a/tests/packages/cmake_defines/CMakeLists.txt
+++ b/tests/packages/cmake_defines/CMakeLists.txt
@@ -7,9 +7,18 @@ set(ONE_LEVEL_LIST
 set(NESTED_LIST
     ""
     CACHE STRING "")
+set(PRESET_ONLY_VAR
+    ""
+    CACHE STRING "")
+set(OVERWRITTEN_VAR
+    ""
+    CACHE STRING "")
 
 set(out_file "${CMAKE_CURRENT_BINARY_DIR}/log.txt")
 file(WRITE "${out_file}" "")
+
+file(APPEND "${out_file}" "PRESET_ONLY_VAR=${PRESET_ONLY_VAR}\n")
+file(APPEND "${out_file}" "OVERWRITTEN_VAR=${OVERWRITTEN_VAR}\n")
 
 foreach(list IN ITEMS ONE_LEVEL_LIST NESTED_LIST)
   list(LENGTH ${list} length)

--- a/tests/packages/cmake_defines/CMakePresets.json
+++ b/tests/packages/cmake_defines/CMakePresets.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "scikit",
+      "cacheVariables": {
+        "PRESET_ONLY_VAR": "defined",
+        "OVERWRITTEN_VAR": "original"
+      },
+      "binaryDir": "/dev/null",
+      "generator": "Ninja"
+    }
+  ]
+}

--- a/tests/packages/cmake_defines/pyproject.toml
+++ b/tests/packages/cmake_defines/pyproject.toml
@@ -9,3 +9,8 @@ ONE_LEVEL_LIST = [
     "Baz",
 ]
 NESTED_LIST = [ "Apple", "Lemon;Lime", "Banana" ]
+OVERWRITTEN_VAR = "overwritten"
+
+[[tool.scikit-build.overrides]]
+if.env.WITH_PRESET = true
+cmake.preset = "scikit"

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -790,6 +790,7 @@ def test_skbuild_settings_cmake_define_list():
     assert settings.cmake.define == {
         "NESTED_LIST": r"Apple;Lemon\;Lime;Banana",
         "ONE_LEVEL_LIST": "Foo;Bar;ExceptionallyLargeListEntryThatWouldOverflowTheLine;Baz",
+        "OVERWRITTEN_VAR": "overwritten",
     }
 
 


### PR DESCRIPTION
Back in #790 I commented that we could support `configurePresets` if we overwrite the `binarydir`. It seems to work fine, but I realized we still have an issue to discuss how to deal with the generator. My thinking is that depending on `make-fallback` value and if `preset` is present we deffer to the value of `preset` and let it handle the rest. Although not sure how to detect/handle multi-config then, but wouldn't it build all configs if it wasn't specified explicitly? The documentation of `make-fallback` is also confusing me a bit.

PS: it took me way too long to figure out `nox -t gen` was a thing :facepalm: 
