### PR TITLE
chore: switch to typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,10 +98,11 @@ repos:
           - hatchling
           - hatch-vcs
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+  - repo: https://github.com/crate-ci/typos
+    rev: "v1.40.0"
     hooks:
-      - id: codespell
+      - id: typos
+        args: []
         exclude: ^(LICENSE$|src/scikit_build_core/resources/find_python|tests/test_skbuild_settings.py$)
 
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -606,7 +606,7 @@ example:
 
 ```toml
 [tool.scikit-build]
-messages.after-sucesss = "{green}Wheel successfully built"
+messages.after-success = "{green}Wheel successfully built"
 messages.after-failure = """
 {bold.red}Sorry{normal}, build failed. Your platform is {platform.platform}.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,3 +332,7 @@ docstring-code-format = true
 
 [tool.check-sdist]
 sdist-only = ["src/scikit_build_core/_version.py"]
+
+
+[tool.typos.default.extend-words]
+delocate = "delocate"

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -529,10 +529,10 @@ def _build_wheel_impl_impl(
         dist_info = Path(metadata_directory)
         for key, data in dist_info_contents.items():
             path = dist_info / key
-            prevous_data = path.read_bytes()
-            if prevous_data != data:
+            previous_data = path.read_bytes()
+            if previous_data != data:
                 msg = f"Metadata mismatch in {key}"
-                logger.error("{}: {!r} != {!r}", msg, prevous_data, data)
+                logger.error("{}: {!r} != {!r}", msg, previous_data, data)
                 raise AssertionError(msg)
 
     wheel_filename: str = wheel.wheelpath.name

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -141,8 +141,8 @@ def override_match(
             failed_set.add("python-version")
 
     if implementation_name is not None:
-        current_impementation_name = sys.implementation.name
-        match_msg = regex_match(current_impementation_name, implementation_name)
+        current_implementation_name = sys.implementation.name
+        match_msg = regex_match(current_implementation_name, implementation_name)
         if match_msg:
             passed_dict["implementation-name"] = match_msg
         else:
@@ -290,15 +290,15 @@ def record_override(
     *keys: str,
     value: Any,
     tool_skb: dict[str, Any],
-    overriden_items: dict[str, OverrideRecord],
+    overridden_items: dict[str, OverrideRecord],
     passed_all: dict[str, str] | None,
     passed_any: dict[str, str] | None,
 ) -> None:
     full_key = ".".join(keys)
     # Get the original_value to construct the record
-    if full_key in overriden_items:
+    if full_key in overridden_items:
         # We found the original value from a previous override record
-        original_value = overriden_items[full_key].original_value
+        original_value = overridden_items[full_key].original_value
     else:
         # Otherwise navigate the original pyproject table until we resolved all keys
         _dict_or_value = tool_skb
@@ -325,7 +325,7 @@ def record_override(
             # interested in
             original_value = _dict_or_value
     # Now save the override record
-    overriden_items[full_key] = OverrideRecord(
+    overridden_items[full_key] = OverrideRecord(
         key=keys[-1],
         original_value=original_value,
         value=value,
@@ -351,7 +351,7 @@ def process_overrides(
     has_dist_info = Path("PKG-INFO").is_file()
 
     global_matched: set[str] = set()
-    overriden_items: dict[str, OverrideRecord] = {}
+    overridden_items: dict[str, OverrideRecord] = {}
     for override in tool_skb.pop("overrides", []):
         passed_any: dict[str, str] | None = None
         passed_all: dict[str, str] | None = None
@@ -439,7 +439,7 @@ def process_overrides(
                             *[key, key2],
                             value=value2,
                             tool_skb=tool_skb,
-                            overriden_items=overriden_items,
+                            overridden_items=overridden_items,
                             passed_all=passed_all,
                             passed_any=passed_any,
                         )
@@ -454,7 +454,7 @@ def process_overrides(
                         key,
                         value=value,
                         tool_skb=tool_skb,
-                        overriden_items=overriden_items,
+                        overridden_items=overridden_items,
                         passed_all=passed_all,
                         passed_any=passed_any,
                     )
@@ -464,4 +464,4 @@ def process_overrides(
                     tool_skb[key] = inherit_join(
                         value, tool_skb.get(key), inherit_override_tmp
                     )
-    return global_matched, overriden_items
+    return global_matched, overridden_items

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -204,7 +204,7 @@ class SettingsReader:
 
         # Handle overrides
         pyproject = copy.deepcopy(pyproject)
-        self.overrides, self.overriden_items = process_overrides(
+        self.overrides, self.overridden_items = process_overrides(
             pyproject.get("tool", {}).get("scikit-build", {}),
             state=state,
             env=env,
@@ -405,7 +405,7 @@ class SettingsReader:
                 self.print_suggestions()
                 raise SystemExit(7)
             logger.warning("Unrecognized options: {}", ", ".join(unrecognized))
-        _validate_overrides(self.settings, self.overriden_items)
+        _validate_overrides(self.settings, self.overridden_items)
 
         for key, value in self.settings.metadata.items():
             if "provider" not in value:

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -39,7 +39,7 @@ def test_get_requires_parts(fp: FakeProcess):
     assert set(GetRequires().ninja()) == {*ninja}
 
 
-def test_get_requires_parts_uneeded(fp: FakeProcess):
+def test_get_requires_parts_unneeded(fp: FakeProcess):
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.18.0"}}',

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -328,7 +328,7 @@ def test_pep517_wheel_time_hash(monkeypatch, tmp_path: Path):
 
 
 @pytest.mark.usefixtures("package_simple_pyproject_ext")
-def test_prepare_metdata_for_build_wheel():
+def test_prepare_metadata_for_build_wheel():
     metadata = build.util.project_wheel_metadata(str(Path.cwd()), isolated=False)
     answer = {
         "Metadata-Version": "2.2",
@@ -346,7 +346,7 @@ def test_prepare_metdata_for_build_wheel():
 
 
 @pytest.mark.usefixtures("package_simple_pyproject_ext")
-def test_prepare_metdata_for_build_wheel_by_hand(tmp_path):
+def test_prepare_metadata_for_build_wheel_by_hand(tmp_path):
     mddir = tmp_path / "dist"
     mddir.mkdir()
     out = prepare_metadata_for_build_wheel(str(mddir), {})

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -98,12 +98,12 @@ def test_skbuild_overrides_pyver(
         assert settings.cmake.define == {"SPAM": "EGGS"}
         assert settings.experimental
         assert settings.sdist.cmake
-        assert len(settings_reader.overriden_items) == 4
+        assert len(settings_reader.overridden_items) == 4
     else:
         assert not settings.cmake.args
         assert not settings.cmake.define
         assert not settings.experimental
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("implementation_version", ["7.3.14", "7.3.15"])
@@ -133,8 +133,8 @@ def test_skbuild_overrides_implver(
 
     if implementation_version == "7.3.15":
         assert settings.experimental
-        assert len(settings_reader.overriden_items) == 1
-        override_item = settings_reader.overriden_items["experimental"]
+        assert len(settings_reader.overridden_items) == 1
+        override_item = settings_reader.overridden_items["experimental"]
         assert override_item.original_value is None
         assert isinstance(override_item.value, bool)
         assert override_item.value
@@ -145,7 +145,7 @@ def test_skbuild_overrides_implver(
         assert "implementation-version" in override_item.passed_all
     else:
         assert not settings.experimental
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("implementation_name", ["cpython", "pypy"])
@@ -186,18 +186,18 @@ def test_skbuild_overrides_dual(
     if implementation_name == "pypy" and platform_system == "darwin":
         assert not settings.editable.verbose
         assert settings.install.components == ["headers"]
-        assert len(settings_reader.overriden_items) == 2
-        assert "editable.verbose" in settings_reader.overriden_items
-        assert "install.components" in settings_reader.overriden_items
+        assert len(settings_reader.overridden_items) == 2
+        assert "editable.verbose" in settings_reader.overridden_items
+        assert "install.components" in settings_reader.overridden_items
     elif implementation_name == "cpython" and platform_system == "darwin":
         assert settings.editable.verbose
         assert settings.install.components == ["bindings"]
-        assert len(settings_reader.overriden_items) == 1
-        assert "install.components" in settings_reader.overriden_items
+        assert len(settings_reader.overridden_items) == 1
+        assert "install.components" in settings_reader.overridden_items
     else:
         assert settings.editable.verbose
         assert not settings.install.components
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("implementation_name", ["cpython", "pypy"])
@@ -245,7 +245,7 @@ def test_skbuild_overrides_any(
     else:
         assert settings.editable.verbose
         assert not settings.install.components
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("python_version", ["3.9", "3.10"])
@@ -289,7 +289,7 @@ def test_skbuild_overrides_any_mixed(
     else:
         assert settings.editable.verbose
         assert not settings.install.components
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("platform_node", ["thismatch", "matchthat"])
@@ -316,7 +316,7 @@ def test_skbuild_overrides_platnode(
         assert settings.experimental
     else:
         assert not settings.experimental
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("platform_machine", ["x86_64", "x86_32", "other"])
@@ -348,25 +348,25 @@ def test_skbuild_overrides_regex(
 
     settings_reader = SettingsReader.from_file(pyproject_toml)
     settings = settings_reader.settings
-    overriden_item = settings_reader.overriden_items.get("install.components")
+    overridden_item = settings_reader.overridden_items.get("install.components")
 
     if platform_machine == "x86_64":
         assert settings.install.components == ["headers"]
-        assert len(settings_reader.overriden_items) == 1
-        assert overriden_item
-        assert overriden_item.key == "components"
-        assert overriden_item.original_value == ["default"]
-        assert overriden_item.value == ["headers"]
+        assert len(settings_reader.overridden_items) == 1
+        assert overridden_item
+        assert overridden_item.key == "components"
+        assert overridden_item.original_value == ["default"]
+        assert overridden_item.value == ["headers"]
     elif platform_machine == "x86_32":
         assert settings.install.components == ["headers_32"]
-        assert len(settings_reader.overriden_items) == 1
-        assert overriden_item
-        assert overriden_item.key == "components"
-        assert overriden_item.original_value == ["default"]
-        assert overriden_item.value == ["headers_32"]
+        assert len(settings_reader.overridden_items) == 1
+        assert overridden_item
+        assert overridden_item.key == "components"
+        assert overridden_item.original_value == ["default"]
+        assert overridden_item.value == ["headers_32"]
     else:
         assert settings.install.components == ["default"]
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 def test_skbuild_overrides_no_if(
@@ -558,7 +558,7 @@ def test_skbuild_env_bool_all_any(
         assert settings.sdist.cmake
     else:
         assert not settings.sdist.cmake
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("state", ["wheel", "sdist"])
@@ -582,7 +582,7 @@ def test_skbuild_overrides_state(state: str, tmp_path: Path):
         assert settings.experimental
     else:
         assert not settings.experimental
-        assert not settings_reader.overriden_items
+        assert not settings_reader.overridden_items
 
 
 @pytest.mark.parametrize("inherit", ["none", "append", "prepend"])


### PR DESCRIPTION
This is written in Rust, and is able to find snake_case / CamelCase typos. See https://github.com/scientific-python/cookie/pull/724.
