### PR TITLE
fix: make sure all paths are CMake paths

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -232,15 +232,15 @@ class Builder:
         numpy_include_dir = get_numpy_include_dir()
 
         # Classic Find Python
-        cache_config["PYTHON_EXECUTABLE"] = sys.executable
+        cache_config["PYTHON_EXECUTABLE"] = Path(sys.executable)
         cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir
         if python_library:
             cache_config["PYTHON_LIBRARY"] = python_library
 
         # Modern Find Python
         for prefix in ("Python", "Python3"):
-            cache_config[f"{prefix}_EXECUTABLE"] = sys.executable
-            cache_config[f"{prefix}_ROOT_DIR"] = sys.prefix
+            cache_config[f"{prefix}_EXECUTABLE"] = Path(sys.executable)
+            cache_config[f"{prefix}_ROOT_DIR"] = Path(sys.prefix)
             cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
             cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
             # FindPython may break if this is set - only useful on Windows

--- a/tests/packages/dynamic_metadata/CMakeLists.txt
+++ b/tests/packages/dynamic_metadata/CMakeLists.txt
@@ -11,3 +11,5 @@ set(Python_SOABI ${SKBUILD_SOABI})
 python_add_library(_module MODULE src/module.c WITH_SOABI)
 
 install(TARGETS _module DESTINATION ${SKBUILD_PROJECT_NAME})
+install(
+  CODE "execute_process(COMMAND ${Python_EXECUTABLE} -V COMMAND_ECHO STDOUT)")


### PR DESCRIPTION
Fix #1061. All paths need to be of type Path so they are converted to CMake paths and the type is correct (PATH).