### PR TITLE
feat: add experimental PEP 817 variant support

### DIFF
--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -117,6 +117,51 @@ Windows currently requires a little extra care. You should set the C define
 `Py_GIL_DISABLED` on Windows; due to the way the two builds share the same
 config files, Python cannot set it for you on the free-threaded variant.
 
+## Building wheel variants (experimental)
+
+```{warning}
+This is an early preview of [PEP 817][] wheel variant support. The interface may
+change, and it must be opted into with `experimental = true`.
+```
+
+Scikit-build-core can attach variant metadata to a wheel, producing a
+variant-labeled filename (the label becomes the final field of the wheel name)
+and a `variant.json` file inside `*.dist-info`. This lets you ship several wheels
+for the same version that differ by hardware or library features (CPU ABI, CUDA
+version, BLAS implementation, etc.).
+
+Because each variant of a build needs different settings, the variant options are
+**only allowed in config-settings or `[[tool.scikit-build.overrides]]`** — they
+cannot be hard-coded at the top level of `pyproject.toml`. The relevant settings
+are:
+
+- `variant` / `variant-name`: variant properties in
+  `namespace :: feature :: value` form (repeatable).
+- `variant-label`: override the computed label used in the wheel filename.
+- `null-variant`: build the null variant (mutually exclusive with the above).
+
+When any of these are set, [`variantlib`][] is automatically injected as a build
+requirement, and the experimental flag must be enabled. For example, to build a
+CPU-ABI variant with `pip`:
+
+```bash
+pip wheel . \
+  -Cexperimental=true \
+  -Cvariant="cpu :: abi :: cp313" \
+  -Cvariant-label=cpu
+```
+
+Or to enable it for everyone via an override (still keeping the per-build values
+in config-settings), put the experimental flag in `pyproject.toml`:
+
+```toml
+[tool.scikit-build]
+experimental = true
+```
+
+Pass `-Cvariant=...` (and friends) at build time to select which variant to
+produce.
+
 [^1]:
     Due to a [bug in packaging](https://github.com/pypa/packaging/issues/160),
     some backends may mistakenly produce the wrong tags (including
@@ -133,5 +178,7 @@ config files, Python cannot set it for you on the free-threaded variant.
 [scientific python development guidelines]: https://learn.scientific-python.org/development
 [pybind11 example]: https://github.com/pybind/scikit_build_example
 [dozens of recipes]: https://github.com/search?type=code&q=org%3Aconda-forge+path%3Arecipe%2Fmeta.yaml+scikit-build-core
+[pep 817]: https://peps.python.org/pep-0817
+[`variantlib`]: https://github.com/wheelnext/variantlib
 
 <!-- prettier-ignore-end -->

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -126,14 +126,14 @@ change, and it must be opted into with `experimental = true`.
 
 Scikit-build-core can attach variant metadata to a wheel, producing a
 variant-labeled filename (the label becomes the final field of the wheel name)
-and a `variant.json` file inside `*.dist-info`. This lets you ship several wheels
-for the same version that differ by hardware or library features (CPU ABI, CUDA
-version, BLAS implementation, etc.).
+and a `variant.json` file inside `*.dist-info`. This lets you ship several
+wheels for the same version that differ by hardware or library features (CPU
+ABI, CUDA version, BLAS implementation, etc.).
 
-Because each variant of a build needs different settings, the variant options are
-**only allowed in config-settings or `[[tool.scikit-build.overrides]]`** — they
-cannot be hard-coded at the top level of `pyproject.toml`. The relevant settings
-are:
+Because each variant of a build needs different settings, the variant options
+are **only allowed in config-settings or `[[tool.scikit-build.overrides]]`** —
+they cannot be hard-coded at the top level of `pyproject.toml`. The relevant
+settings are:
 
 - `variant` / `variant-name`: variant properties in
   `namespace :: feature :: value` form (repeatable).

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -98,6 +98,16 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: null-variant
+  :type: ``bool``
+  :default: false
+
+  Experimental PEP 817 null-variant selector.
+
+  This is only allowed in overrides or config-settings.
+```
+
+```{eval-rst}
 .. confval:: strict-config
   :type: ``bool``
   :default: true
@@ -107,6 +117,33 @@ print(mk_skbuild_docs())
   If False, warnings will be printed for unknown options.
 
   If True, an error will be raised.
+```
+
+```{eval-rst}
+.. confval:: variant
+  :type: ``list[str]``
+
+  Experimental PEP 817 variant properties.
+
+  This is only allowed in overrides or config-settings.
+```
+
+```{eval-rst}
+.. confval:: variant-label
+  :type: ``str``
+
+  Experimental PEP 817 wheel variant label override.
+
+  This is only allowed in overrides or config-settings.
+```
+
+```{eval-rst}
+.. confval:: variant-name
+  :type: ``list[str]``
+
+  Experimental PEP 817 variant properties used for wheel metadata selection.
+
+  This is only allowed in overrides or config-settings.
 ```
 
 ## backport

--- a/src/scikit_build_core/_variants.py
+++ b/src/scikit_build_core/_variants.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ._vendor.pyproject_metadata import StandardMetadata
+    from .settings.skbuild_model import ScikitBuildSettings
+
+VARIANTLIB_BUILD_REQUIREMENT = "variantlib"
+VARIANT_DIST_INFO_FILENAME = "variant.json"
+
+__all__ = [
+    "VARIANT_DIST_INFO_FILENAME",
+    "get_wheel_variant",
+    "validate_variant_settings",
+    "variant_build_requires",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@dataclasses.dataclass(frozen=True)
+class WheelVariant:
+    label: str
+    dist_info_contents: bytes
+
+
+def has_variant_config(settings: ScikitBuildSettings) -> bool:
+    return bool(
+        settings.variant
+        or settings.variant_name
+        or settings.null_variant
+        or settings.variant_label
+    )
+
+
+def variant_build_requires(settings: ScikitBuildSettings) -> list[str]:
+    if settings.variant or settings.variant_name or settings.null_variant:
+        return [VARIANTLIB_BUILD_REQUIREMENT]
+    return []
+
+
+def validate_variant_settings(settings: ScikitBuildSettings) -> None:
+    if not has_variant_config(settings):
+        return
+
+    if not settings.experimental:
+        from ._logging import rich_error
+
+        rich_error(
+            "experimental must be enabled currently to use PEP 817 variant settings"
+        )
+
+    if settings.null_variant and (settings.variant or settings.variant_name):
+        from ._logging import rich_error
+
+        rich_error(
+            'null-variant is mutually exclusive with "variant" and "variant-name"'
+        )
+
+    if settings.null_variant and settings.variant_label:
+        from ._logging import rich_error
+
+        rich_error('null-variant is mutually exclusive with "variant-label"')
+
+    if settings.variant_label and not (
+        settings.variant or settings.variant_name or settings.null_variant
+    ):
+        from ._logging import rich_error
+
+        rich_error('variant-label requires "variant", "variant-name", or null-variant')
+
+
+def get_wheel_variant(
+    settings: ScikitBuildSettings,
+    pyproject: dict[str, object],
+    metadata: StandardMetadata,
+) -> WheelVariant | None:
+    if not (settings.variant or settings.variant_name or settings.null_variant):
+        return None
+
+    from ._logging import rich_error
+
+    try:
+        variantlib_api = importlib.import_module("variantlib.api")
+        variantlib_errors = importlib.import_module("variantlib.errors")
+        variantlib_models = importlib.import_module("variantlib.models.variant")
+        variantlib_pyproject = importlib.import_module("variantlib.pyproject_toml")
+    except ModuleNotFoundError:
+        rich_error("variantlib is required to use PEP 817 variant settings")
+
+    get_variant_label = variantlib_api.get_variant_label
+    make_variant_dist_info = variantlib_api.make_variant_dist_info
+    validation_error = variantlib_errors.ValidationError
+    variant_description: Any = variantlib_models.VariantDescription
+    variant_property: Any = variantlib_models.VariantProperty
+    variant_pyproject_toml: Any = variantlib_pyproject.VariantPyProjectToml
+
+    try:
+        properties = [
+            variant_property.from_str(value)
+            for value in [*settings.variant_name, *settings.variant]
+        ]
+        variant = variant_description(properties)
+        variant_info = variant_pyproject_toml(pyproject)
+        variant_label = get_variant_label(variant, settings.variant_label)
+        dist_info_contents = make_variant_dist_info(
+            variant,
+            variant_info=variant_info,
+            variant_label=settings.variant_label,
+        ).encode("utf-8")
+    except validation_error as err:
+        rich_error(str(err))
+
+    if metadata.version is None:
+        msg = "project.version is required to build variant wheel metadata"
+        raise AssertionError(msg)
+
+    return WheelVariant(label=variant_label, dist_info_contents=dist_info_contents)

--- a/src/scikit_build_core/_variants.py
+++ b/src/scikit_build_core/_variants.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import importlib
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -10,6 +11,9 @@ if TYPE_CHECKING:
 
 VARIANTLIB_BUILD_REQUIREMENT = "variantlib"
 VARIANT_DIST_INFO_FILENAME = "variant.json"
+# A wheel filename uses "-" as the field separator, so the variant label (the
+# final field) must not contain dashes or whitespace.
+_VARIANT_LABEL_RE = re.compile(r"[A-Za-z0-9_.]+")
 
 __all__ = [
     "VARIANT_DIST_INFO_FILENAME",
@@ -111,10 +115,16 @@ def get_wheel_variant(
         dist_info_contents = make_variant_dist_info(
             variant,
             variant_info=variant_info,
-            variant_label=settings.variant_label,
+            variant_label=variant_label,
         ).encode("utf-8")
     except validation_error as err:
         rich_error(str(err))
+
+    if not _VARIANT_LABEL_RE.fullmatch(variant_label):
+        rich_error(
+            f"Computed variant label {variant_label!r} is not safe for a wheel "
+            "filename; it must match [A-Za-z0-9_.]+ (no dashes or whitespace)"
+        )
 
     if metadata.version is None:
         msg = "project.version is required to build variant wheel metadata"

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -147,6 +147,7 @@ def get_requires_for_build_sdist(
 
     return [
         *cmake_requires,
+        *requires.variants(),
         *requires.dynamic_metadata(),
     ]
 
@@ -165,6 +166,7 @@ def get_requires_for_build_wheel(
 
     return [
         *cmake_requires,
+        *requires.variants(),
         *requires.dynamic_metadata(),
     ]
 
@@ -183,5 +185,6 @@ def get_requires_for_build_editable(
 
     return [
         *cmake_requires,
+        *requires.variants(),
         *requires.dynamic_metadata(),
     ]

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -18,6 +18,7 @@ from zipfile import ZipInfo
 import pathspec
 
 from .. import __version__
+from .._variants import VARIANT_DIST_INFO_FILENAME
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -76,6 +77,8 @@ class WheelWriter:
     tags: AbstractSet[Tag]
     wheel_metadata: WheelMetadata
     metadata_dir: Path | None
+    variant_label: str = ""
+    variant_dist_info_contents: bytes | None = None
     _zipfile: zipfile.ZipFile | None = None
 
     @property
@@ -93,7 +96,8 @@ class WheelWriter:
         optbuildver = (
             [self.wheel_metadata.build_tag] if self.wheel_metadata.build_tag else []
         )
-        return "-".join([self.name_ver, *optbuildver, pyver, abi, arch])
+        variant = [self.variant_label] if self.variant_label else []
+        return "-".join([self.name_ver, *optbuildver, pyver, abi, arch, *variant])
 
     @property
     def wheelpath(self) -> Path:
@@ -145,6 +149,11 @@ class WheelWriter:
             "METADATA": bytes(rfc822),
             "WHEEL": self.wheel_metadata.as_bytes(),
             **entry_points_dict,
+            **(
+                {VARIANT_DIST_INFO_FILENAME: self.variant_dist_info_contents}
+                if self.variant_dist_info_contents is not None
+                else {}
+            ),
             **extra_metadata,
         }
 

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -136,8 +136,11 @@ class WheelWriter:
             for f in metadata_files
             if f.is_file()
         }
-        if {"METADATA", "WHEEL", "RECORD", "entry_points.txt"} & extra_metadata.keys():
-            msg = "Cannot have METADATA, WHEEL, RECORD, or entry_points.txt in metadata_dir"
+        reserved = {"METADATA", "WHEEL", "RECORD", "entry_points.txt"}
+        if self.variant_dist_info_contents is not None:
+            reserved.add(VARIANT_DIST_INFO_FILENAME)
+        if reserved & extra_metadata.keys():
+            msg = f"Cannot have {', '.join(sorted(reserved))} in metadata_dir"
             raise ValueError(msg)
 
         entry_points_txt = entry_points.getvalue().encode("utf-8")

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -18,6 +18,7 @@ from packaging.utils import canonicalize_name
 from .._compat import tomllib
 from .._compat.typing import assert_never
 from .._logging import LEVEL_VALUE, logger, rich_error, rich_print
+from .._variants import get_wheel_variant
 from ..builder.builder import Builder, archs_to_tags, get_archs
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMaker
@@ -276,6 +277,7 @@ def _build_wheel_impl_impl(
     with tempfile.TemporaryDirectory() as tmpdir:
         build_tmp_folder = Path(tmpdir)
         wheel_dir = build_tmp_folder / "wheel"
+        wheel_variant = get_wheel_variant(settings, pyproject, metadata)
 
         tags = WheelTag.compute_best(
             archs_to_tags(get_archs(os.environ)),
@@ -383,6 +385,10 @@ def _build_wheel_impl_impl(
                     build_tag=settings.wheel.build_tag,
                 ),
                 wheel_dirs["metadata"],
+                variant_label=wheel_variant.label if wheel_variant else "",
+                variant_dist_info_contents=(
+                    wheel_variant.dist_info_contents if wheel_variant else None
+                ),
             )
             dist_info_contents = wheel.dist_info_contents()
             dist_info = Path(metadata_directory) / f"{wheel.name_ver}.dist-info"
@@ -501,6 +507,10 @@ def _build_wheel_impl_impl(
                 build_tag=settings.wheel.build_tag,
             ),
             wheel_dirs["metadata"],
+            variant_label=wheel_variant.label if wheel_variant else "",
+            variant_dist_info_contents=(
+                wheel_variant.dist_info_contents if wheel_variant else None
+            ),
         ) as wheel:
             wheel.build(wheel_dirs, exclude=settings.wheel.exclude)
 

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -11,6 +11,7 @@ from packaging.tags import sys_tags
 
 from .._compat import tomllib
 from .._logging import logger
+from .._variants import variant_build_requires
 from ..format import pyproject_format
 from ..program_search import (
     best_program,
@@ -157,3 +158,9 @@ class GetRequires:
                 yield from getattr(
                     module, "get_requires_for_dynamic_metadata", lambda _: []
                 )(config)
+
+    def variants(self) -> Generator[str, None, None]:
+        if self.settings.fail:
+            return
+
+        yield from variant_build_requires(self.settings)

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -671,6 +671,29 @@
           "build-dir": {
             "$ref": "#/properties/build-dir"
           },
+          "variant": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Experimental PEP 817 variant properties."
+          },
+          "variant-name": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Experimental PEP 817 variant properties used for wheel metadata selection."
+          },
+          "variant-label": {
+            "type": "string",
+            "description": "Experimental PEP 817 wheel variant label override."
+          },
+          "null-variant": {
+            "type": "boolean",
+            "default": false,
+            "description": "Experimental PEP 817 null-variant selector."
+          },
           "fail": {
             "type": "boolean",
             "description": "Immediately fail the build. This is only allowed in overrides or config-settings."

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -546,6 +546,46 @@ class ScikitBuildSettings:
     Enable early previews of features not finalized yet.
     """
 
+    variant: List[str] = dataclasses.field(
+        default_factory=list,
+        metadata=SettingsFieldMetadata(override_only=True),
+    )
+    """
+    Experimental PEP 817 variant properties.
+
+    This is only allowed in overrides or config-settings.
+    """
+
+    variant_name: List[str] = dataclasses.field(
+        default_factory=list,
+        metadata=SettingsFieldMetadata(override_only=True),
+    )
+    """
+    Experimental PEP 817 variant properties used for wheel metadata selection.
+
+    This is only allowed in overrides or config-settings.
+    """
+
+    variant_label: Optional[str] = dataclasses.field(
+        default=None,
+        metadata=SettingsFieldMetadata(override_only=True),
+    )
+    """
+    Experimental PEP 817 wheel variant label override.
+
+    This is only allowed in overrides or config-settings.
+    """
+
+    null_variant: bool = dataclasses.field(
+        default=False,
+        metadata=SettingsFieldMetadata(override_only=True),
+    )
+    """
+    Experimental PEP 817 null-variant selector.
+
+    This is only allowed in overrides or config-settings.
+    """
+
     minimum_version: Optional[Version] = dataclasses.field(
         default=None,
         metadata=SettingsFieldMetadata(

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -13,12 +13,13 @@ from packaging.version import Version
 from .. import __version__
 from .._compat import tomllib
 from .._logging import logger, rich_error, rich_print, rich_warning
+from .._variants import validate_variant_settings
 from ..errors import CMakeConfigError
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .skbuild_model import CMakeSettings, NinjaSettings, ScikitBuildSettings
 from .skbuild_overrides import process_overrides
-from .sources import ConfSource, EnvSource, SourceChain, TOMLSource
+from .sources import ConfSource, EnvSource, Source, SourceChain, TOMLSource
 
 if TYPE_CHECKING:
     import os
@@ -138,6 +139,7 @@ def _handle_move(
 def _validate_overrides(
     settings: ScikitBuildSettings,
     overrides: dict[str, OverrideRecord],
+    sources: tuple[Source, ...],
 ) -> None:
     """Validate all fields with any override information."""
 
@@ -145,13 +147,30 @@ def _validate_overrides(
         field: dataclasses.Field[Any],
         value: Any,
         prefix: str = "",
+        path: tuple[str, ...] = (),
         record: OverrideRecord | None = None,
     ) -> None:
         """Do the actual validation."""
         # Check if we had a hard-coded value in the record
         conf_key = field.name.replace("_", "-")
         if field.metadata.get("override_only", False):
-            original_value = record.original_value if record else value
+            is_dict = field.name == "metadata"
+            if any(
+                source.has_item(*path, field.name, is_dict=is_dict)
+                for source in sources[:3]
+            ):
+                return
+
+            if record is not None:
+                original_value = record.original_value
+            elif any(
+                source.has_item(*path, field.name, is_dict=is_dict)
+                for source in sources[3:]
+            ):
+                original_value = value
+            else:
+                original_value = None
+
             if original_value is not None:
                 msg = f"{prefix}{conf_key} is not allowed to be hard-coded in the pyproject.toml file"
                 if settings.strict_config:
@@ -164,6 +183,7 @@ def _validate_overrides(
         obj: Any,
         record: OverrideRecord | None = None,
         prefix: str = "",
+        path: tuple[str, ...] = (),
     ) -> None:
         """Navigate through all the keys and validate each field."""
         for field in dataclasses.fields(obj):
@@ -175,11 +195,15 @@ def _validate_overrides(
                 field=field,
                 value=value,
                 prefix=prefix,
+                path=path,
                 record=closest_record,
             )
             if dataclasses.is_dataclass(value):
                 validate_field_recursive(
-                    obj=value, record=closest_record, prefix=f"{prefix}{conf_key}."
+                    obj=value,
+                    record=closest_record,
+                    prefix=f"{prefix}{conf_key}.",
+                    path=(*path, field.name),
                 )
 
     # Navigate all fields starting from the top-level
@@ -258,6 +282,7 @@ class SettingsReader:
             prefixes=["tool", "scikit-build"],
         )
         self.settings = self.sources.convert_target(ScikitBuildSettings)
+        validate_variant_settings(self.settings)
 
         static_settings = SourceChain(
             *toml_srcs, prefixes=["tool", "scikit-build"]
@@ -421,7 +446,7 @@ class SettingsReader:
                 self.print_suggestions()
                 raise SystemExit(7)
             logger.warning("Unrecognized options: {}", ", ".join(unrecognized))
-        _validate_overrides(self.settings, self.overridden_items)
+        _validate_overrides(self.settings, self.overridden_items, self.sources.sources)
 
         for key, value in self.settings.metadata.items():
             if "provider" not in value:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -154,13 +154,21 @@ def _validate_overrides(
         # Check if we had a hard-coded value in the record
         conf_key = field.name.replace("_", "-")
         if field.metadata.get("override_only", False):
+            # "metadata" is the one dict-valued override-only field; has_item
+            # needs to know to use dict-presence semantics for it.
             is_dict = field.name == "metadata"
+            # override-only fields are also allowed via env vars and
+            # config-settings (sources[:3]); only pyproject.toml is forbidden.
             if any(
                 source.has_item(*path, field.name, is_dict=is_dict)
                 for source in sources[:3]
             ):
                 return
 
+            # Decide whether the value was actually hard-coded in pyproject.toml.
+            # We can't rely on `value is not None`, since some override-only
+            # fields have non-None falsy defaults (e.g. [] or False), so we ask
+            # the TOML sources (sources[3:]) whether the key is really present.
             if record is not None:
                 original_value = record.original_value
             elif any(

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -139,6 +139,39 @@ def test_get_requires_for_build_sdist_cmake(fp: FakeProcess):
     assert set(get_requires_for_build_sdist({"sdist.cmake": "True"})) == expected
 
 
+@pytest.mark.parametrize(
+    ("hook", "config"),
+    [
+        (
+            get_requires_for_build_sdist,
+            {"experimental": "true", "variant": "cpu :: abi :: cp313"},
+        ),
+        (
+            get_requires_for_build_wheel,
+            {"experimental": "true", "variant": "cpu :: abi :: cp313"},
+        ),
+        (
+            get_requires_for_build_editable,
+            {"experimental": "true", "variant-name": "cpu :: abi :: cp313"},
+        ),
+    ],
+)
+def test_get_requires_for_build_with_variant(
+    fp: FakeProcess,
+    hook,
+    config: dict[str, str],
+):
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
+    fp.register(
+        ["lipo", "-info", "cmake/path"],
+        stdout="Architectures in the fat file: ... are: x86_64 arm64",
+    )
+    assert "variantlib" in hook(config)
+
+
 def test_get_requires_for_build_wheel(fp: FakeProcess):
     expected = {"cmake>=3.15", *ninja}
     fp.register(

--- a/tests/test_prepare_metadata.py
+++ b/tests/test_prepare_metadata.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 import textwrap
+import types
 from pathlib import Path
+from typing import Any
 
 import pytest
 from packaging.version import Version
@@ -23,6 +25,14 @@ def test_prepare_metadata_for_build(fp, editable):
     fp.pass_command([sys.executable, fp.any()])
     fp.pass_command([fp.program("cmake"), "-E", "capabilities"])
     fp.pass_command([fp.program("cmake3"), "-E", "capabilities"])
+    fp.register(
+        ["lipo", "-info", fp.program("cmake")],
+        stdout="Architectures in the fat file: ... are: x86_64 arm64",
+    )
+    fp.register(
+        ["lipo", "-info", fp.program("cmake3")],
+        stdout="Architectures in the fat file: ... are: x86_64 arm64",
+    )
 
     if editable:
         assert (
@@ -89,3 +99,85 @@ def test_license_normalization():
         settings=ScikitBuildSettings(),
     )
     assert metadata.license == "Apache-2.0"
+
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext")
+def test_prepare_metadata_for_build_wheel_variant(fp, monkeypatch, tmp_path):
+    fp.pass_command([sys.executable, fp.any()])
+    fp.pass_command([fp.program("cmake"), "-E", "capabilities"])
+    fp.pass_command([fp.program("cmake3"), "-E", "capabilities"])
+    fp.register(
+        ["lipo", "-info", fp.program("cmake")],
+        stdout="Architectures in the fat file: ... are: x86_64 arm64",
+    )
+    fp.register(
+        ["lipo", "-info", fp.program("cmake3")],
+        stdout="Architectures in the fat file: ... are: x86_64 arm64",
+    )
+
+    variantlib: Any = types.ModuleType("variantlib")
+    variantlib_api: Any = types.ModuleType("variantlib.api")
+    variantlib_errors: Any = types.ModuleType("variantlib.errors")
+    variantlib_models: Any = types.ModuleType("variantlib.models")
+    variantlib_models_variant: Any = types.ModuleType("variantlib.models.variant")
+    variantlib_pyproject: Any = types.ModuleType("variantlib.pyproject_toml")
+
+    class ValidationError(Exception):
+        pass
+
+    class VariantProperty:
+        def __init__(self, raw: str) -> None:
+            self.raw = raw
+
+        @classmethod
+        def from_str(cls, raw: str):
+            return cls(raw)
+
+    class VariantDescription:
+        def __init__(self, properties) -> None:
+            self.properties = properties
+
+    class VariantPyProjectToml:
+        def __init__(self, pyproject) -> None:
+            self.pyproject = pyproject
+
+    def get_variant_label(variant, label):
+        _ = variant
+        return label or "cpu"
+
+    def make_variant_dist_info(variant, *, variant_info, variant_label):
+        _ = variant_info
+        raw = ",".join(prop.raw for prop in variant.properties)
+        return f"label={variant_label or 'cpu'};properties={raw}"
+
+    variantlib_api.get_variant_label = get_variant_label
+    variantlib_api.make_variant_dist_info = make_variant_dist_info
+    variantlib_errors.ValidationError = ValidationError
+    variantlib_models_variant.VariantDescription = VariantDescription
+    variantlib_models_variant.VariantProperty = VariantProperty
+    variantlib_pyproject.VariantPyProjectToml = VariantPyProjectToml
+
+    monkeypatch.setitem(sys.modules, "variantlib", variantlib)
+    monkeypatch.setitem(sys.modules, "variantlib.api", variantlib_api)
+    monkeypatch.setitem(sys.modules, "variantlib.errors", variantlib_errors)
+    monkeypatch.setitem(sys.modules, "variantlib.models", variantlib_models)
+    monkeypatch.setitem(
+        sys.modules, "variantlib.models.variant", variantlib_models_variant
+    )
+    monkeypatch.setitem(sys.modules, "variantlib.pyproject_toml", variantlib_pyproject)
+
+    mddir = tmp_path / "dist"
+    mddir.mkdir()
+    out = prepare_metadata_for_build_wheel(
+        str(mddir),
+        {
+            "experimental": "true",
+            "variant": "cpu :: abi :: cp313",
+            "variant-label": "cpu",
+        },
+    )
+
+    assert out == "cmake_example-0.0.1.dist-info"
+    assert (
+        mddir / out / "variant.json"
+    ).read_text() == "label=cpu;properties=cpu :: abi :: cp313"

--- a/tests/test_prepare_metadata.py
+++ b/tests/test_prepare_metadata.py
@@ -116,9 +116,11 @@ def test_prepare_metadata_for_build_wheel_variant(fp, monkeypatch, tmp_path):
     )
 
     variantlib: Any = types.ModuleType("variantlib")
+    variantlib.__path__ = []  # mark as a package so submodule imports resolve
     variantlib_api: Any = types.ModuleType("variantlib.api")
     variantlib_errors: Any = types.ModuleType("variantlib.errors")
     variantlib_models: Any = types.ModuleType("variantlib.models")
+    variantlib_models.__path__ = []
     variantlib_models_variant: Any = types.ModuleType("variantlib.models.variant")
     variantlib_pyproject: Any = types.ModuleType("variantlib.pyproject_toml")
 

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -52,6 +52,10 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.backport.find_python == Version("3.26.1")
     assert settings.strict_config
     assert not settings.experimental
+    assert settings.variant == []
+    assert settings.variant_name == []
+    assert settings.variant_label is None
+    assert not settings.null_variant
     assert settings.minimum_version is None
     assert settings.build_dir == ""
     assert settings.metadata == {}
@@ -94,6 +98,9 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SKBUILD_BACKPORT_FIND_PYTHON", "0")
     monkeypatch.setenv("SKBUILD_STRICT_CONFIG", "0")
     monkeypatch.setenv("SKBUILD_EXPERIMENTAL", "1")
+    monkeypatch.setenv("SKBUILD_VARIANT", "cpu :: abi :: cp313;gpu :: cuda :: 12.0")
+    monkeypatch.setenv("SKBUILD_VARIANT_NAME", "blas :: impl :: openblas")
+    monkeypatch.setenv("SKBUILD_VARIANT_LABEL", "cpu")
     monkeypatch.setenv("SKBUILD_MINIMUM_VERSION", "0.12")
     monkeypatch.setenv("SKBUILD_BUILD_DIR", "a/b/c")
     monkeypatch.setenv("SKBUILD_EDITABLE_REBUILD", "True")
@@ -142,6 +149,10 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.backport.find_python == Version("0")
     assert not settings.strict_config
     assert settings.experimental
+    assert settings.variant == ["cpu :: abi :: cp313", "gpu :: cuda :: 12.0"]
+    assert settings.variant_name == ["blas :: impl :: openblas"]
+    assert settings.variant_label == "cpu"
+    assert not settings.null_variant
     assert settings.minimum_version == Version("0.12")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
@@ -192,6 +203,9 @@ def test_skbuild_settings_config_settings(
         "backport.find-python": "0",
         "strict-config": "false",
         "experimental": "1",
+        "variant": ["cpu :: abi :: cp313", "gpu :: cuda :: 12.0"],
+        "variant-name": "blas :: impl :: openblas",
+        "variant-label": "cpu",
         "minimum-version": "0.10",
         "build-dir": "a/b/c",
         "editable.mode": "redirect",
@@ -236,6 +250,10 @@ def test_skbuild_settings_config_settings(
     assert settings.backport.find_python == Version("0")
     assert not settings.strict_config
     assert settings.experimental
+    assert settings.variant == ["cpu :: abi :: cp313", "gpu :: cuda :: 12.0"]
+    assert settings.variant_name == ["blas :: impl :: openblas"]
+    assert settings.variant_label == "cpu"
+    assert not settings.null_variant
     assert settings.minimum_version == Version("0.10")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
@@ -415,6 +433,32 @@ def test_skbuild_settings_pyproject_toml_broken(
         "tool.scikit-build.generate,",
         "tool.scikit-build.search?",
     ]
+
+
+def test_skbuild_settings_variant_requires_experimental(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(
+            pyproject_toml,
+            {"variant": "cpu :: abi :: cp313"},
+        )
+
+
+def test_skbuild_settings_null_variant_conflicts(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(
+            pyproject_toml,
+            {
+                "experimental": "true",
+                "null-variant": "true",
+                "variant": "cpu :: abi :: cp313",
+            },
+        )
 
 
 def test_skbuild_settings_pyproject_conf_broken(

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -71,3 +71,29 @@ def test_wheel_writer_simple(tmp_path, monkeypatch):
         for info in zf.infolist():
             assert info.external_attr == (0o664 | stat.S_IFREG) << 16
             assert info.compress_type == zipfile.ZIP_DEFLATED
+
+
+def test_wheel_writer_variant(tmp_path):
+    metadata = StandardMetadata.from_pyproject(
+        {
+            "project": {
+                "name": "something",
+                "version": "1.2.3",
+            },
+        },
+        metadata_version="2.3",
+    )
+    out_dir = tmp_path / "out"
+
+    wheel = scikit_build_core.build._wheelfile.WheelWriter(
+        metadata,
+        out_dir,
+        {Tag("py3", "none", "any")},
+        scikit_build_core.build._wheelfile.WheelMetadata(),
+        None,
+        variant_label="cpu",
+        variant_dist_info_contents=b'{"variant":"cpu"}',
+    )
+
+    assert wheel.wheelpath.name == "something-1.2.3-py3-none-any-cpu.whl"
+    assert wheel.dist_info_contents()["variant.json"] == b'{"variant":"cpu"}'

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -1,6 +1,7 @@
 import stat
 import zipfile
 
+import pytest
 from packaging.tags import Tag
 
 import scikit_build_core.build._wheelfile
@@ -97,3 +98,31 @@ def test_wheel_writer_variant(tmp_path):
 
     assert wheel.wheelpath.name == "something-1.2.3-py3-none-any-cpu.whl"
     assert wheel.dist_info_contents()["variant.json"] == b'{"variant":"cpu"}'
+
+
+def test_wheel_writer_variant_metadata_dir_conflict(tmp_path):
+    metadata = StandardMetadata.from_pyproject(
+        {
+            "project": {
+                "name": "something",
+                "version": "1.2.3",
+            },
+        },
+        metadata_version="2.3",
+    )
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    (metadata_dir / "variant.json").write_bytes(b'{"variant":"override"}')
+
+    wheel = scikit_build_core.build._wheelfile.WheelWriter(
+        metadata,
+        tmp_path / "out",
+        {Tag("py3", "none", "any")},
+        scikit_build_core.build._wheelfile.WheelMetadata(),
+        metadata_dir,
+        variant_label="cpu",
+        variant_dist_info_contents=b'{"variant":"cpu"}',
+    )
+
+    with pytest.raises(ValueError, match=r"variant\.json"):
+        wheel.dist_info_contents()


### PR DESCRIPTION
Accept variant config settings behind the experimental flag, inject variantlib when variants are requested, and emit variant-aware wheel metadata and filenames. Include generated schema/docs updates and focused tests for settings, build requirements, and metadata output. Close #1068.

:robot: Assisted-by: Copilot:GPT-5.4
