### PR TITLE
docs: use newly fixed click-extra for admonitions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ author = "Henry Schreiner"
 # ones.
 extensions = [
     "conftabs",  # in /ext
+    "click_extra.sphinx",
     "erbsland.sphinx.ansi",
     "myst_parser",
     "sphinx-jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ dev = [
     "rich",
 ]
 docs = [
+    "click-extra[sphinx]",
     "erbsland-sphinx-ansi; python_version>='3.10'",
     "furo",
     "hatchling",


### PR DESCRIPTION
This is now out, so we can try it again (followup to #1224).
