### PR TITLE
feat: add "explicit" inclusion-mode (opt-in include)

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -456,7 +456,9 @@ print(mk_skbuild_docs())
 
   Files to include in the SDist even if they are skipped by default. Supports gitignore syntax.
 
-  Always takes precedence over :confval:`sdist.exclude`
+  In ``"default"`` and ``"classic"``, this takes precedence over
+  :confval:`sdist.exclude`. In ``"manual"``, files must be included first,
+  then exclude rules are applied.
 
   .. seealso::
      :confval:`sdist.exclude`
@@ -473,7 +475,8 @@ print(mk_skbuild_docs())
 
   * "default": Process the git ignore files. Shortcuts on ignored directories.
   * "classic": The behavior before 0.12, like "default" but does not shortcut directories.
-  * "manual": No extra logic, based on include/exclude only.
+  * "manual": Explicit allowlist mode; files must match ``include`` and then
+    are filtered by ``exclude``.
 
   If you don't set this, it will be "default" unless you set the minimum
   version below 0.12, in which case it will be "classic".

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -681,7 +681,7 @@ print(mk_skbuild_docs())
 ```{eval-rst}
 .. confval:: sdist.inclusion-mode
 
-  :Type: ``"classic" | "default" | "manual"``
+  :Type: ``"classic" | "default" | "manual" | "explicit"``
   :Default: "default"  # "classic"
   :Config-settings: ``sdist.inclusion-mode`` or ``skbuild.sdist.inclusion-mode``
   :Environment variable: ``SKBUILD_SDIST_INCLUSION_MODE``
@@ -693,6 +693,9 @@ print(mk_skbuild_docs())
   * "default": Process the git ignore files. Shortcuts on ignored directories.
   * "classic": The behavior before 0.12, like "default" but does not shortcut directories.
   * "manual": No extra logic, based on include/exclude only.
+  * "explicit": Opt-in only. Nothing is included unless it matches an ``include``
+    pattern, and ``exclude`` is applied after, so it can trim included files back
+    out. Like "manual", git ignore files are not read. (1.0+)
 
   If you don't set this, it will be "default" unless you set the minimum
   version below 0.12, in which case it will be "classic".

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -76,7 +76,7 @@ def each_unignored_file(
 
     for dirstr, dirs, filenames in os.walk(str(starting_path), followlinks=True):
         dirpath = Path(dirstr)
-        if mode != "classic":
+        if mode == "default":
             for dname in dirs:
                 if not match_path(
                     dirpath,
@@ -86,6 +86,7 @@ def each_unignored_file(
                     builtin_exclude_spec,
                     user_exclude_spec,
                     nested_excludes,
+                    manual_mode=False,
                     is_path=True,
                 ):
                     # Check to see if any include rules start with this
@@ -103,6 +104,7 @@ def each_unignored_file(
                 builtin_exclude_spec,
                 user_exclude_spec,
                 nested_excludes,
+                manual_mode=mode == "manual",
                 is_path=False,
             ):
                 yield path
@@ -117,12 +119,22 @@ def match_path(
     user_exclude_spec: pathspec.GitIgnoreSpec,
     nested_excludes: dict[Path, pathspec.GitIgnoreSpec],
     *,
+    manual_mode: bool,
     is_path: bool,
 ) -> bool:
     ptype = "directory" if is_path else "file"
 
-    # Always include something included
-    if include_spec.match_file(p):
+    included = include_spec.match_file(p)
+
+    # In manual mode, an item must be explicitly included first.
+    if manual_mode and not included:
+        logger.debug(
+            "Excluding {} {} because manual mode requires explicit include.", ptype, p
+        )
+        return False
+
+    # Always include something included in non-manual modes
+    if not manual_mode and included:
         logger.debug("Including {} {} because it is explicitly included.", ptype, p)
         return True
 

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -50,22 +50,24 @@ def each_unignored_file(
     exclude: Sequence[str] = (),
     build_dir: str = "",
     *,
-    mode: Literal["classic", "default", "manual"],
+    mode: Literal["classic", "default", "manual", "explicit"],
 ) -> Generator[Path, None, None]:
     """
     Runs through all non-ignored files. Must be run from the root directory.
     """
+    # "manual" and "explicit" do not consult git ignore files at all.
+    reads_gitignore = mode in {"classic", "default"}
+    explicit = mode == "explicit"
+
     global_exclude_lines = []
-    if mode != "manual":
+    if reads_gitignore:
         for gi in [Path(".git/info/exclude"), Path(".gitignore")]:
             ignore_errs = [FileNotFoundError, NotADirectoryError]
             with contextlib.suppress(*ignore_errs), gi.open(encoding="utf-8") as f:
                 global_exclude_lines += f.readlines()
 
     nested_excludes = (
-        {}
-        if mode == "manual"
-        else {
+        {
             Path(dirpath): pathspec.GitIgnoreSpec.from_lines(
                 (Path(dirpath) / filename).read_text(encoding="utf-8").splitlines()
             )
@@ -73,6 +75,8 @@ def each_unignored_file(
             for filename in filenames
             if filename == ".gitignore" and dirpath != "."
         }
+        if reads_gitignore
+        else {}
     )
 
     exclude_build_dir = build_dir.format(**pyproject_format(dummy=True))
@@ -123,6 +127,7 @@ def each_unignored_file(
                     user_exclude_spec,
                     nested_excludes,
                     is_path=True,
+                    explicit=explicit,
                 ):
                     # Only prune if no include pattern could match a file below
                     # this directory. A literal include deeper than the dir, or
@@ -143,6 +148,7 @@ def each_unignored_file(
                 user_exclude_spec,
                 nested_excludes,
                 is_path=False,
+                explicit=explicit,
             ):
                 yield path
 
@@ -188,8 +194,38 @@ def match_path(
     nested_excludes: dict[Path, pathspec.GitIgnoreSpec],
     *,
     is_path: bool,
+    explicit: bool = False,
 ) -> bool:
     ptype = "directory" if is_path else "file"
+
+    # In "explicit" mode the set is purely include minus exclude: nothing is in
+    # unless an include matches it, and exclude is applied after (so it wins over
+    # include). git ignore files are not consulted (they are empty here anyway).
+    if explicit:
+        if (c := user_exclude_spec.check_file(p)).include:
+            assert c.index is not None
+            logger.debug(
+                "Excluding {} {} because it is explicitly excluded by the user with {!r}.",
+                ptype,
+                p,
+                user_exclude_spec.patterns[c.index].pattern,
+            )
+            return False
+        if (c := include_spec.check_file(p)).include:
+            assert c.index is not None
+            logger.debug(
+                "Including {} {} because it is explicitly included by rule {!r}.",
+                ptype,
+                p,
+                include_spec.patterns[c.index].pattern,
+            )
+            return True
+        logger.debug(
+            "Excluding {} {} because no include rule opts it in (explicit mode).",
+            ptype,
+            p,
+        )
+        return False
 
     # Always include something included
     if (c := include_spec.check_file(p)).include:

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -62,7 +62,7 @@ def packages_to_file_mapping(
     src_exclude: Sequence[str],
     target_exclude: Sequence[str],
     build_dir: str,
-    mode: Literal["classic", "default", "manual"],
+    mode: Literal["classic", "default", "manual", "explicit"],
 ) -> dict[str, str]:
     """
     This will output a mapping of source files to target files.

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -172,7 +172,8 @@
           "enum": [
             "classic",
             "default",
-            "manual"
+            "manual",
+            "explicit"
           ],
           "description": "Method to use to compute the files to include and exclude."
         },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -213,7 +213,9 @@ class SDistSettings:
     """
     Files to include in the SDist even if they are skipped by default. Supports gitignore syntax.
 
-    Always takes precedence over :confval:`sdist.exclude`
+    In ``"default"`` and ``"classic"``, this takes precedence over
+    :confval:`sdist.exclude`. In ``"manual"``, files must be included first,
+    then exclude rules are applied.
 
     .. seealso::
        :confval:`sdist.exclude`
@@ -240,7 +242,8 @@ class SDistSettings:
 
     * "default": Process the git ignore files. Shortcuts on ignored directories.
     * "classic": The behavior before 0.12, like "default" but does not shortcut directories.
-    * "manual": No extra logic, based on include/exclude only.
+        * "manual": Explicit allowlist mode; files must match ``include`` and then
+            are filtered by ``exclude``.
 
     If you don't set this, it will be "default" unless you set the minimum
     version below 0.12, in which case it will be "classic".

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -306,7 +306,7 @@ class SDistSettings:
        :confval:`sdist.include`
     """
 
-    inclusion_mode: Optional[Literal["classic", "default", "manual"]] = (
+    inclusion_mode: Optional[Literal["classic", "default", "manual", "explicit"]] = (
         dataclasses.field(
             default=None,
             metadata=SettingsFieldMetadata(display_default='"default"  # "classic"'),
@@ -320,6 +320,9 @@ class SDistSettings:
     * "default": Process the git ignore files. Shortcuts on ignored directories.
     * "classic": The behavior before 0.12, like "default" but does not shortcut directories.
     * "manual": No extra logic, based on include/exclude only.
+    * "explicit": Opt-in only. Nothing is included unless it matches an ``include``
+      pattern, and ``exclude`` is applied after, so it can trim included files back
+      out. Like "manual", git ignore files are not read. (1.0+)
 
     If you don't set this, it will be "default" unless you set the minimum
     version below 0.12, in which case it will be "classic".

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -446,6 +446,14 @@ class SettingsReader:
                 rich_error(
                     "minimum-version can't be less than 0.12 to use sdist.inclusion-mode"
                 )
+            if (
+                self.settings.sdist.inclusion_mode == "explicit"
+                and self.settings.minimum_version is not None
+                and self.settings.minimum_version < Version("1.0")
+            ):
+                rich_error(
+                    'minimum-version must be at least 1.0 to use sdist.inclusion-mode = "explicit"'
+                )
         elif (
             self.settings.minimum_version is not None
             and self.settings.minimum_version < Version("0.12")

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -129,11 +129,7 @@ def test_on_each_with_symlink(
         nested_dir / ".gitignore",
     }
     if mode == "manual":
-        files |= {
-            hidden_file,
-            nested_dir.joinpath("ignored.txt"),
-            nested_dir.joinpath("more/ignored.txt"),
-        }
+        files = set()
     assert set(each_unignored_file(Path(), mode=mode)) == files
 
 
@@ -188,17 +184,37 @@ def test_include_patterns(
         ]
     }
     if mode == "manual":
-        expected |= {Path("temp.tmp"), Path("local_ignored_file.txt")}
+        expected = {
+            Path(s)
+            for s in [
+                "setup.py",
+                "src/__init__.py",
+                "src/main.py",
+                "src/utils.py",
+                "tests/test_main.py",
+                "tests/test_utils.py",
+                "tests/tmp.py",
+            ]
+        }
     assert result == expected
 
     # Test including specific files
     result = set(each_unignored_file(Path(), include=["tests/tmp.py"], mode=mode))
-    assert result == expected | {Path("tests/tmp.py")}
+    if mode == "manual":
+        assert result == {Path("tests/tmp.py")}
+    else:
+        assert result == expected | {Path("tests/tmp.py")}
 
     # Test including with wildcards
     result = set(each_unignored_file(Path(), include=["tests/*"], mode=mode))
-    expected = expected | {Path("tests/tmp.py")}
-    assert result == expected
+    if mode == "manual":
+        expected = {
+            Path(s)
+            for s in ["tests/test_main.py", "tests/test_utils.py", "tests/tmp.py"]
+        }
+        assert result == expected
+    else:
+        assert result == expected | {Path("tests/tmp.py")}
 
 
 def test_include_pattern_with_nested_path_and_broad_exclude(
@@ -206,8 +222,8 @@ def test_include_pattern_with_nested_path_and_broad_exclude(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Test that nested include patterns are not pruned by directory traversal,
-    even when exclude patterns match all paths.
+    Test that nested include patterns are not pruned by directory traversal.
+    In manual mode, excludes are applied after includes.
     """
     monkeypatch.chdir(tmp_path)
     nested_file = Path("a") / "b" / "c.txt"
@@ -222,7 +238,7 @@ def test_include_pattern_with_nested_path_and_broad_exclude(
             mode="manual",
         )
     )
-    assert result == {nested_file}
+    assert result == set()
 
 
 def test_exclude_patterns(
@@ -257,7 +273,7 @@ def test_exclude_patterns(
         ]
     }
     if mode == "manual":
-        expected |= {Path("tests/tmp.py"), Path("local_ignored_file.txt")}
+        expected = set()
     assert result == expected
 
     # Test excluding directories
@@ -280,7 +296,7 @@ def test_exclude_patterns(
         ]
     }
     if mode == "manual":
-        expected |= {Path("temp.tmp"), Path("local_ignored_file.txt")}
+        expected = set()
     assert result == expected
 
     # Test excluding with wildcards
@@ -299,7 +315,7 @@ def test_exclude_patterns(
         ]
     }
     if mode == "manual":
-        expected |= {Path("temp.tmp"), Path("local_ignored_file.txt")}
+        expected = set()
     assert result == expected
 
 
@@ -324,6 +340,8 @@ def test_include_overrides_exclude(
         )
     )
     expected = {Path(s) for s in ["src/main.py", "tests/test_main.py"]}
+    if mode == "manual":
+        expected = set()
     assert result == expected
 
     # Exclude everything but include a file from inside a directory
@@ -333,6 +351,8 @@ def test_include_overrides_exclude(
         )
     )
     expected = {Path(s) for s in ["tests/test_main.py"]}
+    if mode == "manual":
+        expected = set()
     assert result == expected
 
 
@@ -372,17 +392,15 @@ def test_gitignore_interaction(
         ]
     }
     if mode == "manual":
-        expected |= {
-            Path("cache.db"),
-            Path("debug.log"),
-            Path("local_ignored_file.txt"),
-            Path("temp.tmp"),
-        }
+        expected = set()
     assert result == expected
 
     # Test that include can override gitignore
     result = set(each_unignored_file(Path(), include=["*.tmp"], mode=mode))
-    assert result == expected | {Path("temp.tmp")}
+    if mode == "manual":
+        assert result == {Path("temp.tmp")}
+    else:
+        assert result == expected | {Path("temp.tmp")}
 
 
 def test_nested_gitignore(
@@ -422,17 +440,15 @@ def test_nested_gitignore(
         ]
     }
     if mode == "manual":
-        expected |= {
-            Path("local_ignored_file.txt"),
-            Path("src/utils.py"),
-            Path("temp.tmp"),
-            Path("tests/tmp.py"),
-        }
+        expected = set()
     assert result == expected
 
     # Test that include can override nested gitignore
     result = set(each_unignored_file(Path(), include=["src/utils.py"], mode=mode))
-    assert result == expected | {Path("src/utils.py")}
+    if mode == "manual":
+        assert result == {Path("src/utils.py")}
+    else:
+        assert result == expected | {Path("src/utils.py")}
 
 
 def test_build_dir_exclusion(
@@ -474,11 +490,7 @@ def test_build_dir_exclusion(
         ]
     }
     if mode == "manual":
-        expected |= {
-            Path("local_ignored_file.txt"),
-            Path("temp.tmp"),
-            Path("tests/tmp.py"),
-        }
+        expected = set()
     assert result == expected
     assert build_file.relative_to(tmp_path) not in result
 
@@ -486,7 +498,10 @@ def test_build_dir_exclusion(
     result = set(
         each_unignored_file(Path(), include=["build/*"], build_dir="build", mode=mode)
     )
-    assert result == expected | {Path("build/output.so")}
+    if mode == "manual":
+        assert result == set()
+    else:
+        assert result == expected | {Path("build/output.so")}
 
 
 def test_complex_combinations(
@@ -526,6 +541,8 @@ def test_complex_combinations(
     expected = {
         Path(s) for s in ["tests/test_main.py", "temp.tmp"]
     }  # Only these should match
+    if mode == "manual":
+        expected = set()
     assert result == expected
 
 
@@ -590,9 +607,5 @@ def test_nonexistent_patterns(
         ]
     }
     if mode == "manual":
-        expected |= {
-            Path("local_ignored_file.txt"),
-            Path("temp.tmp"),
-            Path("tests/tmp.py"),
-        }
+        expected = set()
     assert exclude_result == expected

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -709,6 +709,96 @@ def test_consecutive_excluded_dirs_not_descended(
     assert Path("excluded_b") not in descended_paths
 
 
+def test_explicit_is_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    In "explicit" mode nothing is packaged unless it matches an include pattern.
+    """
+    monkeypatch.chdir(tmp_path)
+    _setup_test_filesystem(tmp_path)
+
+    # No include -> nothing, even though many files exist.
+    assert set(each_unignored_file(Path(), mode="explicit")) == set()
+
+    # Only included files appear; siblings are dropped (the opposite of the other
+    # modes, which include everything by default).
+    result = set(each_unignored_file(Path(), include=["*.py"], mode="explicit"))
+    assert result == {
+        Path(s)
+        for s in [
+            "setup.py",
+            "src/__init__.py",
+            "src/main.py",
+            "src/utils.py",
+            "tests/test_main.py",
+            "tests/test_utils.py",
+            "tests/tmp.py",
+        ]
+    }
+
+
+def test_explicit_exclude_wins_over_include(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    In "explicit" mode exclude is applied after the opt-in, so it trims included
+    files back out (in every other mode, include would win).
+    """
+    monkeypatch.chdir(tmp_path)
+    _setup_test_filesystem(tmp_path)
+
+    result = set(
+        each_unignored_file(
+            Path(),
+            include=["src/**"],
+            exclude=["src/utils.py"],
+            mode="explicit",
+        )
+    )
+    assert result == {Path("src/__init__.py"), Path("src/main.py")}
+
+    # Sanity check: in "manual" mode the same include/exclude keeps utils.py,
+    # because there include overrides exclude.
+    manual = set(
+        each_unignored_file(
+            Path(),
+            include=["src/**"],
+            exclude=["src/utils.py"],
+            mode="manual",
+        )
+    )
+    assert Path("src/utils.py") in manual
+
+
+def test_explicit_ignores_gitignore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    "explicit" mode does not read git ignore files (like "manual").
+    """
+    monkeypatch.chdir(tmp_path)
+    _setup_test_filesystem(tmp_path)
+
+    # src/.gitignore would hide utils.py in default/classic mode; explicit ignores
+    # it, so an include still picks utils.py (and the nested .gitignore itself).
+    (tmp_path / "src" / ".gitignore").write_text("utils.py\n")
+
+    result = set(each_unignored_file(Path(), include=["src/**"], mode="explicit"))
+    assert result == {
+        Path(s)
+        for s in [
+            "src/.gitignore",
+            "src/__init__.py",
+            "src/main.py",
+            "src/utils.py",
+        ]
+    }
+
+
 def test_nonexistent_patterns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -1182,3 +1182,38 @@ def test_backcompat_sdist_resolve_symlinks(
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
     assert settings_reader.settings.sdist.resolve_symlinks == "all"
+
+
+def test_sdist_inclusion_mode_explicit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SKBUILD_SDIST_INCLUSION_MODE", "explicit")
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.sdist.inclusion_mode == "explicit"
+
+
+def test_sdist_inclusion_mode_explicit_requires_minimum_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    # Pin the reported version so the generic "backend too old" check passes and
+    # the explicit-specific 1.0 gate is what fires (CI builds report 0.1.dev*).
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.0.0"
+    )
+    monkeypatch.setenv("SKBUILD_SDIST_INCLUSION_MODE", "explicit")
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            minimum-version = "0.12"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml, {})
+    assert "1.0" in capsys.readouterr().err


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1248.

Adds a fourth `sdist.inclusion-mode` value, **`"explicit"`**, for an allowlist-style ("opt-in") workflow.

### Behavior

Nothing is packaged unless it matches an `include` pattern, and `exclude` is applied **after** the opt-in, so it trims included files back out. This is the inverse of the existing modes, where `include` always wins over `exclude`. Like `"manual"`, git ignore files are not consulted.

| mode | reads gitignore | nested ignore | prunes dirs | default = include? | include vs exclude |
|------|------|------|------|------|------|
| classic  | yes | yes | no  | yes | include wins |
| default  | yes | yes | yes | yes | include wins |
| manual   | no  | no  | yes | yes | include wins |
| **explicit** | **no** | **no** | **yes** | **no (opt-in)** | **exclude wins** |

The mode is read from `[tool.scikit-build.sdist]` but governs both sdist file selection and wheel *package* collection (both paths pass `settings.sdist.inclusion_mode`), so in `"explicit"` mode a package directory contributes only files matched by `sdist.include`.

### Example

```toml
[tool.scikit-build.sdist]
inclusion-mode = "explicit"
include = ["src/**/*.py", "README.md"]
exclude = ["src/**/_scratch.py"]  # trims back out, even though include matched
```

### Implementation

- `settings/skbuild_model.py` — new `Literal` value + docstring (drives schema/docs generation).
- `build/_file_processor.py` — `each_unignored_file` skips git-ignore data for `"explicit"` (like `"manual"`) while still pruning directories; `match_path` gains an `explicit` branch with *exclude → include → exclude-by-default* precedence.
- `build/_pathutil.py` — widened the `mode` literal used for wheel package collection.
- Regenerated `scikit-build.schema.json` and `docs/reference/configs.md`.

### Tests

- `tests/test_file_processor.py` — dedicated tests for the opt-in baseline, exclude-wins-over-include (contrasted against `"manual"`), and git-ignore being skipped.
- `tests/test_skbuild_settings.py` — `SKBUILD_SDIST_INCLUSION_MODE=explicit` round-trip.
