### PR TITLE
fix: typo in license-files

### DIFF
--- a/src/scikit_build_core/metadata/__init__.py
+++ b/src/scikit_build_core/metadata/__init__.py
@@ -25,7 +25,7 @@ _LIST_STR_FIELDS = frozenset(
         "classifiers",
         "keywords",
         "dependencies",
-        "license_files",
+        "license-files",
     ]
 )
 


### PR DESCRIPTION
Noticed in https://github.com/scikit-build/dynamic-metadata/pull/39.