### PR TITLE
fix: Ignore deprecation message from cattrs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ filterwarnings = [
     "default:The distutils.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning",  # Caused by setuptools sometimes
     "default:check_home argument is deprecated and ignored.:DeprecationWarning",  # Caused by setuptools sometimes
     "ignore::scikit_build_core._vendor.pyproject_metadata.errors.ConfigurationWarning",
+    "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning",  # From cattrs 24.1.2 and other?
 ]
 log_cli_level = "info"
 pythonpath = ["tests/utils"]


### PR DESCRIPTION
Deprecation message introduced in Python3.14. Filed upstream issue: https://github.com/python-attrs/cattrs/issues/635