### PR TITLE
docs: fix incorrect name (PYBIND11_NEWPYTHON)

### DIFF
--- a/docs/examples/getting_started/pybind11/CMakeLists.txt
+++ b/docs/examples/getting_started/pybind11/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
-set(PYBIND11_NEWPYTHON ON)
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(example example.cpp)

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -268,7 +268,7 @@ CMake from searching for both `C` and `CXX` compilers (the default).
 
 If you place find Python first, pybind11 will respect it instead of the classic
 FindPythonInterp/FindPythonLibs mechanisms, which work, but are not as modern.
-Here we set `PYBIND11_NEWPYTHON` to `ON` instead of doing the find Python
+Here we set `PYBIND11_FINDPYTHON` to `ON` instead of doing the find Python
 ourselves. Pybind11 places its config file such that CMake can find it from
 site-packages.
 


### PR DESCRIPTION
See https://github.com/mlc-ai/xgrammar/pull/249.
