### PR TITLE
chore: show platform info

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import platform
 import shutil
+import sys
 import sysconfig
 import tempfile
 from collections.abc import Mapping
@@ -258,6 +260,12 @@ def _build_wheel_impl_impl(
         "{green}*** {bold}scikit-build-core {__version__}",
         *cmake_msg,
         f"{{red}}({state})",
+    )
+    logger.info(
+        "Implementation: {} {} on {}",
+        sys.implementation.name,
+        sys.platform,
+        platform.machine(),
     )
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -18,7 +18,7 @@ from ..cmake import CMake
 from ..errors import CMakeNotFoundError
 from ..resources import resources
 
-__all__ = ["process_overides", "regex_match"]
+__all__ = ["process_overrides", "regex_match"]
 
 
 def __dir__() -> list[str]:
@@ -257,7 +257,7 @@ def inherit_join(
     raise TypeError(msg)
 
 
-def process_overides(
+def process_overrides(
     tool_skb: dict[str, Any],
     *,
     state: Literal["sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"],

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -17,7 +17,7 @@ from ..errors import CMakeConfigError
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .skbuild_model import CMakeSettings, NinjaSettings, ScikitBuildSettings
-from .skbuild_overrides import process_overides
+from .skbuild_overrides import process_overrides
 from .sources import ConfSource, EnvSource, SourceChain, TOMLSource
 
 if TYPE_CHECKING:
@@ -151,7 +151,7 @@ class SettingsReader:
 
         # Handle overrides
         pyproject = copy.deepcopy(pyproject)
-        self.overrides = process_overides(
+        self.overrides = process_overrides(
             pyproject.get("tool", {}).get("scikit-build", {}),
             state=state,
             env=env,
@@ -188,7 +188,7 @@ class SettingsReader:
 
         if extra_settings is not None:
             extra_skb = copy.deepcopy(dict(extra_settings))
-            process_overides(extra_skb, state=state, env=env, retry=retry)
+            process_overrides(extra_skb, state=state, env=env, retry=retry)
             toml_srcs.insert(0, TOMLSource(settings=extra_skb))
 
         prefixed = {


### PR DESCRIPTION
Adding a little bit of info from overrides. Later it might be nice to print out the whole set of overridable info, but this will at least help for investigating platforms like iOS.
