### PR TITLE
tests: ignore setuptools-scm warning for packages that don't use it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ filterwarnings = [
     "ignore::scikit_build_core._vendor.pyproject_metadata.errors.ConfigurationWarning",
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning",  # From cattrs 24.1.2 and other?
     "ignore:The 'wheel.metadata' package has been made private:DeprecationWarning",
+    "ignore:version of cmake-example already set:UserWarning",  # Caused by setuptoools-scm 9+ being installed
 ]
 log_cli_level = "INFO"
 pythonpath = ["tests/utils"]


### PR DESCRIPTION
Should fix our CI.
