### PR TITLE
chore: ignore lock files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ Thumbs.db
 
 /docs/**/build
 .vscode/
+uv.lock
+*pylock


### PR DESCRIPTION
Getting a warning if one exists about it being placed in the SDist.
