### PR TITLE
docs: fix incorrect configuration example

### DIFF
--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -113,8 +113,8 @@ the `site-packages` folder where the project will be installed or the build
 isolation's `site-packages` folder. This default can be disabled by setting
 
 ```toml
-[tool.scikit-build.search]
-site-packages = false
+[tool.scikit-build]
+search.site-packages = false
 ```
 
 Additionally, scikit-build-core reads the entry-point `cmake.prefix` of the

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -114,7 +114,7 @@ isolation's `site-packages` folder. This default can be disabled by setting
 
 ```toml
 [tool.scikit-build.search]
-search.use-site-packages = false
+site-packages = false
 ```
 
 Additionally, scikit-build-core reads the entry-point `cmake.prefix` of the


### PR DESCRIPTION
The documentation provides an incorrect example for disabling `site-packages` when searching for CMake configs. It should align with the value specified in the [schema](https://github.com/scikit-build/scikit-build-core/blob/main/src/scikit_build_core/resources/scikit-build.schema.json#L414)