### PR TITLE
Move the file-api parsing to a debug message

### DIFF
--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -265,7 +265,7 @@ class CMaker:
             if self._file_api_query.exists():
                 self.file_api = load_reply_dir(self._file_api_query)
         except ExceptionGroup as exc:
-            logger.warning("Could not parse CMake file-api")
+            logger.debug("Could not parse CMake file-api")
             logger.debug(str(exc))
 
     def _compute_build_args(


### PR DESCRIPTION
We have known issues where the file-api can fail

Fixes #1130 