### PR TITLE
chore: coverage now warns on 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ run.disable_warnings = [
   "module-not-measured",  # Triggers in multithreaded context on build
   "no-sysmon",
   "couldnt-parse",  # site-customize is unparsable on latest GHA windows versions
+  "no-ctracer",     # Not available on Python 3.14, for example
 ]
 report.exclude_also = [
     '\.\.\.',


### PR DESCRIPTION
With warnings as errors, this is now a guaranteed error on 3.14.
