### PR TITLE
Add option to pass CMake cache file directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ cmake.build-type = "Release"
 # The source directory to use when building the project.
 cmake.source-dir = "."
 
+# CMake cache file to be loaded.
+cmake.cache-file = ""
+
 # The versions of Ninja to allow.
 ninja.version = ">=1.5"
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -186,6 +186,13 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: cmake.cache-file
+  :type: ``Path``
+
+  CMake cache file to be loaded.
+```
+
+```{eval-rst}
 .. confval:: cmake.define
   :type: ``EnvVar``
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -281,6 +281,9 @@ class Builder:
             cache_config.update(cache_entries)
 
         self.config.init_cache(cache_config)
+        cache_file_args = []
+        if self.settings.cmake.cache_file:
+            cache_file_args.append(f"-C{self.settings.cmake.cache_file}")
 
         if sys.platform.startswith("darwin"):
             # Cross-compile support for macOS - respect ARCHFLAGS if set
@@ -293,7 +296,11 @@ class Builder:
 
         self.config.configure(
             defines=cmake_defines,
-            cmake_args=[*self.get_cmake_args(), *configure_args],
+            cmake_args=[
+                *cache_file_args,
+                *self.get_cmake_args(),
+                *configure_args,
+            ],
         )
 
     def build(self, build_args: Sequence[str]) -> None:

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -102,6 +102,10 @@
           },
           "description": "DEPRECATED in 0.10; use build.targets instead.",
           "deprecated": true
+        },
+        "cache-file": {
+          "type": "string",
+          "description": "CMake cache file to be loaded."
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -133,6 +133,11 @@ class CMakeSettings:
     DEPRECATED in 0.10; use build.targets instead.
     """
 
+    cache_file: Optional[Path] = None
+    """
+    CMake cache file to be loaded.
+    """
+
 
 @dataclasses.dataclass
 class SearchSettings:


### PR DESCRIPTION
@eirrgang sorry it took so long to get to this, but this should give you a more direct way to hook your cache-file as needed