### PR TITLE
fix: better logging on why something fails/passes file check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest] # Windows command output issue (wrong Python selected)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,7 @@ repos:
           - nox
           - orjson
           - packaging>=24.2
+          - pathspec
           - pytest<9 # pytest 9 requires Python 3.10+
           - pytest-subprocess
           - rich

--- a/noxfile.py
+++ b/noxfile.py
@@ -149,6 +149,7 @@ def docs(session: nox.Session) -> None:
     """
     Build the docs. Use "--non-interactive" to avoid serving. Pass "-b linkcheck" to check links.
     """
+    uv_pip = ["uv", "pip"] if session.venv_backend == "uv" else ["pip"]
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -159,6 +160,7 @@ def docs(session: nox.Session) -> None:
     serve = args.builder == "html" and session.interactive
     extra_installs = ["sphinx-autobuild"] if serve else []
     session.install("-e.", "--group=docs", *extra_installs)
+    session.run(*uv_pip, "list")
 
     session.chdir("docs")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
     "myst-parser >=0.13",
     "setuptools",
     "sphinx >=7.0",
-    "sphinx-autodoc-typehints != 3.9.*",
+    "sphinx-autodoc-typehints != 3.9.6",
     "sphinx-copybutton",
     "sphinx-inline-tabs",
     "sphinx-jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
     "myst-parser >=0.13",
     "setuptools",
     "sphinx >=7.0",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints != 3.9.*",
     "sphinx-copybutton",
     "sphinx-inline-tabs",
     "sphinx-jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "exceptiongroup >=1.0; python_version<'3.11'",
     "importlib-resources >=1.3; python_version<'3.9'",
     "packaging >=23.2",
-    "pathspec >=0.10.1",
+    "pathspec >=0.12.0",
     "tomli >=1.2.2; python_version<'3.11'",
     "typing-extensions >=4; python_version<'3.11'",
 ]
@@ -220,7 +220,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
 [[tool.mypy.overrides]]
-module = ["numpy", "pathspec", "setuptools_scm", "hatch_fancy_pypi_readme", "virtualenv"]
+module = ["numpy", "setuptools_scm", "hatch_fancy_pypi_readme", "virtualenv"]
 ignore_missing_imports = true
 
 

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -122,47 +122,57 @@ def match_path(
     ptype = "directory" if is_path else "file"
 
     # Always include something included
-    if include_spec.match_file(p):
-        logger.debug("Including {} {} because it is explicitly included.", ptype, p)
+    if (c := include_spec.check_file(p)).include:
+        logger.debug(
+            "Including {} {} because it is explicitly included by rule {!r}.",
+            ptype,
+            p,
+            include_spec.patterns[c.index].pattern,  # type: ignore[attr-defined, index]
+        )
         return True
 
     # Always exclude something excluded
-    if user_exclude_spec.match_file(p):
+    if (c := user_exclude_spec.check_file(p)).include:
         logger.debug(
-            "Excluding {} {} because it is explicitly excluded by the user.", ptype, p
+            "Excluding {} {} because it is explicitly excluded by the user with {!r}.",
+            ptype,
+            p,
+            user_exclude_spec.patterns[c.index].pattern,  # type: ignore[attr-defined, index]
         )
         return False
 
     # Ignore from global ignore
-    if global_exclude_spec.match_file(p):
+    if (c := global_exclude_spec.check_file(p)).include:
         logger.debug(
-            "Excluding {} {} because it is explicitly excluded by the global ignore.",
+            "Excluding {} {} because it is explicitly excluded by the global ignore with {!r}.",
             ptype,
             p,
+            global_exclude_spec.patterns[c.index].pattern,  # type: ignore[attr-defined, index]
         )
         return False
 
     # Ignore built-in patterns
-    if builtin_exclude_spec.match_file(p):
+    if (c := builtin_exclude_spec.check_file(p)).include:
         logger.debug(
-            "Excluding {} {} because it is explicitly excluded by the built-in ignore.",
+            "Excluding {} {} because it is explicitly excluded by the built-in ignore with {!r}.",
             ptype,
             p,
+            builtin_exclude_spec.patterns[c.index].pattern,  # type: ignore[attr-defined, index]
         )
         return False
 
     # Check relative ignores (Python 3.9's is_relative_to workaround)
-    if any(
-        nex.match_file(p.relative_to(np))
-        for np, nex in nested_excludes.items()
-        if dirpath == np or np in dirpath.parents
-    ):
-        logger.debug(
-            "Excluding {} {} because it is explicitly excluded by nested ignore.",
-            ptype,
-            p,
-        )
-        return False
+    for np, nex in nested_excludes.items():
+        if (dirpath == np or np in dirpath.parents) and (
+            c := nex.check_file(p.relative_to(np))
+        ).include:
+            logger.debug(
+                "Excluding {} {} because it is explicitly excluded by nested ignore with {!r}.",
+                ptype,
+                p,
+                nex.patterns[c.index].pattern,  # type: ignore[attr-defined, index]
+            )
+            return False
 
     logger.debug(
         "Including {} {} because it exists (and isn't matched any other way).", ptype, p


### PR DESCRIPTION
This should help debug #1248.

Includes an exclusion for https://github.com/tox-dev/sphinx-autodoc-typehints/issues/656.