### PR TITLE
Break the circular dependency in pybind11

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -1,5 +1,8 @@
 %global debug_package %{nil}
 
+# Whether to run additional tests, enabled by default
+%bcond optional_tests 1
+
 Name:           python-scikit-build-core
 Version:        0.0.0
 Release:        %autorelease
@@ -47,7 +50,7 @@ cp -p src/scikit_build_core/_vendor/pyproject_metadata/LICENSE LICENSE-pyproject
 
 %generate_buildrequires
 export HATCH_METADATA_CLASSIFIERS_NO_VERIFY=1
-%pyproject_buildrequires -g test,test-meta,test-numpy
+%pyproject_buildrequires -g test%{?with_optional_tests:,test-meta,test-numpy,test-pybind11}
 
 
 %build
@@ -62,6 +65,7 @@ export HATCH_METADATA_CLASSIFIERS_NO_VERIFY=1
 
 %check
 %pyproject_check_import
+# Additional tests from optional_tests are automatically skipped/picked-up by pytest
 %pytest \
     -m "not network"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ test = [
     "cattrs >=22.2.0",
     "pip>=23; python_version<'3.13'",
     "pip>=24.1; python_version>='3.13'",
-    "pybind11 >=2.11",
     "pytest >=7.2",
     "pytest-subprocess >=1.5",
     'pytest-xdist >=3.1',
@@ -111,6 +110,10 @@ test-schema = [
     "fastjsonschema",
     "validate-pyproject",
 ]
+test-pybind11 = [
+    { include-group = "test" },
+    "pybind11 >=2.11",
+]
 cov = [
     { include-group = "test" },
     "pytest-cov",
@@ -120,6 +123,7 @@ dev = [
     { include-group = "test-hatchling" },
     { include-group = "test-meta" },
     { include-group = "test-numpy" },
+    { include-group = "test-pybind11" },
     { include-group = "test-schema" },
     "rich",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,6 @@ def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
         "cython",
         "hatchling",
         "pip",
-        "pybind11",
         "setuptools",
         "virtualenv",
         "wheel",
@@ -68,6 +67,9 @@ def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
     if importlib.util.find_spec("ninja") is not None:
         packages.append("ninja")
+
+    if importlib.util.find_spec("pybind11") is not None:
+        packages.append("pybind11")
 
     subprocess.run(
         [
@@ -350,6 +352,11 @@ def protect_get_requires(fp, monkeypatch):
         return orig_find_spec(name, package)
 
     monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+
+@pytest.fixture
+def pybind11():
+    return pytest.importorskip("pybind11")
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -199,7 +199,7 @@ def test_passing_cxx_flags(monkeypatch, env_var, setting, tmp_path: Path):
 
 @pytest.mark.compile
 @pytest.mark.configure
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "pybind11")
 def test_pep517_wheel(virtualenv, tmp_path: Path):
     dist = tmp_path / "dist"
     out = build_wheel(
@@ -252,7 +252,7 @@ def test_pep517_wheel(virtualenv, tmp_path: Path):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.parametrize("package", ["simple_pyproject_source_dir"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 def test_pep517_wheel_source_dir(virtualenv, tmp_path: Path):
     dist = tmp_path / "dist"
     out = build_wheel(str(dist), config_settings={"skbuild.wheel.build-tag": "1foo"})

--- a/tests/test_pyproject_pep518.py
+++ b/tests/test_pyproject_pep518.py
@@ -25,6 +25,7 @@ def compute_uncompressed_hash(inp: Path):
 
 @pytest.mark.network
 @pytest.mark.integration
+@pytest.mark.usefixtures("pybind11")
 def test_pep518_sdist(isolated, package_simple_pyproject_ext, tmp_path: Path):
     correct_metadata = textwrap.dedent(
         """\
@@ -167,7 +168,7 @@ def test_pep518_wheel_sdist_with_cmake_config(
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "pybind11")
 @pytest.mark.parametrize(
     "build_args", [(), ("--wheel",)], ids=["sdist_to_wheel", "wheel_directly"]
 )
@@ -212,7 +213,7 @@ def test_pep518_wheel(isolated, build_args, tmp_path: Path):
 @pytest.mark.parametrize(
     "build_args", [(), ("--wheel",)], ids=["sdist_to_wheel", "wheel_directly"]
 )
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "pybind11")
 def test_pep518_rebuild_build_dir(isolated, tmp_path, build_args):
     isolated.install("build[virtualenv]")
 
@@ -257,7 +258,7 @@ def test_pep518_rebuild_build_dir(isolated, tmp_path, build_args):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "pybind11")
 def test_pep518_pip(isolated):
     isolated.install("-v", ".")
 

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -70,7 +70,7 @@ def test_pep517_sdist(tmp_path: Path):
 @pytest.mark.configure
 @pytest.mark.broken_on_urct
 @pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 def test_pep517_wheel(virtualenv, tmp_path: Path):
     dist = tmp_path / "dist"
     out = build_wheel(str(dist))
@@ -152,7 +152,7 @@ def test_toml_sdist(tmp_path: Path):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.parametrize("package", ["toml_setuptools_ext"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 @pytest.mark.skipif(
     setuptools_version < Version("61.0"), reason="Requires setuptools 61+"
 )
@@ -187,7 +187,7 @@ def test_toml_wheel(virtualenv, tmp_path: Path):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.parametrize("package", ["mixed_setuptools"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 def test_mixed_wheel(virtualenv, tmp_path: Path):
     dist = tmp_path / "dist"
     out = build_wheel(str(dist))

--- a/tests/test_setuptools_pep518.py
+++ b/tests/test_setuptools_pep518.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.setuptools
     strict=False,
 )
 @pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 def test_pep518_wheel(isolated, tmp_path: Path):
     dist = tmp_path / "dist"
     isolated.install("build[virtualenv]")
@@ -57,7 +57,7 @@ def test_pep518_wheel(isolated, tmp_path: Path):
     strict=False,
 )
 @pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
-@pytest.mark.usefixtures("package")
+@pytest.mark.usefixtures("package", "pybind11")
 def test_pep518_pip(isolated):
     isolated.install("-v", ".")
 


### PR DESCRIPTION
I wonder if we could do some other cleanup, like moving `cattrs` and `pytest-xdist` in a group? For now only pybind11 is requiring this separation and not sure what all tests depend on it so hoping the CI can give the list. 