### PR TITLE
chore: avoid a numpy yanked warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,11 @@ test-meta = [
 ]
 test-numpy = [
     { include-group = "test-core" },
-    "numpy>=1.24; python_version<'3.15' and platform_python_implementation!='PyPy' and (platform_system != 'Windows' or platform_machine != 'ARM64')",
-    "numpy~=1.24; python_version=='3.8' and platform_python_implementation=='PyPy'",
+    "numpy>=1.24.1; python_version<'3.15' and platform_python_implementation!='PyPy' and (platform_system != 'Windows' or platform_machine != 'ARM64')",
+    "numpy~=1.24.1; python_version=='3.8' and platform_python_implementation=='PyPy'",
     "numpy~=2.0; python_version=='3.9' and platform_python_implementation=='PyPy'",
     "numpy~=2.2; python_version=='3.10' and platform_python_implementation=='PyPy'",
-    "numpy~=2.4; python_version=='3.11' and platform_python_implementation=='PyPy'",
+    "numpy~=2.4.1; python_version=='3.11' and platform_python_implementation=='PyPy'",
 ]
 test-pybind11 = [
     { include-group = "test-core" },


### PR DESCRIPTION
This is giving a warning about 2.4.0 being yanked.
