### PR TITLE
fix: always normalize SDist names

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -133,8 +133,8 @@ The following behaviors are affected by `minimum-version`:
 - `minimum-version` 0.10+ (or unset) `cmake.targets` and `cmake.verbose` are
   replaced with `build.targets` and `build.verbose`. The CMake minimum version
   will be detected if not given.
-- `minimum-version` 0.12+ (or unset) uses `"default"` instead of `"classic"` as the
-  default for `sdist.include-mode`.
+- `minimum-version` 0.12+ (or unset) uses `"default"` instead of `"classic"` as
+  the default for `sdist.include-mode`.
 
 :::
 

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -10,7 +10,6 @@ import tarfile
 from pathlib import Path
 
 from packaging.utils import canonicalize_name
-from packaging.version import Version
 
 from .. import __version__
 from .._compat import tomllib


### PR DESCRIPTION
Fix for #1241. Removes the back-compat setting for SDist name normalization.