### PR TITLE
ci: add graalpy

### DIFF
--- a/.github/workflows/ci-graalpy.yml
+++ b/.github/workflows/ci-graalpy.yml
@@ -1,0 +1,62 @@
+name: CI (GraalPy)
+
+# GraalPy is slow (a serial test run takes ~35 min) and is therefore opt-in:
+# the job only runs on PRs carrying the "graalpy" label. `labeled` lets adding
+# the label start it without a new push; `synchronize` reruns it on later pushes
+# to an already-labeled PR. Keeping it in its own workflow means toggling labels
+# does not retrigger the main CI workflow.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+permissions: {}
+
+jobs:
+  graalpy:
+    name: 🐍 GraalPy 25.0 • CMake 4.0 on ubuntu-latest
+    runs-on: ubuntu-latest
+    if:
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'graalpy')
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "graalpy-25.0"
+          allow-prereleases: true
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Setup CMake 4.0
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
+        with:
+          cmake-version: "4.0"
+
+      - name: Install package (uv)
+        # --no-config bypasses [tool.uv].exclude-newer, which otherwise filters
+        # out the date-less numpy wheels served by the GraalVM index.
+        run:
+          uv pip install --no-config -e.[wheels,wheel-free-setuptools]
+          --group=dev --system --only-binary=numpy
+          --extra-index-url=https://www.graalvm.org/python/wheels/
+          --index-strategy=unsafe-best-match
+
+      - name: Test package (serial)
+        # GraalPy is too slow for xdist here; run serially.
+        run: pytest -ra -v --showlocals --durations=20
+        env:
+          PIP_ONLY_BINARY: numpy
+          PIP_EXTRA_INDEX_URL: https://www.graalvm.org/python/wheels/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,11 +115,12 @@ test-meta = [
 ]
 test-numpy = [
     { include-group = "test-core" },
-    "numpy>=1.24.1; python_version<'3.15' and platform_python_implementation!='PyPy' and (platform_system != 'Windows' or platform_machine != 'ARM64')",
+    "numpy>=1.24.1; python_version<'3.15' and platform_python_implementation!='PyPy' and implementation_name!='graalpy' and (platform_system != 'Windows' or platform_machine != 'ARM64')",
     "numpy~=1.24.1; python_version=='3.8' and platform_python_implementation=='PyPy'",
     "numpy~=2.0; python_version=='3.9' and platform_python_implementation=='PyPy'",
     "numpy~=2.2; python_version=='3.10' and platform_python_implementation=='PyPy'",
     "numpy~=2.4.1; python_version=='3.11' and platform_python_implementation=='PyPy'",
+    "numpy==2.2.4; python_version=='3.12' and implementation_name=='graalpy' and platform_system != 'Darwin'",
 ]
 test-pybind11 = [
     { include-group = "test-core" },

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -458,7 +458,9 @@ def test_is_module():
 )
 def test_is_module_rejects_versioned_sonames():
     assert is_module(Path("tango/_tango.so"))
-    assert is_module(Path("tango/_tango.abi3.so"))
+    if ".abi3.so" in importlib.machinery.EXTENSION_SUFFIXES:
+        # GraalPy and other non-CPython interpreters may not support abi3.
+        assert is_module(Path("tango/_tango.abi3.so"))
 
     # Versioned sonames are not importable (PEP 3149); they alias the real
     # _tango.so and must not resolve as the module (issue #1144).

--- a/tests/test_fortran.py
+++ b/tests/test_fortran.py
@@ -1,4 +1,5 @@
 import shutil
+import sys
 import sysconfig
 import zipfile
 from pathlib import Path
@@ -37,6 +38,10 @@ ninja_info = best_program(get_ninja_programs(), version=SpecifierSet(">=1.10"))
 )
 @pytest.mark.skipif(
     ninja_info is None, reason="Ninja needs to be 1.10+ to support Fortran with CMake"
+)
+@pytest.mark.skipif(
+    sys.implementation.name == "graalpy",
+    reason="GraalPy segfaults calling a Fortran extension through numpy",
 )
 def test_pep517_wheel(tmp_path, monkeypatch, virtualenv):
     dist = tmp_path / "dist"


### PR DESCRIPTION
Hitting an issue in https://github.com/scikit-hep/boost-histogram/pull/1016:

```
 <         File "/tmp/pip-build-env-n4l8ms0l/overlay/lib/python3.11/site-
    packages/scikit_build_core/build/metadata.py", line 44, in
    get_standard_metadata
  <           new_pyproject_dict["project"] = process_dynamic_metadata(
  <         File "/tmp/pip-build-env-n4l8ms0l/overlay/lib/python3.11/site-
    packages/scikit_build_core/builder/_load_provider.py", line 149, in
    process_dynamic_metadata
  <           return dict(settings)
  <         File "/opt/_internal/graalpy311-
    graalpy242_311_native/lib/python3.11/_collections_abc.py", line 837, in
    __iter__
  <           yield from self._mapping
  <         File "/tmp/pip-build-env-n4l8ms0l/overlay/lib/python3.11/site-
    packages/scikit_build_core/builder/_load_provider.py", line 128, in __iter__
  <           yield from self.providers
  <       RuntimeError: dictionary changed size during iteration
```

Let's see if we can reproduce in tests.
