### PR TITLE
chore: bump PyPy to currently supported 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           # TODO: investigate failure with pypy-3.9/macos-latest (#1166)
           - python-version: "pypy-3.10"
             runs-on: macos-latest
-            cmake-version: "3.15.x"
+            cmake-version: "4.0.x"
           - python-version: "3.9"
             runs-on: macos-15-intel
             cmake-version: "3.18.x"


### PR DESCRIPTION
Also add test for oldest available version on macOS ~~(3.10)~~.

Fixes #1163.