### PR TITLE
bug: Properly handle Union in file-api

### DIFF
--- a/src/scikit_build_core/file_api/model/index.py
+++ b/src/scikit_build_core/file_api/model/index.py
@@ -57,10 +57,10 @@ class CMake:
 
 @dataclasses.dataclass(frozen=True)
 class Reply:
-    codemodel_v2: Optional[CodeModel]
-    cache_v2: Optional[Cache]
-    cmakefiles_v1: Optional[CMakeFiles]
-    toolchains_v1: Optional[Toolchains]
+    codemodel_v2: Optional[CodeModel] = None
+    cache_v2: Optional[Cache] = None
+    cmakefiles_v1: Optional[CMakeFiles] = None
+    toolchains_v1: Optional[Toolchains] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -8,6 +8,11 @@ from typing import Any, Callable, Dict, List, Type, TypeVar, Union  # noqa: TID2
 
 from .._compat.builtins import ExceptionGroup
 from .._compat.typing import get_args, get_origin
+from ..utils.typing import (
+    get_target_raw_type,
+    is_union_type,
+    process_union,
+)
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
 from .model.codemodel import CodeModel, Target
@@ -93,17 +98,27 @@ class Converter:
     def _convert_any(self, item: Any, target: Any) -> Any: ...
 
     def _convert_any(self, item: Any, target: Union[Type[T], Any]) -> Any:
+        target = process_union(target)
         if dataclasses.is_dataclass(target) and isinstance(target, type):
             # We don't have DataclassInstance exposed in typing yet
             return self.make_class(item, target)
-        origin = get_origin(target)
-        if origin is not None:
-            if origin is list:
-                return [self._convert_any(i, get_args(target)[0]) for i in item]
-            if origin is Union:
-                return self._convert_any(item, get_args(target)[0])
+        raw_target = get_target_raw_type(target)
+        # For generic Unions we try each type on at a time
+        if is_union_type(raw_target):
+            last_err: Exception = AssertionError("Failed for unknown reason")
+            for maybe_target in get_args(target):
+                try:
+                    return self._convert_any(item, maybe_target)
+                except ExceptionGroup as err:  # noqa: PERF203
+                    last_err = err
+                    continue
+            raise last_err
 
-        return target(item)  # type: ignore[call-arg]
+        origin = get_origin(target)
+        if origin is not None and origin is list:
+            return [self._convert_any(i, get_args(target)[0]) for i in item]
+
+        return target(item)
 
 
 def load_reply_dir(path: Path) -> Index:

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -103,13 +103,23 @@ class Converter:
             # We don't have DataclassInstance exposed in typing yet
             return self.make_class(item, target)
         raw_target = get_target_raw_type(target)
-        # For generic Unions we try each type on at a time
+        # For generic Unions we try each type one at a time. We first match the
+        # shape of the item against the candidate, so that e.g. ``str(<dict>)``
+        # cannot shadow a dataclass member in ``Union[str, Paths]``: a dict-like
+        # item must go to a dataclass member, and any other item to a
+        # non-dataclass member.
         if is_union_type(raw_target):
-            last_err: Exception = AssertionError("Failed for unknown reason")
+            last_err: Exception = TypeError(f"No member of {target} matched {item!r}")
             for maybe_target in get_args(target):
+                sub_target = process_union(maybe_target)
+                is_dataclass = dataclasses.is_dataclass(sub_target) and isinstance(
+                    sub_target, type
+                )
+                if isinstance(item, dict) != is_dataclass:
+                    continue
                 try:
                     return self._convert_any(item, maybe_target)
-                except ExceptionGroup as err:  # noqa: PERF203
+                except (ExceptionGroup, TypeError) as err:
                     last_err = err
                     continue
             raise last_err

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sysconfig
 from pathlib import Path
+from typing import List, Union
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -12,8 +13,9 @@ from scikit_build_core.cmake import CMake, CMaker
 from scikit_build_core.file_api._cattrs_converter import (
     load_reply_dir as load_reply_dir_cattrs,
 )
+from scikit_build_core.file_api.model.common import Paths
 from scikit_build_core.file_api.query import stateless_query
-from scikit_build_core.file_api.reply import load_reply_dir
+from scikit_build_core.file_api.reply import Converter, load_reply_dir
 
 DIR = Path(__file__).parent.absolute()
 
@@ -52,6 +54,21 @@ def test_cattrs_comparison(tmp_path):
     cattrs_index = load_reply_dir_cattrs(reply_dir)
     index = load_reply_dir(reply_dir)
     assert index == cattrs_index
+
+
+def test_convert_union_matches_shape():
+    # ``InstallRule.paths`` is a ``List[Union[str, Paths]]``. A bare string must
+    # stay a string, while a mapping must be converted to the dataclass member
+    # (``str(<dict>)`` would otherwise succeed and shadow ``Paths``).
+    converter = Converter(Path())
+    result = converter._convert_any(
+        ["a/string", {"source": "src/dir", "build": "build/dir"}],
+        List[Union[str, Paths]],
+    )
+    assert result == [
+        "a/string",
+        Paths(source=Path("src/dir"), build=Path("build/dir")),
+    ]
 
 
 # TODO: Why is this an IndexError?


### PR DESCRIPTION
Previously only the first type was considered, but evidently that can potentially fail. Seems like this would only happen in one case

https://github.com/scikit-build/scikit-build-core/blob/db72d462f75f25aa372ab2c856106f322976a870/src/scikit_build_core/file_api/model/directory.py#L25