### PR TITLE
chore: increase test duration for pytest

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,6 +1,7 @@
 /pytest:
   summary: Run pytest tests
   tag: [ pytest ]
+  duration: 15m
   # TODO: filter only for network marked tests
   /all:
     summary: All pytest


### PR DESCRIPTION
We hit a timeout issue recently [^1] at the pytest tests in testing-farm. Maintainability wise it's not ideal, but it will do until there is built-in support for pytest discovery and then the timeout could be calculated more dynamically

[^1]: https://artifacts.dev.testing-farm.io/1e62a714-d9aa-4bc3-8c31-956a7e4b9696/