### PR TITLE
docs: don't link-check GitHub (rate limited)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,8 @@ linkcheck_anchors_ignore = [
     "git-archives",
 ]
 linkcheck_ignore = [
-    r"https://github.com/search\?.*",
+    # Rate limited
+    r"https://github.com/?.*",
 ]
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
CI failing due to rate limiting.