### PR TITLE
ci: avoid Windows 3.13.4, warn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          # Python 3.13.4 broken on Windows
+          check-latest: >-
+            ${{ matrix.python-version == '3.13' && runner.os == 'Windows' }}
 
       - uses: astral-sh/setup-uv@v6
         if: matrix.python-version != 'pypy-3.8'

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -231,6 +231,17 @@ class Builder:
         python_include_dir = get_python_include_dir()
         numpy_include_dir = get_numpy_include_dir()
 
+        # Warning for CPython 3.13.4 Windows bug
+        if (
+            sys.implementation.name == "CPython"
+            and sys.version_info[:3] == (3, 13, 4)
+            and sys.platform.startswith("win32")
+            and not sysconfig.get_config_var("Py_GIL_DISABLED")
+        ):  # pragma: nocover
+            logger.warning(
+                "Python 3.13.4 on Windows is broken for building, 3.13.5 was rushed out to fix it. Use an older, newer, or free-threaded version instead."
+            )
+
         # Classic Find Python
         cache_config["PYTHON_EXECUTABLE"] = Path(sys.executable)
         cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir


### PR DESCRIPTION
Avoid broken 3.13.4 on Windows. It still gets pulled by Actions for now: https://github.com/actions/setup-python/issues/1123