### PR TITLE
chore: Prepare cattrs helper and file_api model for the file-api refactoring

### DIFF
--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -9,9 +9,8 @@ from typing import Any, Callable, Dict, Type, TypeVar  # noqa: TID251
 import cattr
 import cattr.preconf.json
 
-from .model.cache import Cache
-from .model.cmakefiles import CMakeFiles
-from .model.codemodel import CodeModel, Target
+from ..utils.typing import process_union
+from .model.codemodel import Target
 from .model.index import Index, Reply
 
 T = TypeVar("T")
@@ -27,28 +26,38 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
     converter = cattr.preconf.json.make_converter()
     converter.register_structure_hook(Path, to_path)
 
-    st_hook = cattr.gen.make_dict_structure_fn(
-        Reply,
-        converter,
-        # mypy fails over here for some reason, but this approach is as documented
-        **{  # type: ignore[arg-type]
-            # TODO: the object kind and version is specified in the file, use that to
-            #  narrow the type
-            f.name: cattr.gen.override(rename=f.name.replace("_", "-"))
-            for f in fields(Reply)
-        },
-    )
-    converter.register_structure_hook(Reply, st_hook)
-
     def from_json_file(with_path: Dict[str, Any], t: Type[T]) -> T:
+        t = process_union(t)
         if with_path["jsonFile"] is None:
             return converter.structure_attrs_fromdict({}, t)
         path = base_dir / Path(with_path["jsonFile"])
         raw = json.loads(path.read_text(encoding="utf-8"))
         return converter.structure_attrs_fromdict(raw, t)
 
+    overrides = {}
+    for f in fields(Reply):
+        # TODO: handle multi-versioned object kind in the struct_hook
+        #  the object kind and version is specified in the file, use that to
+        #  narrow the type
+        # Previous default handling that does not read the kind and version
+        type_override = cattr.gen.override(
+            rename=f.name.replace("_", "-"),
+            struct_hook=from_json_file,
+        )
+        overrides[f.name] = type_override
+
+    converter.register_structure_hook(
+        Reply,
+        cattr.gen.make_dict_structure_fn(
+            Reply,
+            converter,
+            # mypy fails over here for some reason, but this approach is as documented
+            **overrides,  # type: ignore[arg-type]
+        ),
+    )
+    # Other indirectly `jsonFile` loadable fields
     # TODO: Get this list of functions more programmatically
-    for object_kind_type in (CodeModel, Target, Cache, CMakeFiles):
+    for object_kind_type in (Target,):
         converter.register_structure_hook(object_kind_type, from_json_file)
     return converter
 

--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -2,6 +2,7 @@
 
 import builtins
 import json
+from dataclasses import fields
 from pathlib import Path
 from typing import Any, Callable, Dict, Type, TypeVar  # noqa: TID251
 
@@ -29,10 +30,13 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
     st_hook = cattr.gen.make_dict_structure_fn(
         Reply,
         converter,
-        codemodel_v2=cattr.gen.override(rename="codemodel-v2"),
-        cache_v2=cattr.gen.override(rename="cache-v2"),
-        cmakefiles_v1=cattr.gen.override(rename="cmakeFiles-v1"),
-        toolchains_v1=cattr.gen.override(rename="toolchains-v1"),
+        # mypy fails over here for some reason, but this approach is as documented
+        **{  # type: ignore[arg-type]
+            # TODO: the object kind and version is specified in the file, use that to
+            #  narrow the type
+            f.name: cattr.gen.override(rename=f.name.replace("_", "-"))
+            for f in fields(Reply)
+        },
     )
     converter.register_structure_hook(Reply, st_hook)
 
@@ -43,10 +47,9 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
         raw = json.loads(path.read_text(encoding="utf-8"))
         return converter.structure_attrs_fromdict(raw, t)
 
-    converter.register_structure_hook(CodeModel, from_json_file)
-    converter.register_structure_hook(Target, from_json_file)
-    converter.register_structure_hook(Cache, from_json_file)
-    converter.register_structure_hook(CMakeFiles, from_json_file)
+    # TODO: Get this list of functions more programmatically
+    for object_kind_type in (CodeModel, Target, Cache, CMakeFiles):
+        converter.register_structure_hook(object_kind_type, from_json_file)
     return converter
 
 

--- a/src/scikit_build_core/file_api/model/index.py
+++ b/src/scikit_build_core/file_api/model/index.py
@@ -59,7 +59,7 @@ class CMake:
 class Reply:
     codemodel_v2: Optional[CodeModel]
     cache_v2: Optional[Cache]
-    cmakefiles_v1: Optional[CMakeFiles]
+    cmakeFiles_v1: Optional[CMakeFiles]
     toolchains_v1: Optional[Toolchains]
 
 

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -62,9 +62,7 @@ class Converter:
 
         # We don't have DataclassInstance exposed in typing yet
         for field in dataclasses.fields(target):  # type: ignore[arg-type]
-            json_field = field.name.replace("_v", "-v").replace(
-                "cmakefiles", "cmakeFiles"
-            )
+            json_field = field.name.replace("_v", "-v")
             if json_field in data:
                 field_type = field.type
                 try:

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -13,6 +13,7 @@ from .model.cmakefiles import CMakeFiles
 from .model.codemodel import CodeModel, Target
 from .model.directory import Directory
 from .model.index import Index
+from .model.toolchains import Toolchains
 
 __all__ = ["load_reply_dir"]
 
@@ -51,7 +52,7 @@ class Converter:
         Convert a dict to a dataclass. Automatically load a few nested jsonFile classes.
         """
         if (
-            target in {CodeModel, Target, Cache, CMakeFiles, Directory}
+            target in {CodeModel, Target, Cache, CMakeFiles, Directory, Toolchains}
             and "jsonFile" in data
             and data["jsonFile"] is not None
         ):

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -85,7 +85,7 @@ def test_simple_pure(tmp_path):
     cache = index.reply.cache_v2
     assert cache is not None
 
-    cmakefiles = index.reply.cmakefiles_v1
+    cmakefiles = index.reply.cmakeFiles_v1
     assert cmakefiles is not None
 
     toolchains = index.reply.toolchains_v1
@@ -111,7 +111,7 @@ def test_included_dir():
     cache = index.reply.cache_v2
     assert cache is not None
 
-    cmakefiles = index.reply.cmakefiles_v1
+    cmakefiles = index.reply.cmakeFiles_v1
     assert cmakefiles is not None
 
     toolchains = index.reply.toolchains_v1


### PR DESCRIPTION
Making this as a separate PR to be easier to review and check the testing divergence. Will evolve together with #1012 and will keep a tally of what's going on here:
- Renaming the reply fields to simplify the hooks
- Generalize the structure hooks