### PR TITLE
docs: source link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,10 +56,9 @@ author = "Henry Schreiner"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "erbsland.sphinx.ansi",
     "conftabs",  # in /ext
     "progout",  # in /ext
-    "click_extra.sphinx",
-    "erbsland.sphinx.ansi",
     "myst_parser",
     "sphinx-jsonschema",
     "sphinx.ext.autodoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ dev = [
     "rich",
 ]
 docs = [
-    "click-extra[sphinx]",
     "erbsland-sphinx-ansi; python_version>='3.10'",
     "furo",
     "hatchling",


### PR DESCRIPTION
Adds a link back to the source repo, and fixes a WARNING admonition that slips through into the docs without formatting (see https://github.com/executablebooks/MyST-Parser/issues/845).
