### PR TITLE
Update hatchling version requirement to 1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling >=1.24", "hatch-vcs >=0.4"]
+requires = ["hatchling >=1.26", "hatch-vcs >=0.4"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Older versions of hatchling do not understand the Python 3.14 classifier:

```
ValueError: Unknown classifier in field `project.classifiers`: Programming Language :: Python :: 3.14
```