### PR TITLE
docs: add pyarrow to list of projects

### DIFF
--- a/docs/about/projects.md
+++ b/docs/about/projects.md
@@ -70,7 +70,8 @@ for project in projects["project"]:
 * [kiss-icp](https://pypi.org/project/kiss-icp) ([source](https://github.com/PRBonn/kiss-icp/blob/HEAD/python/pyproject.toml))
 * [simsopt](https://pypi.org/project/simsopt) ([source](https://github.com/hiddenSymmetries/simsopt/blob/HEAD/pyproject.toml))
 * [mqt-core](https://pypi.org/project/mqt-core) ([source](https://github.com/munich-quantum-toolkit/core/blob/HEAD/pyproject.toml))
-<!--[[[end]]] (sum: p5ium7Igqx)-->
+* [pyarrow](https://pypi.org/project/pyarrow) ([source](https://github.com/apache/arrow/blob/HEAD/python/pyproject.toml))
+<!--[[[end]]] (sum: M+iKao/rWk)-->
 
 <!-- prettier-ignore-end -->
 

--- a/docs/data/projects.toml
+++ b/docs/data/projects.toml
@@ -148,3 +148,8 @@ github = "hiddenSymmetries/simsopt"
 [[project]]
 pypi = "mqt-core"
 github = "munich-quantum-toolkit/core"
+
+[[project]]
+pypi = "pyarrow"
+github = "apache/arrow"
+path = "python/pyproject.toml"


### PR DESCRIPTION
PyArrow 24.0.0 is releasing in the next couple of days:
- https://lists.apache.org/thread/pwq2mo2zk4b926xt4tf94kfg7g8093ll

We migrated from setuptools to scikit-build-core for the release:
- https://github.com/apache/arrow/pull/49259/

PyPI stats for PyArrow:
https://pypistats.org/packages/pyarrow