### PR TITLE
feat(sdist): resolve symlinks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ sdist.reproducible = true
 # If set to True, CMake will be run before building the SDist.
 sdist.cmake = false
 
+# If set to True, symlinks in the SDist will be dereferenced and their contents
+sdist.dereference = true
+
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ sdist.reproducible = true
 # If set to True, CMake will be run before building the SDist.
 sdist.cmake = false
 
-# If set to True, symlinks in the SDist will be dereferenced and their contents
-sdist.dereference = true
+# Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+sdist.resolve-symlinks = true
 
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ sdist.cmake = false
 # Force-include files into the SDist.
 sdist.force-include = {}
 
+# If set to True, symlinks in the SDist will be dereferenced and their contents
+sdist.dereference = true
+
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ sdist.cmake = false
 # Force-include files into the SDist.
 sdist.force-include = {}
 
-# Which symlinks to resolve in the SDist, copying file contents instead of
+# Which symlinks to resolve in the SDist, storing the target's contents instead.
 sdist.resolve-symlinks = "all"
 
 # A list of packages to auto-copy into the wheel.

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ sdist.cmake = false
 # Force-include files into the SDist.
 sdist.force-include = {}
 
-# If set to True, symlinks in the SDist will be dereferenced and their contents
-sdist.dereference = true
+# Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+sdist.resolve-symlinks = true
 
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ sdist.cmake = false
 # Force-include files into the SDist.
 sdist.force-include = {}
 
-# Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
-sdist.resolve-symlinks = true
+# Which symlinks to resolve in the SDist, copying file contents instead of
+sdist.resolve-symlinks = "all"
 
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -441,6 +441,16 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: sdist.dereference
+  :type: ``bool``
+  :default: true
+
+  If set to True, symlinks in the SDist will be dereferenced and their contents
+  will be copied into the archive. This ensures the source distribution remains
+  usable across different machines and environments.
+```
+
+```{eval-rst}
 .. confval:: sdist.exclude
   :type: ``list[str]``
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -441,16 +441,6 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
-.. confval:: sdist.dereference
-  :type: ``bool``
-  :default: true
-
-  If set to True, symlinks in the SDist will be dereferenced and their contents
-  will be copied into the archive. This ensures the source distribution remains
-  usable across different machines and environments.
-```
-
-```{eval-rst}
 .. confval:: sdist.exclude
   :type: ``list[str]``
 
@@ -501,6 +491,14 @@ print(mk_skbuild_docs())
   Unix and Python 3.9+ recommended.
 
   ``SOURCE_DATE_EPOCH`` will be used for timestamps, or a fixed value if not set.
+```
+
+```{eval-rst}
+.. confval:: sdist.resolve-symlinks
+  :type: ``bool``
+  :default: true
+
+  Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
 ```
 
 ## search

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -717,15 +717,24 @@ print(mk_skbuild_docs())
 
 ```{eval-rst}
 .. confval:: sdist.resolve-symlinks
-  :type: ``bool``
-  :default: true
 
-  Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+  :Type: ``"all" | "none"``
+  :Default: "all"
+  :Config-settings: ``sdist.resolve-symlinks`` or ``skbuild.sdist.resolve-symlinks``
+  :Environment variable: ``SKBUILD_SDIST_RESOLVE_SYMLINKS``
 
-  If not set, it will be ``true`` unless you set the minimum version below 0.13,
-  in which case it will be ``false`` to preserve backward compatibility.
+  Which symlinks to resolve in the SDist, copying file contents instead of
+  storing the symlink.
 
-  .. versionadded: 0.13
+  The modes are:
+
+  * "all": Resolve every symlink, copying its target's contents.
+  * "none": Store symlinks as-is.
+
+  If you don't set this, it will be "all" unless you set the minimum version
+  below 1.0, in which case it will be "none" to preserve backward compatibility.
+
+  .. versionadded: 1.0
 ```
 
 ## search

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -723,8 +723,7 @@ print(mk_skbuild_docs())
   :Config-settings: ``sdist.resolve-symlinks`` or ``skbuild.sdist.resolve-symlinks``
   :Environment variable: ``SKBUILD_SDIST_RESOLVE_SYMLINKS``
 
-  Which symlinks to resolve in the SDist, copying file contents instead of
-  storing the symlink.
+  Which symlinks to resolve in the SDist, storing the target's contents instead.
 
   The modes are:
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -628,6 +628,16 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: sdist.dereference
+  :type: ``bool``
+  :default: true
+
+  If set to True, symlinks in the SDist will be dereferenced and their contents
+  will be copied into the archive. This ensures the source distribution remains
+  usable across different machines and environments.
+```
+
+```{eval-rst}
 .. confval:: sdist.exclude
 
   :Type: ``list[str]``

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -628,16 +628,6 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
-.. confval:: sdist.dereference
-  :type: ``bool``
-  :default: true
-
-  If set to True, symlinks in the SDist will be dereferenced and their contents
-  will be copied into the archive. This ensures the source distribution remains
-  usable across different machines and environments.
-```
-
-```{eval-rst}
 .. confval:: sdist.exclude
 
   :Type: ``list[str]``
@@ -723,6 +713,14 @@ print(mk_skbuild_docs())
   Unix and Python 3.9+ recommended.
 
   ``SOURCE_DATE_EPOCH`` will be used for timestamps, or a fixed value if not set.
+```
+
+```{eval-rst}
+.. confval:: sdist.resolve-symlinks
+  :type: ``bool``
+  :default: true
+
+  Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
 ```
 
 ## search

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -721,6 +721,11 @@ print(mk_skbuild_docs())
   :default: true
 
   Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+
+  If not set, it will be ``true`` unless you set the minimum version below 0.13,
+  in which case it will be ``false`` to preserve backward compatibility.
+
+  .. versionadded: 0.13
 ```
 
 ## search

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -142,7 +142,7 @@ def build_sdist(
                 fileobj=gzip_container,
                 mode="w",
                 format=tarfile.PAX_FORMAT,
-                dereference=settings.sdist.dereference,
+                dereference=settings.sdist.resolve_symlinks,
             )
         )
         assert settings.sdist.inclusion_mode is not None

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -138,7 +138,12 @@ def build_sdist(
             )
         )
         tar = stack.enter_context(
-            tarfile.TarFile(fileobj=gzip_container, mode="w", format=tarfile.PAX_FORMAT)
+            tarfile.TarFile(
+                fileobj=gzip_container,
+                mode="w",
+                format=tarfile.PAX_FORMAT,
+                dereference=settings.sdist.dereference,
+            )
         )
         assert settings.sdist.inclusion_mode is not None
         paths = sorted(

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -142,7 +142,7 @@ def build_sdist(
                 fileobj=gzip_container,
                 mode="w",
                 format=tarfile.PAX_FORMAT,
-                dereference=settings.sdist.resolve_symlinks,
+                dereference=settings.sdist.resolve_symlinks == "all",
             )
         )
         assert settings.sdist.inclusion_mode is not None

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -189,6 +189,11 @@
           "type": "boolean",
           "default": false,
           "description": "If set to True, CMake will be run before building the SDist."
+        },
+        "dereference": {
+          "type": "boolean",
+          "default": true,
+          "description": "If set to True, symlinks in the SDist will be dereferenced and their contents"
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -190,10 +190,10 @@
           "default": false,
           "description": "If set to True, CMake will be run before building the SDist."
         },
-        "dereference": {
+        "resolve-symlinks": {
           "type": "boolean",
           "default": true,
-          "description": "If set to True, symlinks in the SDist will be dereferenced and their contents"
+          "description": "Resolve symlinks in the SDist, copying file contents instead of storing symlinks."
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -196,8 +196,11 @@
           "description": "Force-include files into the SDist."
         },
         "resolve-symlinks": {
-          "type": "boolean",
-          "description": "Resolve symlinks in the SDist, copying file contents instead of storing symlinks."
+          "enum": [
+            "all",
+            "none"
+          ],
+          "description": "Which symlinks to resolve in the SDist, copying file contents instead of"
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -200,7 +200,7 @@
             "all",
             "none"
           ],
-          "description": "Which symlinks to resolve in the SDist, copying file contents instead of"
+          "description": "Which symlinks to resolve in the SDist, storing the target's contents instead."
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -197,7 +197,6 @@
         },
         "resolve-symlinks": {
           "type": "boolean",
-          "default": true,
           "description": "Resolve symlinks in the SDist, copying file contents instead of storing symlinks."
         }
       }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -194,6 +194,11 @@
             }
           },
           "description": "Force-include files into the SDist."
+        },
+        "dereference": {
+          "type": "boolean",
+          "default": true,
+          "description": "If set to True, symlinks in the SDist will be dereferenced and their contents"
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -195,10 +195,10 @@
           },
           "description": "Force-include files into the SDist."
         },
-        "dereference": {
+        "resolve-symlinks": {
           "type": "boolean",
           "default": true,
-          "description": "If set to True, symlinks in the SDist will be dereferenced and their contents"
+          "description": "Resolve symlinks in the SDist, copying file contents instead of storing symlinks."
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -262,11 +262,9 @@ class SDistSettings:
     If set to True, CMake will be run before building the SDist.
     """
 
-    dereference: bool = True
+    resolve_symlinks: bool = True
     """
-    If set to True, symlinks in the SDist will be dereferenced and their contents
-    will be copied into the archive. This ensures the source distribution remains
-    usable across different machines and environments.
+    Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -262,6 +262,13 @@ class SDistSettings:
     If set to True, CMake will be run before building the SDist.
     """
 
+    dereference: bool = True
+    """
+    If set to True, symlinks in the SDist will be dereferenced and their contents
+    will be copied into the archive. This ensures the source distribution remains
+    usable across different machines and environments.
+    """
+
 
 @dataclasses.dataclass
 class WheelSettings:

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -359,9 +359,17 @@ class SDistSettings:
     bulk copy can still be trimmed by an exclude pattern.
     """
 
-    resolve_symlinks: bool = True
+    resolve_symlinks: Optional[bool] = dataclasses.field(
+        default=None,
+        metadata=SettingsFieldMetadata(display_default="true"),
+    )
     """
     Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+
+    If not set, it will be ``true`` unless you set the minimum version below 0.13,
+    in which case it will be ``false`` to preserve backward compatibility.
+
+    .. versionadded: 0.13
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -359,17 +359,23 @@ class SDistSettings:
     bulk copy can still be trimmed by an exclude pattern.
     """
 
-    resolve_symlinks: Optional[bool] = dataclasses.field(
+    resolve_symlinks: Optional[Literal["all", "none"]] = dataclasses.field(
         default=None,
-        metadata=SettingsFieldMetadata(display_default="true"),
+        metadata=SettingsFieldMetadata(display_default='"all"'),
     )
     """
-    Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
+    Which symlinks to resolve in the SDist, copying file contents instead of
+    storing the symlink.
 
-    If not set, it will be ``true`` unless you set the minimum version below 0.13,
-    in which case it will be ``false`` to preserve backward compatibility.
+    The modes are:
 
-    .. versionadded: 0.13
+    * "all": Resolve every symlink, copying its target's contents.
+    * "none": Store symlinks as-is.
+
+    If you don't set this, it will be "all" unless you set the minimum version
+    below 1.0, in which case it will be "none" to preserve backward compatibility.
+
+    .. versionadded: 1.0
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -359,11 +359,9 @@ class SDistSettings:
     bulk copy can still be trimmed by an exclude pattern.
     """
 
-    dereference: bool = True
+    resolve_symlinks: bool = True
     """
-    If set to True, symlinks in the SDist will be dereferenced and their contents
-    will be copied into the archive. This ensures the source distribution remains
-    usable across different machines and environments.
+    Resolve symlinks in the SDist, copying file contents instead of storing symlinks.
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -364,8 +364,7 @@ class SDistSettings:
         metadata=SettingsFieldMetadata(display_default='"all"'),
     )
     """
-    Which symlinks to resolve in the SDist, copying file contents instead of
-    storing the symlink.
+    Which symlinks to resolve in the SDist, storing the target's contents instead.
 
     The modes are:
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -359,6 +359,13 @@ class SDistSettings:
     bulk copy can still be trimmed by an exclude pattern.
     """
 
+    dereference: bool = True
+    """
+    If set to True, symlinks in the SDist will be dereferenced and their contents
+    will be copied into the archive. This ensures the source distribution remains
+    usable across different machines and environments.
+    """
+
 
 @dataclasses.dataclass
 class WheelSettings:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -457,18 +457,18 @@ class SettingsReader:
         if self.settings.sdist.resolve_symlinks is not None:
             if (
                 self.settings.minimum_version is not None
-                and self.settings.minimum_version < Version("0.13")
+                and self.settings.minimum_version < Version("1.0")
             ):
                 rich_error(
-                    "minimum-version can't be less than 0.13 to use sdist.resolve-symlinks"
+                    "minimum-version can't be less than 1.0 to use sdist.resolve-symlinks"
                 )
         elif (
             self.settings.minimum_version is not None
-            and self.settings.minimum_version < Version("0.13")
+            and self.settings.minimum_version < Version("1.0")
         ):
-            self.settings.sdist.resolve_symlinks = False
+            self.settings.sdist.resolve_symlinks = "none"
         else:
-            self.settings.sdist.resolve_symlinks = True
+            self.settings.sdist.resolve_symlinks = "all"
 
     def unrecognized_options(self) -> Generator[str, None, None]:
         return self.sources.unrecognized_options(ScikitBuildSettings)

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -454,6 +454,22 @@ class SettingsReader:
         else:
             self.settings.sdist.inclusion_mode = "default"
 
+        if self.settings.sdist.resolve_symlinks is not None:
+            if (
+                self.settings.minimum_version is not None
+                and self.settings.minimum_version < Version("0.13")
+            ):
+                rich_error(
+                    "minimum-version can't be less than 0.13 to use sdist.resolve-symlinks"
+                )
+        elif (
+            self.settings.minimum_version is not None
+            and self.settings.minimum_version < Version("0.13")
+        ):
+            self.settings.sdist.resolve_symlinks = False
+        else:
+            self.settings.sdist.resolve_symlinks = True
+
     def unrecognized_options(self) -> Generator[str, None, None]:
         return self.sources.unrecognized_options(ScikitBuildSettings)
 

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.build import build_sdist
+
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext")
+def test_pep517_sdist_symlink(tmp_path: Path):
+    # Attempt to create a symlink in the current working directory
+    try:
+        Path("CMakeLists_link.txt").symlink_to("CMakeLists.txt")
+    except OSError:
+        pytest.skip(
+            "Creating symlinks is not supported/allowed on this OS without privileges"
+        )
+
+    out = build_sdist(str(tmp_path))
+
+    with tarfile.open(tmp_path / out, "r:gz") as tar:
+        # Check that the symlink file is actually dereferenced into a regular file
+        link_member = tar.getmember("cmake_example-0.0.1/CMakeLists_link.txt")
+        assert link_member.isreg(), (
+            "The symlink should have been stored as a regular file"
+        )
+
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext")
+def test_pep517_sdist_symlink_no_dereference(tmp_path: Path):
+    try:
+        Path("CMakeLists_link_no_deref.txt").symlink_to("CMakeLists.txt")
+    except OSError:
+        pytest.skip(
+            "Creating symlinks is not supported/allowed on this OS without privileges"
+        )
+
+    out = build_sdist(
+        str(tmp_path),
+        config_settings={"sdist.dereference": "False"},
+    )
+
+    with tarfile.open(tmp_path / out, "r:gz") as tar:
+        # Check that the symlink file is actually NOT dereferenced
+        link_member = tar.getmember("cmake_example-0.0.1/CMakeLists_link_no_deref.txt")
+        assert link_member.issym(), "The symlink should have been stored as a symlink"

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -9,16 +9,16 @@ from scikit_build_core.build import build_sdist
 
 
 @pytest.fixture
-def can_symlink() -> None:
+def can_symlink(tmp_path: Path) -> None:
     """Skip the test if symlinks are not supported on this OS."""
+    target = tmp_path / "target"
+    target.touch()
     try:
-        Path("_symlink_check").symlink_to("_symlink_check_target")
+        tmp_path.joinpath("link").symlink_to(target)
     except OSError:
         pytest.skip(
             "Creating symlinks is not supported/allowed on this OS without privileges"
         )
-    else:
-        Path("_symlink_check").unlink(missing_ok=True)
 
 
 @pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -8,41 +8,43 @@ import pytest
 from scikit_build_core.build import build_sdist
 
 
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
-def test_pep517_sdist_symlink(tmp_path: Path):
-    # Attempt to create a symlink in the current working directory
+@pytest.fixture
+def can_symlink() -> None:
+    """Skip the test if symlinks are not supported on this OS."""
     try:
-        Path("CMakeLists_link.txt").symlink_to("CMakeLists.txt")
+        Path("_symlink_check").symlink_to("_symlink_check_target")
     except OSError:
         pytest.skip(
             "Creating symlinks is not supported/allowed on this OS without privileges"
         )
+    else:
+        Path("_symlink_check").unlink(missing_ok=True)
 
-    out = build_sdist(str(tmp_path))
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")
+@pytest.mark.parametrize(
+    ("config_settings", "expected_type"),
+    [
+        pytest.param({}, "reg", id="dereference_default"),
+        pytest.param({"sdist.resolve-symlinks": "false"}, "sym", id="no_dereference"),
+    ],
+)
+def test_pep517_sdist_symlink(
+    tmp_path: Path,
+    config_settings: dict[str, list[str] | str],
+    expected_type: str,
+) -> None:
+    Path("CMakeLists_link.txt").symlink_to("CMakeLists.txt")
+
+    out = build_sdist(str(tmp_path), config_settings=config_settings or None)
 
     with tarfile.open(tmp_path / out, "r:gz") as tar:
-        # Check that the symlink file is actually dereferenced into a regular file
         link_member = tar.getmember("cmake_example-0.0.1/CMakeLists_link.txt")
-        assert link_member.isreg(), (
-            "The symlink should have been stored as a regular file"
-        )
-
-
-@pytest.mark.usefixtures("package_simple_pyproject_ext")
-def test_pep517_sdist_symlink_no_dereference(tmp_path: Path):
-    try:
-        Path("CMakeLists_link_no_deref.txt").symlink_to("CMakeLists.txt")
-    except OSError:
-        pytest.skip(
-            "Creating symlinks is not supported/allowed on this OS without privileges"
-        )
-
-    out = build_sdist(
-        str(tmp_path),
-        config_settings={"sdist.dereference": "False"},
-    )
-
-    with tarfile.open(tmp_path / out, "r:gz") as tar:
-        # Check that the symlink file is actually NOT dereferenced
-        link_member = tar.getmember("cmake_example-0.0.1/CMakeLists_link_no_deref.txt")
-        assert link_member.issym(), "The symlink should have been stored as a symlink"
+        if expected_type == "reg":
+            assert link_member.isreg(), (
+                "The symlink should have been stored as a regular file"
+            )
+        else:
+            assert link_member.issym(), (
+                "The symlink should have been stored as a symlink"
+            )

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -25,8 +25,8 @@ def can_symlink(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("config_settings", "expected_type"),
     [
-        pytest.param({}, "reg", id="dereference_default"),
-        pytest.param({"sdist.resolve-symlinks": "false"}, "sym", id="no_dereference"),
+        pytest.param({}, "reg", id="resolve_all_default"),
+        pytest.param({"sdist.resolve-symlinks": "none"}, "sym", id="resolve_none"),
     ],
 )
 def test_pep517_sdist_symlink(

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -44,7 +44,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.sdist.inclusion_mode == "default"
     assert settings.sdist.reproducible
     assert not settings.sdist.cmake
-    assert settings.sdist.resolve_symlinks
+    assert settings.sdist.resolve_symlinks == "all"
     assert settings.wheel.packages is None
     assert settings.wheel.py_api == ""
     assert not settings.wheel.expand_macos_universal_tags
@@ -1154,7 +1154,7 @@ def test_backcompat_sdist_resolve_symlinks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setattr(
-        scikit_build_core.settings.skbuild_read_settings, "__version__", "0.13.0"
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.0.0"
     )
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(
@@ -1168,17 +1168,17 @@ def test_backcompat_sdist_resolve_symlinks(
     )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    assert settings_reader.settings.sdist.resolve_symlinks is False
+    assert settings_reader.settings.sdist.resolve_symlinks == "none"
 
     pyproject_toml.write_text(
         textwrap.dedent(
             """\
             [tool.scikit-build]
-            minimum-version = "0.13"
+            minimum-version = "1.0"
             """
         ),
         encoding="utf-8",
     )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    assert settings_reader.settings.sdist.resolve_symlinks is True
+    assert settings_reader.settings.sdist.resolve_symlinks == "all"

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -44,6 +44,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.sdist.inclusion_mode == "default"
     assert settings.sdist.reproducible
     assert not settings.sdist.cmake
+    assert settings.sdist.resolve_symlinks
     assert settings.wheel.packages is None
     assert settings.wheel.py_api == ""
     assert not settings.wheel.expand_macos_universal_tags
@@ -1147,3 +1148,37 @@ def test_backcompat_sdist_inclusion_mode(
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
     assert settings_reader.settings.sdist.inclusion_mode == "classic"
+
+
+def test_backcompat_sdist_resolve_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "0.13.0"
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            minimum-version = "0.12"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert not settings_reader.settings.sdist.resolve_symlinks
+
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            minimum-version = "0.13"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert settings_reader.settings.sdist.resolve_symlinks

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -1168,7 +1168,7 @@ def test_backcompat_sdist_resolve_symlinks(
     )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    assert not settings_reader.settings.sdist.resolve_symlinks
+    assert settings_reader.settings.sdist.resolve_symlinks is False
 
     pyproject_toml.write_text(
         textwrap.dedent(
@@ -1181,4 +1181,4 @@ def test_backcompat_sdist_resolve_symlinks(
     )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    assert settings_reader.settings.sdist.resolve_symlinks
+    assert settings_reader.settings.sdist.resolve_symlinks is True


### PR DESCRIPTION
Dereference symlinks by default to ensure sdists are completely self-contained and universally usable out of their source directories.

Closes #801