### PR TITLE
fix: better support for ninja on Windows

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -118,7 +118,9 @@ class Builder:
         return [*self.settings.cmake.args, *_filter_env_cmake_args(env_cmake_args)]
 
     def get_generator(self, *args: str) -> str | None:
-        return self.config.get_generator(*self.get_cmake_args(), *args)
+        return self.config.get_generator(
+            *self.get_cmake_args(), *args, defines=self.settings.cmake.define
+        )
 
     def _get_entry_point_search_path(self, entry_point: str) -> dict[str, list[Path]]:
         """Get the search path dict from the entry points"""

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -101,10 +101,8 @@ def set_environment_for_gen(
             logger.debug("Default generator: {}", generator)
 
     if sysconfig.get_platform().startswith("win") and "Visual Studio" in generator:
-        # This must also be set when *_PLATFORM is set.
-        env.setdefault("CMAKE_GENERATOR", generator)
-        env.setdefault("CMAKE_GENERATOR_PLATFORM", get_cmake_platform(env))
-        return {}
+        # This ensures we default to the correct platform for Python, can be overridden
+        return {"CMAKE_VS_PLATFORM_NAME_DEFAULT": get_cmake_platform(env)}
 
     # Set Python's recommended CC and CXX if not already set by the user
     if "CC" not in env:

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -240,7 +240,11 @@ class CMaker:
             else:
                 yield f"-D{key}={value}"
 
-    def get_generator(self, *args: str) -> str | None:
+    def get_generator(
+        self,
+        *args: str,
+        defines: Mapping[str, str | os.PathLike[str] | bool] | None = None,
+    ) -> str | None:
         """
         Try to get the generator that will be used to build the project. If it's
         not set, return None (default generator will be used).
@@ -248,6 +252,10 @@ class CMaker:
         generators = [g for g in args if g.startswith("-G")]
         if generators:
             return generators[-1][2:].strip()
+        if defines and "CMAKE_GENERATOR" in defines:
+            gen_value = defines["CMAKE_GENERATOR"]
+            assert isinstance(gen_value, str)
+            return gen_value
         return self.env.get("CMAKE_GENERATOR", None)
 
     def configure(


### PR DESCRIPTION
Fix for #1089. Two fixes:

* The first is using `CMAKE_VS_PLATFORM_NAME_DEFAULT` instead on Windows. I'm not sure how well that will work, but can try it.
* The second supports using define instead of just args when checking for a set
  generator. That won't help preset usage, unless you set it here too, but
  that's easier than setting it via args.
