### PR TITLE
fix: RTD builds when last git tag is more than 50 commits behind

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+  # Unshallow the git clone to allow vcs versioning to pick
+  # up tags properly
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ build:
   # up tags properly
   jobs:
     post_checkout:
-      - git fetch --unshallow || true
+      - git fetch --unshallow
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Description

At the time of writing, the "latest" version of the scikit-build-core documentation website (https://scikit-build-core.readthedocs.io/en/latest/) shows documentation pages from an ancient version. This pull request _should_ fix that.

## Additional context

https://docs.readthedocs.com/platform/stable/build-customization.html#unshallow-git-clone