### PR TITLE
chore: bump macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "pypy-3.10", "3.13", "3.14"]
-        runs-on: [ubuntu-latest, macos-14]
+        runs-on: [ubuntu-latest, macos-latest]
         cmake-version: ["3.15.x"]
 
         include:


### PR DESCRIPTION
The macOS 13 runner will will be retired by 4 December 2025, with jobs using macOS 13 failing temporarily during scheduled brownout time periods starting in November.

[GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)