### PR TITLE
Fix importlib.resources.files() in redirect-mode editable installs (#807)

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -83,7 +83,7 @@ class _SkbuildMultiplexedPath:
 
     Used to combine source-tree and CMake-install-tree paths so that
     importlib.resources.files() can see files from both locations.
-    Works on Python 3.8+ without requiring importlib.resources.readers.
+    Fallback for Python < 3.11, which lacks importlib.resources.readers.MultiplexedPath.
     """
 
     def __init__(self, *paths: str) -> None:
@@ -168,6 +168,10 @@ class _ScikitBuildEditableReader:
             return Path(self._paths[0]) if self._paths else Path(".")
         if len(existing) == 1:
             return Path(existing[0])
+        if sys.version_info >= (3, 11):
+            from importlib.resources.readers import MultiplexedPath
+
+            return MultiplexedPath(*existing)
         return _SkbuildMultiplexedPath(*existing)
 
 

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -208,6 +208,36 @@ class _ScikitBuildResourceLoaderWrapper:
         return _ScikitBuildEditableReader(self._skbuild_paths)
 
 
+def _patch_importlib_resources_for_python39() -> None:
+    """
+    Make importlib.resources.files() honor the editable resource reader on Python 3.9.
+
+    Python 3.9 ignores get_resource_reader().files() and falls back to
+    Path(spec.origin).parent, which points at the source tree for editable
+    installs. Patch that fallback so redirect packages can expose build-tree
+    resources there too.
+    """
+
+    if sys.version_info[:2] != (3, 9):
+        return
+
+    from importlib.resources import _common  # type: ignore[attr-defined]
+
+    if getattr(_common, "_skbuild_editable_patched", False):
+        return
+
+    original_fallback_resources = _common.fallback_resources
+
+    def fallback_resources(spec: object) -> object:
+        loader = getattr(spec, "loader", None)
+        if isinstance(loader, _ScikitBuildResourceLoaderWrapper):
+            return loader.get_resource_reader(getattr(spec, "name", "")).files()
+        return original_fallback_resources(spec)
+
+    _common.fallback_resources = fallback_resources
+    _common._skbuild_editable_patched = True
+
+
 class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
     def __init__(
         self,
@@ -412,6 +442,7 @@ def install(
     :param install_dir: The wheel install directory override, if one was
                         specified
     """
+    _patch_importlib_resources_for_python39()
     sys.meta_path.insert(
         0,
         ScikitBuildRedirectingFinder(

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -235,7 +235,7 @@ def _patch_importlib_resources_for_python39() -> None:
         return original_fallback_resources(spec)
 
     _common.fallback_resources = fallback_resources
-    _common._skbuild_editable_patched = True
+    _common._skbuild_editable_patched = True  # pylint: disable=protected-access
 
 
 class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
@@ -263,7 +263,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
 
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
-        submodule_search_locations: dict[str, list[str]] = {}
+        submodule_search_locations: dict[str, set[str]] = {}
         pkgs: list[str] = []
         # Loop over both python native source files and cmake installed ones
         for tree in (known_source_files, known_wheel_files):
@@ -278,7 +278,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 if not parent:
                     continue
                 # Initialize the tree element if needed
-                submodule_search_locations.setdefault(parent, [])
+                submodule_search_locations.setdefault(parent, set())
                 # Add the parent path to the dictionary values
                 parent_path = os.path.dirname(file)
                 if not parent_path:
@@ -287,8 +287,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                     raise ImportError(msg)
                 if not os.path.isabs(parent_path):
                     parent_path = os.path.join(self.dir, parent_path)
-                if parent_path not in submodule_search_locations[parent]:
-                    submodule_search_locations[parent].append(parent_path)
+                submodule_search_locations[parent].add(parent_path)
         # Second pass: propagate build-tree paths from parent packages to
         # sub-packages.  This covers the case where a Python package (with
         # __init__.py) lives in a directory that also contains CMake-generated
@@ -299,13 +298,13 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             last = pkg.split(".")[-1]
             if not parent or parent not in submodule_search_locations:
                 continue
-            for parent_path in submodule_search_locations[parent]:
+            for parent_path in sorted(submodule_search_locations[parent]):
                 sub_path = os.path.join(parent_path, last)
                 if (
                     os.path.isdir(sub_path)
                     and sub_path not in submodule_search_locations[pkg]
                 ):
-                    submodule_search_locations[pkg].append(sub_path)
+                    submodule_search_locations[pkg].add(sub_path)
 
         self.submodule_search_locations = submodule_search_locations
         self.pkgs = frozenset(pkgs)

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -83,7 +83,8 @@ class _SkbuildMultiplexedPath:
 
     Used to combine source-tree and CMake-install-tree paths so that
     importlib.resources.files() can see files from both locations.
-    Fallback for Python < 3.11, which lacks importlib.resources.readers.MultiplexedPath.
+    Fallback for Python < 3.12, whose importlib.resources.readers.MultiplexedPath
+    mishandles slash-containing joinpath() calls across search locations.
     """
 
     def __init__(self, *paths: str) -> None:
@@ -168,6 +169,15 @@ class _ScikitBuildEditableReader:
             return Path(self._paths[0]) if self._paths else Path(".")
         if len(existing) == 1:
             return Path(existing[0])
+        if sys.version_info >= (3, 12):
+            # The stdlib MultiplexedPath is only reliable on 3.12+.  On 3.11
+            # and earlier, joinpath() with a slash-containing path (e.g.
+            # "namespace1/generated_data") falls back to the first search
+            # location instead of navigating across them, so we use the
+            # _SkbuildMultiplexedPath fallback below.
+            from importlib.resources.readers import MultiplexedPath
+
+            return MultiplexedPath(*[Path(p) for p in existing])
         return _SkbuildMultiplexedPath(*existing)
 
     def open_resource(self, resource: str) -> object:
@@ -288,23 +298,6 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 if not os.path.isabs(parent_path):
                     parent_path = os.path.join(self.dir, parent_path)
                 submodule_search_locations[parent].add(parent_path)
-        # Second pass: propagate build-tree paths from parent packages to
-        # sub-packages.  This covers the case where a Python package (with
-        # __init__.py) lives in a directory that also contains CMake-generated
-        # data files but has no Python modules of its own in the build tree.
-        # Processing in depth order ensures parents are resolved before children.
-        for pkg in sorted(pkgs, key=lambda p: p.count(".")):
-            parent = ".".join(pkg.split(".")[:-1])
-            last = pkg.split(".")[-1]
-            if not parent or parent not in submodule_search_locations:
-                continue
-            for parent_path in sorted(submodule_search_locations[parent]):
-                sub_path = os.path.join(parent_path, last)
-                if (
-                    os.path.isdir(sub_path)
-                    and sub_path not in submodule_search_locations[pkg]
-                ):
-                    submodule_search_locations[pkg].add(sub_path)
 
         self.submodule_search_locations = submodule_search_locations
         self.pkgs = frozenset(pkgs)
@@ -323,38 +316,35 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             submodule_search_locations = None
 
         if fullname in self.known_wheel_files:
-            redir = self.known_wheel_files[fullname]
             if self.rebuild_flag:
                 self.rebuild()
-            is_pkg = redir.endswith(("__init__.py", "__init__.pyc"))
-            spec = importlib.util.spec_from_file_location(
-                fullname,
-                os.path.join(self.dir, redir),
-                submodule_search_locations=submodule_search_locations
-                if is_pkg
-                else None,
-            )
-            if spec is not None and is_pkg and submodule_search_locations:
-                spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
-                    spec.loader, submodule_search_locations
-                )
-            return spec
+            origin = os.path.join(self.dir, self.known_wheel_files[fullname])
+            return self._make_spec(fullname, origin, submodule_search_locations)
         if fullname in self.known_source_files:
-            redir = self.known_source_files[fullname]
-            is_pkg = redir.endswith(("__init__.py", "__init__.pyc"))
-            spec = importlib.util.spec_from_file_location(
-                fullname,
-                redir,
-                submodule_search_locations=submodule_search_locations
-                if is_pkg
-                else None,
-            )
-            if spec is not None and is_pkg and submodule_search_locations:
-                spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
-                    spec.loader, submodule_search_locations
-                )
-            return spec
+            origin = self.known_source_files[fullname]
+            return self._make_spec(fullname, origin, submodule_search_locations)
         return None
+
+    def _make_spec(
+        self,
+        fullname: str,
+        origin: str,
+        submodule_search_locations: list[str] | None,
+    ) -> ModuleSpec | None:
+        is_pkg = origin.endswith(("__init__.py", "__init__.pyc"))
+        spec = importlib.util.spec_from_file_location(
+            fullname,
+            origin,
+            submodule_search_locations=submodule_search_locations if is_pkg else None,
+        )
+        # For packages with multiple search locations (e.g. a source tree and a
+        # CMake install tree), wrap the loader so importlib.resources.files()
+        # can see resources from every location, not just origin's directory.
+        if spec is not None and is_pkg and submodule_search_locations:
+            spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
+                spec.loader, submodule_search_locations
+            )
+        return spec
 
     def rebuild(self) -> None:
         # Don't rebuild if not set to a local path

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -168,11 +168,24 @@ class _ScikitBuildEditableReader:
             return Path(self._paths[0]) if self._paths else Path(".")
         if len(existing) == 1:
             return Path(existing[0])
-        if sys.version_info >= (3, 11):
-            from importlib.resources.readers import MultiplexedPath
-
-            return MultiplexedPath(*existing)
         return _SkbuildMultiplexedPath(*existing)
+
+    def open_resource(self, resource: str) -> object:
+        return self.files().joinpath(resource).open("rb")  # type: ignore[attr-defined]
+
+    def resource_path(self, resource: str) -> str:
+        path = self.files().joinpath(resource)  # type: ignore[attr-defined]
+        if hasattr(path, "__fspath__"):
+            return str(path)
+        msg = f"{resource!r} is not available as a concrete file path"
+        raise FileNotFoundError(msg)
+
+    def is_resource(self, name: str) -> bool:
+        path = self.files().joinpath(name)  # type: ignore[attr-defined]
+        return hasattr(path, "is_file") and path.is_file()
+
+    def contents(self) -> object:
+        return (item.name for item in self.files().iterdir())  # type: ignore[attr-defined]
 
 
 class _ScikitBuildResourceLoaderWrapper:
@@ -220,7 +233,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
 
         # Construct the __path__ of all resource files
         # I.e. the paths of all package-like objects
-        submodule_search_locations: dict[str, set[str]] = {}
+        submodule_search_locations: dict[str, list[str]] = {}
         pkgs: list[str] = []
         # Loop over both python native source files and cmake installed ones
         for tree in (known_source_files, known_wheel_files):
@@ -235,7 +248,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 if not parent:
                     continue
                 # Initialize the tree element if needed
-                submodule_search_locations.setdefault(parent, set())
+                submodule_search_locations.setdefault(parent, [])
                 # Add the parent path to the dictionary values
                 parent_path = os.path.dirname(file)
                 if not parent_path:
@@ -244,7 +257,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                     raise ImportError(msg)
                 if not os.path.isabs(parent_path):
                     parent_path = os.path.join(self.dir, parent_path)
-                submodule_search_locations[parent].add(parent_path)
+                if parent_path not in submodule_search_locations[parent]:
+                    submodule_search_locations[parent].append(parent_path)
         # Second pass: propagate build-tree paths from parent packages to
         # sub-packages.  This covers the case where a Python package (with
         # __init__.py) lives in a directory that also contains CMake-generated
@@ -257,8 +271,11 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 continue
             for parent_path in submodule_search_locations[parent]:
                 sub_path = os.path.join(parent_path, last)
-                if os.path.isdir(sub_path):
-                    submodule_search_locations[pkg].add(sub_path)
+                if (
+                    os.path.isdir(sub_path)
+                    and sub_path not in submodule_search_locations[pkg]
+                ):
+                    submodule_search_locations[pkg].append(sub_path)
 
         self.submodule_search_locations = submodule_search_locations
         self.pkgs = frozenset(pkgs)

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -77,6 +77,120 @@ class FileLockIfUnix:
         os.close(self.lock_file_fd)
 
 
+class _SkbuildMultiplexedPath:
+    """
+    A Traversable that merges multiple filesystem directories.
+
+    Used to combine source-tree and CMake-install-tree paths so that
+    importlib.resources.files() can see files from both locations.
+    Works on Python 3.8+ without requiring importlib.resources.readers.
+    """
+
+    def __init__(self, *paths: str) -> None:
+        from pathlib import Path
+
+        self._paths = [Path(p) for p in paths if os.path.isdir(p)]
+
+    @property
+    def name(self) -> str:
+        return self._paths[0].name if self._paths else ""
+
+    def is_dir(self) -> bool:
+        return True
+
+    def is_file(self) -> bool:
+        return False
+
+    def open(self, *args: object, **kwargs: object) -> object:
+        raise IsADirectoryError(self._paths[0] if self._paths else "")
+
+    def read_bytes(self) -> bytes:
+        raise IsADirectoryError
+
+    def read_text(self, encoding: str | None = None) -> str:
+        raise IsADirectoryError
+
+    def iterdir(self) -> object:
+        seen: dict[str, object] = {}
+        for base in self._paths:
+            for child in base.iterdir():
+                if child.name not in seen:
+                    seen[child.name] = child
+        return iter(seen.values())
+
+    def joinpath(self, *descendants: object) -> object:
+        if not descendants:
+            return self
+        from pathlib import Path
+
+        first = str(descendants[0])
+        rest = descendants[1:]
+        parts = first.split("/")
+        child_name, extra = parts[0], parts[1:]
+
+        candidates = [p / child_name for p in self._paths if (p / child_name).exists()]
+        if not candidates:
+            return (self._paths[0] / child_name) if self._paths else Path(child_name)
+        if len(candidates) == 1 or not all(c.is_dir() for c in candidates):
+            result: object = candidates[0]
+        else:
+            result = _SkbuildMultiplexedPath(*[str(c) for c in candidates])
+        for part in extra:
+            result = result / part  # type: ignore[operator]
+        for desc in rest:
+            result = result / str(desc)  # type: ignore[operator]
+        return result
+
+    def __truediv__(self, child: object) -> object:
+        return self.joinpath(str(child))
+
+    def __repr__(self) -> str:
+        paths = ", ".join(f"'{p}'" for p in self._paths)
+        return f"_SkbuildMultiplexedPath({paths})"
+
+
+class _ScikitBuildEditableReader:
+    """
+    Resource reader for editable installs with multiple package roots.
+
+    Provides importlib.resources.files() access across both the source tree
+    and the CMake install tree.
+    """
+
+    def __init__(self, paths: list[str]) -> None:
+        self._paths = paths
+
+    def files(self) -> object:
+        from pathlib import Path
+
+        existing = [p for p in self._paths if os.path.isdir(p)]
+        if not existing:
+            return Path(self._paths[0]) if self._paths else Path(".")
+        if len(existing) == 1:
+            return Path(existing[0])
+        return _SkbuildMultiplexedPath(*existing)
+
+
+class _ScikitBuildResourceLoaderWrapper:
+    """
+    Thin wrapper around a module loader that provides multi-path resource reading.
+
+    Delegates all loader functionality to the wrapped loader, overriding only
+    get_resource_reader() to return a reader covering all search paths (both
+    source and CMake install trees).
+    """
+
+    def __init__(self, loader: object, search_paths: list[str]) -> None:
+        self._skbuild_loader = loader
+        self._skbuild_paths = search_paths
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._skbuild_loader, name)
+
+    def get_resource_reader(self, module_name: str) -> _ScikitBuildEditableReader:
+        return _ScikitBuildEditableReader(self._skbuild_paths)
+
+
 class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
     def __init__(
         self,
@@ -127,6 +241,21 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 if not os.path.isabs(parent_path):
                     parent_path = os.path.join(self.dir, parent_path)
                 submodule_search_locations[parent].add(parent_path)
+        # Second pass: propagate build-tree paths from parent packages to
+        # sub-packages.  This covers the case where a Python package (with
+        # __init__.py) lives in a directory that also contains CMake-generated
+        # data files but has no Python modules of its own in the build tree.
+        # Processing in depth order ensures parents are resolved before children.
+        for pkg in sorted(pkgs, key=lambda p: p.count(".")):
+            parent = ".".join(pkg.split(".")[:-1])
+            last = pkg.split(".")[-1]
+            if not parent or parent not in submodule_search_locations:
+                continue
+            for parent_path in submodule_search_locations[parent]:
+                sub_path = os.path.join(parent_path, last)
+                if os.path.isdir(sub_path):
+                    submodule_search_locations[pkg].add(sub_path)
+
         self.submodule_search_locations = submodule_search_locations
         self.pkgs = frozenset(pkgs)
 
@@ -147,22 +276,34 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             redir = self.known_wheel_files[fullname]
             if self.rebuild_flag:
                 self.rebuild()
-            return importlib.util.spec_from_file_location(
+            is_pkg = redir.endswith(("__init__.py", "__init__.pyc"))
+            spec = importlib.util.spec_from_file_location(
                 fullname,
                 os.path.join(self.dir, redir),
                 submodule_search_locations=submodule_search_locations
-                if fullname in self.pkgs
+                if is_pkg
                 else None,
             )
+            if spec is not None and is_pkg and submodule_search_locations:
+                spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
+                    spec.loader, submodule_search_locations
+                )
+            return spec
         if fullname in self.known_source_files:
             redir = self.known_source_files[fullname]
-            return importlib.util.spec_from_file_location(
+            is_pkg = redir.endswith(("__init__.py", "__init__.pyc"))
+            spec = importlib.util.spec_from_file_location(
                 fullname,
                 redir,
                 submodule_search_locations=submodule_search_locations
-                if fullname in self.pkgs
+                if is_pkg
                 else None,
             )
+            if spec is not None and is_pkg and submodule_search_locations:
+                spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
+                    spec.loader, submodule_search_locations
+                )
+            return spec
         return None
 
     def rebuild(self) -> None:

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -17,7 +17,6 @@ import pytest
         pytest.param(
             True,
             id="package",
-            marks=[pytest.mark.xfail(reason="Only data folders supported currently")],
         ),
         pytest.param(False, id="datafolder"),
     ],
@@ -151,8 +150,6 @@ def test_importlib_resources(editable, isolated):
         pytest.skip("importlib.resources.files is introduced in Python 3.9")
 
     # TODO: Investigate these failures
-    if editable.mode == "redirect":
-        pytest.xfail("Redirect mode is at navigating importlib.resources.files")
     if platform.system() == "Windows" and editable.mode == "inplace":
         pytest.xfail("Windows fails to import the top-level extension module")
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -18,14 +18,18 @@ import pytest
             True,
             id="package",
         ),
-        pytest.param(False, id="datafolder"),
+        pytest.param(
+            False,
+            id="datafolder",
+            marks=pytest.mark.xfail(
+                sys.version_info[:2] == (3, 9),
+                reason="Python 3.9 redirect does not support resource-only data folders yet",
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("package", ["navigate_editable"], indirect=True)
 @pytest.mark.usefixtures("package")
-@pytest.mark.xfail(
-    sys.version_info[:2] == (3, 9), reason="Python 3.9 not supported yet"
-)
 def test_navigate_editable(isolated, isolate, py_pkg):
     if py_pkg:
         init_py = Path("python/shared_pkg/data/__init__.py")

--- a/tests/test_editable_generated.py
+++ b/tests/test_editable_generated.py
@@ -254,10 +254,6 @@ def test_configure_time_generated_module(editable, isolated):
         pytest.param(None, id="not_editable"),
         pytest.param(
             "redirect",
-            marks=pytest.mark.xfail(
-                sys.version_info[0:2] == (3, 9),
-                reason="Python 3.9 redirect doesn't work for generated data in a namespace subpackage from a generated module.",
-            ),
         ),
         pytest.param(
             "inplace",

--- a/tests/test_editable_generated.py
+++ b/tests/test_editable_generated.py
@@ -74,7 +74,6 @@ def test_basic_data_resources(editable, isolated):
         pytest.param(None, id="not_editable"),
         pytest.param(
             "redirect",
-            marks=pytest.mark.xfail(reason="Redirection requires #808", strict=True),
         ),
         pytest.param(
             "inplace",
@@ -113,7 +112,6 @@ def test_configure_time_generated_data(editable, isolated):
         pytest.param(None, id="not_editable"),
         pytest.param(
             "redirect",
-            marks=pytest.mark.xfail(reason="Redirection requires #808", strict=True),
         ),
         pytest.param(
             "inplace",
@@ -152,7 +150,6 @@ def test_build_time_generated_data(editable, isolated):
         pytest.param(None, id="not_editable"),
         pytest.param(
             "redirect",
-            marks=pytest.mark.xfail(reason="Redirection requires #808", strict=True),
         ),
         pytest.param(
             "inplace",

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -9,8 +9,8 @@ def process_dict(d: dict[str, str]) -> dict[str, str]:
     return {k: str(Path(v)) for k, v in d.items()}
 
 
-def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
-    return {k: {str(Path(x)) for x in v} for k, v in d.items()}
+def process_dict_set(d: dict[str, set[str]]) -> dict[str, list[str]]:
+    return {k: sorted(str(Path(x)) for x in v) for k, v in d.items()}
 
 
 def test_editable_redirect():
@@ -47,7 +47,9 @@ def test_editable_redirect():
         install_dir="",
     )
 
-    assert finder.submodule_search_locations == process_dict_set(
+    assert {
+        k: sorted(v) for k, v in finder.submodule_search_locations.items()
+    } == process_dict_set(
         {
             "pkg": {
                 "/sitepackages/pkg",

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -9,8 +9,8 @@ def process_dict(d: dict[str, str]) -> dict[str, str]:
     return {k: str(Path(v)) for k, v in d.items()}
 
 
-def process_dict_set(d: dict[str, set[str]]) -> dict[str, list[str]]:
-    return {k: sorted(str(Path(x)) for x in v) for k, v in d.items()}
+def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
+    return {k: {str(Path(x)) for x in v} for k, v in d.items()}
 
 
 def test_editable_redirect():
@@ -47,9 +47,7 @@ def test_editable_redirect():
         install_dir="",
     )
 
-    assert {
-        k: sorted(v) for k, v in finder.submodule_search_locations.items()
-    } == process_dict_set(
+    assert finder.submodule_search_locations == process_dict_set(
         {
             "pkg": {
                 "/sitepackages/pkg",


### PR DESCRIPTION
Fix #807. Looking at what copilot does for this.

Assisted-by: Copilot:claude-sonnet-4.6
Assisted-by: ClaudeCode:claude-opus-4.8
