### PR TITLE
ci: cmake-version missing?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "pypy-3.11", "3.13", "3.14"]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest]
         cmake-version: ["3.15.x"]
 
         include:
@@ -82,6 +82,9 @@ jobs:
           - python-version: "3.14t"
             runs-on: macos-latest
             cmake-version: "4.2.x"
+          - python-version: "3.8"
+            runs-on: macos-latest
+            cmake-version: "3.21.x"
           - python-version: "3.9"
             runs-on: macos-15-intel
             cmake-version: "3.18.x"


### PR DESCRIPTION
Fix #1228. Seems to have gone missing.
