### PR TITLE
Add exclude-exts options

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -329,8 +329,8 @@ wheel.exclude = ["**.pyx"]
 Previously these were matched on the source path, rather than the wheel path,
 and didn't apply to CMake output.
 
-You can exclude files from the built wheel based on file extension
-as well (not guaranteed to be respected by editable installs):
+You can exclude files from the built wheel based on file extension as well (not
+guaranteed to be respected by editable installs):
 
 ```toml
 [tool.scikit-build]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -329,6 +329,20 @@ wheel.exclude = ["**.pyx"]
 Previously these were matched on the source path, rather than the wheel path,
 and didn't apply to CMake output.
 
+You can exclude files from the built wheel based on file extension
+as well (not guaranteed to be respected by editable installs):
+
+```toml
+[tool.scikit-build]
+wheel.exclude-exts = [".c", ".cuh", ".h"]
+```
+
+Default value: `[".pyc", ".pyo"]`
+
+:::{versionadded} 0.12
+
+Support to exclude based on file extension.
+
 :::
 
 :::{note}

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -148,7 +148,7 @@ class WheelWriter:
         }
 
     def build(
-        self, wheel_dirs: Mapping[str, Path], exclude: Sequence[str] = ()
+        self, wheel_dirs: Mapping[str, Path], exclude: Sequence[str] = (), exclude_exts: Sequence[str] = ()
     ) -> None:
         (targetlib,) = {"platlib", "purelib"} & set(wheel_dirs)
         assert {
@@ -175,7 +175,7 @@ class WheelWriter:
                     continue
                 if any(x.endswith(".dist-info") for x in filename.parts):
                     continue
-                if filename.suffix in {".pyc", ".pyo"}:
+                if filename.suffix in exclude_exts:
                     continue
                 relpath = filename.relative_to(path)
                 if exclude_spec.match_file(relpath):

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -148,7 +148,10 @@ class WheelWriter:
         }
 
     def build(
-        self, wheel_dirs: Mapping[str, Path], exclude: Sequence[str] = (), exclude_exts: Sequence[str] = ()
+        self,
+        wheel_dirs: Mapping[str, Path],
+        exclude: Sequence[str] = (),
+        exclude_exts: Sequence[str] = (),
     ) -> None:
         (targetlib,) = {"platlib", "purelib"} & set(wheel_dirs)
         assert {

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -495,7 +495,11 @@ def _build_wheel_impl_impl(
             ),
             wheel_dirs["metadata"],
         ) as wheel:
-            wheel.build(wheel_dirs, exclude=settings.wheel.exclude, exclude_exts=settings.wheel.exclude_exts)
+            wheel.build(
+                wheel_dirs,
+                exclude=settings.wheel.exclude,
+                exclude_exts=settings.wheel.exclude_exts,
+            )
 
             str_pkgs = (
                 str(Path.cwd().joinpath(p).parent.resolve()) for p in packages.values()

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -495,7 +495,7 @@ def _build_wheel_impl_impl(
             ),
             wheel_dirs["metadata"],
         ) as wheel:
-            wheel.build(wheel_dirs, exclude=settings.wheel.exclude)
+            wheel.build(wheel_dirs, exclude=settings.wheel.exclude, exclude_exts=settings.wheel.exclude_exts)
 
             str_pkgs = (
                 str(Path.cwd().joinpath(p).parent.resolve()) for p in packages.values()

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,4 +1,5 @@
 import dataclasses
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
@@ -305,6 +306,18 @@ class WheelSettings:
     A set of patterns to exclude from the wheel.
 
     This is additive to the SDist exclude patterns. This applies to the final paths
+    in the wheel, and can exclude files from CMake output as well.  Editable installs
+    may not respect this exclusion.
+    """
+
+    exclude_exts: List[str] = dataclasses.field(
+        default_factory=lambda: [".pyc", ".pyo"],
+        metadata=SettingsFieldMetadata(display_default="true"),
+    )
+    """
+    A set of file extensions to exclude from the wheel.
+
+    This is additive to the SDist/Wheel exclude patterns. This applies to the final paths
     in the wheel, and can exclude files from CMake output as well.  Editable installs
     may not respect this exclusion.
     """

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -1,5 +1,4 @@
 import dataclasses
-from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 


### PR DESCRIPTION
This PR adds an `exclude-exts` option to wheel config.

Why not use existing `exclude`?
1. Previously `.pyc` and `.pyo` were hard-coded to be excluded and there was no way to configure this
2. Pattern-based exclusion for file extensions is not always straightforward (e.g., using `**/*.c*` to exclude `*.c`, `*.cpp`, `*.cu*` would accidentally exclude compiled `*.cpython*.so` files)