### PR TITLE
ci: use native uv integration in rtd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,7 +138,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,11 +9,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
-  commands:
-    - git fetch --unshallow
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --group docs
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2026/04/uv-native-support for info.

Added in https://github.com/readthedocs/readthedocs.org/pull/12879.

Needs schema update: https://github.com/python-jsonschema/check-jsonschema/pull/676
