### PR TITLE
chore: bump pytest version and include pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         run: pip list
 
       - name: Test min package
-        run: pytest -ra --showlocals -Wdefault
+        run: pytest -n auto -ra --showlocals -Wdefault
 
   manylinux:
     name: Manylinux on 🐍 3.13 • Free-threaded
@@ -222,7 +222,7 @@ jobs:
         run: /venv/bin/pip install -e .[test] ninja
 
       - name: Test package
-        run: /venv/bin/pytest
+        run: /venv/bin/pytest -n auto
 
   cygwin:
     name: Tests on 🐍 3.9 • cygwin
@@ -246,7 +246,7 @@ jobs:
 
       - name: Test package
         run:
-          python3.9 -m pytest -ra --showlocals -m "not virtualenv"
+          python3.9 -m pytest -n auto -ra --showlocals -m "not virtualenv"
           --durations=20
 
   msys:
@@ -279,7 +279,7 @@ jobs:
 
       - name: Test package
         run: >-
-          python -m pytest -ra --showlocals -m "not broken_on_urct"
+          python -m pytest -n auto -ra --showlocals -m "not broken_on_urct"
           --durations=20
 
   mingw64:
@@ -312,7 +312,7 @@ jobs:
 
       - name: Test package
         run: >-
-          python -m pytest -ra --showlocals -m "not setuptools" --durations=20
+          python -m pytest -n augo -ra --showlocals -m "not setuptools" --durations=20
         env:
           SETUPTOOLS_USE_DISTUTILS: "local"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Test package
         run: >-
-          python -m pytest -n augo -ra --showlocals -m "not setuptools"
+          python -m pytest -n auto -ra --showlocals -m "not setuptools"
           --durations=20
         env:
           SETUPTOOLS_USE_DISTUTILS: "local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,8 @@ jobs:
 
       - name: Test package
         run: >-
-          python -m pytest -n augo -ra --showlocals -m "not setuptools" --durations=20
+          python -m pytest -n augo -ra --showlocals -m "not setuptools"
+          --durations=20
         env:
           SETUPTOOLS_USE_DISTUTILS: "local"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         run: /venv/bin/pip install -e .[test] ninja
 
       - name: Test package
-        run: /venv/bin/pytest -n auto
+        run: /venv/bin/pytest
 
   cygwin:
     name: Tests on 🐍 3.9 • cygwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,13 @@ jobs:
         run:
           uv pip install
           -e.[test,test-meta,test-numpy,test-schema,test-hatchling,wheels,cov,wheel-free-setuptools]
-          pytest-xdist --system
+          --system
 
       - name: Install package (pip)
         if: matrix.python-version == 'pypy-3.8'
         run:
           pip install
           -e.[test,test-meta,test-numpy,test-schema,wheels,cov,wheel-free-setuptools]
-          pytest-xdist
 
       - name: Test package
         if: "!contains(matrix.python_version, 'pypy')"

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ strict-config = true
 experimental = false
 
 # If set, this will provide a method for backward compatibility.
-minimum-version = "0.10"  # current version
+minimum-version = "0.11"  # current version
 
 # The build directory. Defaults to a temporary directory, but can be set.
 build-dir = ""

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,7 +74,7 @@ def _run_tests(
         posargs.append("--cov-config=pyproject.toml")
 
     install_arg = f"-e.[{','.join(_extras)}]"
-    session.install(install_arg, *install_args, "pytest-xdist", silent=False)
+    session.install(install_arg, *install_args, silent=False)
     session.run("pytest", *run_args, *posargs, env=env)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ test = [
     "pip>=23; python_version<'3.13'",
     "pip>=24.1; python_version>='3.13'",
     "pybind11 >=2.11",
-    "pytest >=7.0",  # 7.2+ recommended for better tracebacks with ExceptionGroup
+    "pytest >=7.2",
     "pytest-subprocess >=1.5",
+    'pytest-xdist >=3.1',
     'setuptools >=43; python_version<"3.9"',
     'setuptools >=45; python_version=="3.9"',
     'setuptools >=49; python_version>="3.10" and python_version<"3.12"',
@@ -126,14 +127,13 @@ build.hooks.vcs.version-file = "src/scikit_build_core/_version.py"
 
 [tool.uv]
 dev-dependencies = ["scikit-build-core[test,test-hatchling,test-meta,test-numpy,test-schema,cov,dev]"]
-environments = ["python_version >= '3.11'"]
 pip.reinstall-package = ["scikit-build-core"]
 workspace.members = ["tmp/hello/hello"]
 
 
 [tool.pytest.ini_options]
-minversion = "7.0"
-addopts = ["-rfEsX", "--strict-markers", "--strict-config"]
+minversion = "7.2"
+addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
     "error",


### PR DESCRIPTION
Minor cleanup. Require pytest 7.2+.
