### PR TITLE
ci: restore example builds for Windows/macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,9 +331,12 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@v2
 
   docs:
-    name: Docs on ubuntu-latest
-    runs-on: ubuntu-latest
+    name: Docs on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -348,12 +351,14 @@ jobs:
           python-versions: "3.12"
 
       - name: Linkcheck
+        if: runner.os == 'Linux'
         run: nox -s docs -- -b linkcheck
 
       - name: Manpage
         run: nox -s docs -- -b man -W
 
       - name: Build docs with warnings as errors
+        if: runner.os == 'Linux'
         run: nox -s docs -- -W
 
       - name: Check examples

--- a/docs/examples/getting_started/c/CMakeLists.txt
+++ b/docs/examples/getting_started/c/CMakeLists.txt
@@ -3,7 +3,7 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(
   Python
-  COMPONENTS Interpreter Development.Module
+  COMPONENTS Development.Module
   REQUIRED)
 
 python_add_library(example MODULE example.c WITH_SOABI)


### PR DESCRIPTION
Trying to track down a Windows bug where we can't find the correct library to link to but FindPython can, but only when Interpreter is specified.
