### PR TITLE
tests: add some coverage

### DIFF
--- a/tests/test_auto_cmake_version.py
+++ b/tests/test_auto_cmake_version.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from scikit_build_core.settings.auto_cmake_version import find_min_cmake_version
+
+
+def test_find_cmake_version_found():
+    result = find_min_cmake_version("cmake_minimum_required(VERSION 3.15)")
+    assert result == "3.15"
+
+
+def test_find_cmake_version_with_fatal_error():
+    result = find_min_cmake_version(
+        "cmake_minimum_required(VERSION 3.15 FATAL_ERROR)"
+    )
+    assert result == "3.15"
+
+
+def test_find_cmake_version_with_quotes():
+    result = find_min_cmake_version('cmake_minimum_required("3.20")')
+    assert result == "3.20"
+
+
+def test_find_cmake_version_not_found():
+    result = find_min_cmake_version("project(foo)")
+    assert result is None

--- a/tests/test_auto_cmake_version.py
+++ b/tests/test_auto_cmake_version.py
@@ -9,9 +9,7 @@ def test_find_cmake_version_found():
 
 
 def test_find_cmake_version_with_fatal_error():
-    result = find_min_cmake_version(
-        "cmake_minimum_required(VERSION 3.15 FATAL_ERROR)"
-    )
+    result = find_min_cmake_version("cmake_minimum_required(VERSION 3.15 FATAL_ERROR)")
     assert result == "3.15"
 
 

--- a/tests/test_auto_requires.py
+++ b/tests/test_auto_requires.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from packaging.version import Version
+
+from scikit_build_core.settings.auto_requires import get_min_requires, min_from_spec
+
+
+def test_min_from_spec_ge():
+    from packaging.specifiers import Specifier
+
+    assert min_from_spec(Specifier(">=3.15")) == Version("3.15")
+
+
+def test_min_from_spec_eq():
+    from packaging.specifiers import Specifier
+
+    assert min_from_spec(Specifier("==3.15")) == Version("3.15")
+
+
+def test_min_from_spec_tilde():
+    from packaging.specifiers import Specifier
+
+    assert min_from_spec(Specifier("~=3.15")) == Version("3.15")
+
+
+def test_min_from_spec_gt():
+    from packaging.specifiers import Specifier
+
+    assert min_from_spec(Specifier(">3.15")) == Version("3.15")
+
+
+def test_min_from_spec_no_min():
+    from packaging.specifiers import Specifier
+
+    assert min_from_spec(Specifier("<3.15")) is None
+
+
+def test_get_min_requires_found():
+    result = get_min_requires("cmake", ["cmake>=3.15", "ninja>=1.5"])
+    assert result == Version("3.15")
+
+
+def test_get_min_requires_not_found():
+    result = get_min_requires("cmake", ["ninja>=1.5"])
+    assert result is None
+
+
+def test_get_min_requires_with_markers():
+    result = get_min_requires(
+        "cmake",
+        ['cmake>=3.15; python_version >= "3.10"', 'cmake>=3.20; python_version < "3.10"'],
+    )
+    # At least one should match
+    assert result is not None
+
+
+def test_get_min_requires_multiple():
+    result = get_min_requires("cmake", ["cmake>=3.15", "cmake>=3.20"])
+    assert result == Version("3.15")

--- a/tests/test_auto_requires.py
+++ b/tests/test_auto_requires.py
@@ -48,7 +48,10 @@ def test_get_min_requires_not_found():
 def test_get_min_requires_with_markers():
     result = get_min_requires(
         "cmake",
-        ['cmake>=3.15; python_version >= "3.10"', 'cmake>=3.20; python_version < "3.10"'],
+        [
+            'cmake>=3.15; python_version >= "3.10"',
+            'cmake>=3.20; python_version < "3.10"',
+        ],
     )
     # At least one should match
     assert result is not None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -533,3 +533,65 @@ def test_generator_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         ),
     )
     assert builder.get_generator() == "Anything"
+
+
+def test_wheel_tag_invalid_build_tag_no_digit():
+    with pytest.raises(AssertionError, match="must start with a digit"):
+        WheelTag.compute_best([], build_tag="abc")
+
+
+def test_wheel_tag_invalid_build_tag_with_dash():
+    with pytest.raises(AssertionError, match="cannot contain dashes"):
+        WheelTag.compute_best([], build_tag="1-invalid")
+
+
+def test_wheel_tag_tags_dict():
+    tag = WheelTag(pyvers=["cp311"], abis=["cp311"], archs=["linux_x86_64"])
+    assert tag.tags_dict() == {
+        "pyver": ["cp311"],
+        "abi": ["cp311"],
+        "arch": ["linux_x86_64"],
+    }
+
+
+def test_wheel_tag_as_tags_set():
+    tag = WheelTag(pyvers=["py3"], abis=["none"], archs=["any"])
+    tag_set = tag.as_tags_set()
+    assert len(tag_set) == 1
+    (t,) = tag_set
+    assert str(t) == "py3-none-any"
+
+
+def test_wheel_tag_py_api_multiple_cp_versions():
+    with pytest.raises(AssertionError, match="must be a single cp version"):
+        WheelTag.compute_best([], py_api="cp39.cp310")
+
+
+def test_wheel_tag_py_api_cp_with_purelib():
+    with pytest.raises(AssertionError, match="platlib is set to false"):
+        WheelTag.compute_best([], py_api="cp39", root_is_purelib=True)
+
+
+def test_wheel_tag_py_api_version_too_high():
+    """When cp version is higher than current Python, the py_api is silently ignored."""
+    tag = WheelTag.compute_best([], py_api="cp3999")
+    # Should not be abi3 since version is too high; falls back to normal tag
+    assert "abi3" not in str(tag)
+    assert "cp3999" not in str(tag)
+
+
+def test_wheel_tag_py_api_invalid_format():
+    with pytest.raises(AssertionError, match="Unexpected py-api"):
+        WheelTag.compute_best([], py_api="invalid_format")
+
+
+def test_wheel_tag_windows_archs(monkeypatch):
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: None if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    monkeypatch.setattr(sys, "platform", "win32")
+    tag = WheelTag.compute_best(["x86_64"])
+    assert "x86_64" in tag.arch

--- a/tests/test_dynamic_metadata_unit.py
+++ b/tests/test_dynamic_metadata_unit.py
@@ -103,3 +103,54 @@ def test_regex() -> None:
 def test_actions(field: str, input_: Any, output: Any) -> None:
     result = _process_dynamic_metadata(field, lambda x: x.format(sub=42), input_)
     assert output == result
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_input", "match"),
+    [
+        pytest.param(
+            "version",
+            ["not", "a", "string"],
+            "must be a string",
+            id="str-field-not-str",
+        ),
+        pytest.param(
+            "classifiers",
+            "not-a-list",
+            "must be a list of strings",
+            id="list-str-field-not-list",
+        ),
+        pytest.param(
+            "scripts",
+            "not-a-dict",
+            "must be a dictionary of strings",
+            id="dict-str-field-not-dict",
+        ),
+        pytest.param(
+            "authors",
+            "not-a-list",
+            "must be a dictionary of strings",
+            id="list-dict-field-not-list",
+        ),
+        pytest.param(
+            "entry-points",
+            "not-a-dict",
+            "must be a dictionary of dictionary of strings",
+            id="entry-points-not-dict",
+        ),
+        pytest.param(
+            "optional-dependencies",
+            "not-a-dict",
+            "must be a dictionary of lists",
+            id="optional-deps-not-dict",
+        ),
+    ],
+)
+def test_actions_type_errors(field: str, bad_input: Any, match: str) -> None:
+    with pytest.raises(RuntimeError, match=match):
+        _process_dynamic_metadata(field, lambda x: x, bad_input)
+
+
+def test_actions_unsupported_field() -> None:
+    with pytest.raises(RuntimeError, match="Unsupported field"):
+        _process_dynamic_metadata("not-a-real-field", lambda x: x, "anything")

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scikit_build_core.resources._editable_redirect import ScikitBuildRedirectingFinder
+import pytest
+
+from scikit_build_core.resources._editable_redirect import (
+    FileLockIfUnix,
+    ScikitBuildRedirectingFinder,
+    install,
+)
 
 
 def process_dict(d: dict[str, str]) -> dict[str, str]:
@@ -68,3 +74,113 @@ def test_editable_redirect():
         }
     )
     assert finder.pkgs == ["pkg", "pkg.subpkg"]
+
+
+def test_find_spec_source():
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"mod": "/src/mod.py"},
+        known_wheel_files={},
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir="/sp",
+        install_dir="",
+    )
+    spec = finder.find_spec("mod")
+    assert spec is not None
+    assert spec.origin == "/src/mod.py"
+
+
+def test_find_spec_wheel():
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={"mod": "mod.py"},
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir="/sp",
+        install_dir="",
+    )
+    spec = finder.find_spec("mod")
+    assert spec is not None
+    assert spec.origin == str(Path("/sp/mod.py"))
+
+
+def test_find_spec_package():
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"pkg": "/src/pkg/__init__.py"},
+        known_wheel_files={},
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir="/sp",
+        install_dir="",
+    )
+    spec = finder.find_spec("pkg")
+    assert spec is not None
+    assert spec.submodule_search_locations is not None
+
+
+def test_find_spec_unknown():
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={},
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir="/sp",
+        install_dir="",
+    )
+    assert finder.find_spec("unknown") is None
+
+
+def test_install_inserts_meta_path():
+    import sys
+
+    before = len(sys.meta_path)
+    install(
+        known_source_files={"mod": "/src/mod.py"},
+        known_wheel_files={},
+        path=None,
+    )
+    assert len(sys.meta_path) == before + 1
+    # clean up
+    sys.meta_path.pop(0)
+
+
+def test_filelock_if_unix_no_fcntl(tmp_path):
+    # Skip on Windows where fcntl isn't available
+    pytest.importorskip("fcntl")
+
+    lock = FileLockIfUnix(str(tmp_path / "editable_rebuild.lock"))
+    lock.acquire()
+    assert lock.lock_file_fd is not None
+    lock.release()
+
+
+def test_filelock_if_unix_missing_fcntl(monkeypatch, tmp_path):
+    import builtins
+
+    real_import = builtins.__import__
+    fcntl_msg = "No module named 'fcntl'"
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ModuleNotFoundError(fcntl_msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    lock = FileLockIfUnix(str(tmp_path / "editable_rebuild.lock"))
+    lock.acquire()
+    assert lock.lock_file_fd is None
+    lock.release()
+    # Should not raise

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 from scikit_build_core.errors import (
     CMakeAccessError,
     CMakeConfigError,
@@ -14,16 +16,21 @@ from scikit_build_core.errors import (
 )
 
 
-class FakeCalledProcessError(Exception):
-    def __init__(self, returncode: int, cmd: list[str], stdout: bytes = b"", stderr: bytes = b"") -> None:
-        self.returncode = returncode
-        self.cmd = cmd
+class FakeCalledProcessError(subprocess.CalledProcessError):
+    """Simple re-implementation to avoid subprocess internals."""
+
+    def __init__(
+        self, returncode: int, cmd: list[str], stdout: bytes = b"", stderr: bytes = b""
+    ) -> None:
+        super().__init__(returncode, cmd)
         self.stdout = stdout
         self.stderr = stderr
 
 
 def test_failed_process_error_str():
-    exc = FakeCalledProcessError(1, ["cmake", "--version"], stdout=b"out\n", stderr=b"err\n")
+    exc = FakeCalledProcessError(
+        1, ["cmake", "--version"], stdout=b"out\n", stderr=b"err\n"
+    )
     err = FailedProcessError(exc, "Build failed")
     msg = str(err)
     assert "Build failed" in msg

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from scikit_build_core.errors import (
+    CMakeAccessError,
+    CMakeConfigError,
+    CMakeNotFoundError,
+    CMakeVersionError,
+    FailedLiveProcessError,
+    FailedProcessError,
+    NinjaNotFoundError,
+    NinjaVersionError,
+    NotFoundError,
+    ScikitBuildError,
+)
+
+
+class FakeCalledProcessError(Exception):
+    def __init__(self, returncode: int, cmd: list[str], stdout: bytes = b"", stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_failed_process_error_str():
+    exc = FakeCalledProcessError(1, ["cmake", "--version"], stdout=b"out\n", stderr=b"err\n")
+    err = FailedProcessError(exc, "Build failed")
+    msg = str(err)
+    assert "Build failed" in msg
+    assert "'cmake --version'" in msg
+    assert "return code 1" in msg
+    assert "stdout:\n    out" in msg
+    assert "stderr:\n    err" in msg
+
+
+def test_failed_process_error_no_output():
+    exc = FakeCalledProcessError(1, ["cmake"])
+    err = FailedProcessError(exc, "Build failed")
+    msg = str(err)
+    assert "stdout" not in msg
+    assert "stderr" not in msg
+
+
+def test_failed_live_process_error():
+    err = FailedLiveProcessError("msg", msg="live")
+    assert str(err) == "msg"
+    assert err.msg == "live"
+
+
+def test_exception_hierarchy():
+    assert issubclass(CMakeNotFoundError, NotFoundError)
+    assert issubclass(NinjaNotFoundError, NotFoundError)
+    assert issubclass(NotFoundError, ScikitBuildError)
+    assert issubclass(CMakeAccessError, FailedProcessError)
+    assert issubclass(CMakeVersionError, ScikitBuildError)
+    assert issubclass(NinjaVersionError, ScikitBuildError)
+    assert issubclass(CMakeConfigError, ScikitBuildError)
+
+
+def test_dir():
+    from scikit_build_core import errors
+
+    assert "ScikitBuildError" in errors.__dir__()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,13 +7,12 @@ import pytest
 from scikit_build_core.format import RootPathResolver, pyproject_format
 
 
-class FakeSettings:
-    class cmake:  # noqa: N801
-        build_type = "Release"
-
-
 def test_pyproject_format_basic():
-    fmt = pyproject_format(settings=FakeSettings(), state="wheel")
+    class FakeSettings:
+        class cmake:  # noqa: N801
+            build_type = "Release"
+
+    fmt = pyproject_format(settings=FakeSettings(), state="wheel")  # type: ignore[call-overload]
     assert fmt["build_type"] == "Release"
     assert fmt["state"] == "wheel"
     assert "cache_tag" in fmt
@@ -25,11 +24,15 @@ def test_pyproject_format_dummy():
 
 
 def test_pyproject_format_with_tags():
+    class FakeSettings:
+        class cmake:  # noqa: N801
+            build_type = "Release"
+
     class FakeTag:
         def __str__(self):
             return "cp313-cp313-macosx_14_0_arm64"
 
-    fmt = pyproject_format(settings=FakeSettings(), tags=FakeTag())
+    fmt = pyproject_format(settings=FakeSettings(), tags=FakeTag())  # type: ignore[call-overload]
     assert fmt["wheel_tag"] == "cp313-cp313-macosx_14_0_arm64"
 
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.format import RootPathResolver, pyproject_format
+
+
+class FakeSettings:
+    class cmake:  # noqa: N801
+        build_type = "Release"
+
+
+def test_pyproject_format_basic():
+    fmt = pyproject_format(settings=FakeSettings(), state="wheel")
+    assert fmt["build_type"] == "Release"
+    assert fmt["state"] == "wheel"
+    assert "cache_tag" in fmt
+
+
+def test_pyproject_format_dummy():
+    fmt = pyproject_format(dummy=True)
+    assert all(v == "*" for v in fmt.values())
+
+
+def test_pyproject_format_with_tags():
+    class FakeTag:
+        def __str__(self):
+            return "cp313-cp313-macosx_14_0_arm64"
+
+    fmt = pyproject_format(settings=FakeSettings(), tags=FakeTag())
+    assert fmt["wheel_tag"] == "cp313-cp313-macosx_14_0_arm64"
+
+
+def test_root_path_resolver_uri():
+    resolver = RootPathResolver()
+    assert resolver.__format__("uri").startswith("file://")
+
+
+def test_root_path_resolver_parent():
+    resolver = RootPathResolver(Path("/a/b/c"))
+    result = resolver.__format__("parent")
+    assert "a/b" in result
+
+
+def test_root_path_resolver_parent_uri():
+    resolver = RootPathResolver(Path("/a/b/c"))
+    result = resolver.__format__("parent:uri")
+    assert result.endswith("/b")
+
+
+def test_root_path_resolver_str():
+    resolver = RootPathResolver(Path("/a/b"))
+    result = resolver.__format__("")
+    assert "RootPathResolver" in result or "/a/b" in result
+
+
+def test_root_path_resolver_unknown():
+    resolver = RootPathResolver()
+    with pytest.raises(ValueError, match="Could not handle format"):
+        resolver.__format__("unknown")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 
 import pytest
 
@@ -19,43 +19,37 @@ def fake_metadata():
 
 
 def test_generate_from_template(fake_metadata) -> None:
-    gen = type(
-        "Gen",
-        (),
-        {
-            "template": "name=$name, version=$version",
-            "template_path": None,
-            "path": "out.txt",
-        },
+    class Gen:
+        template = "name=$name, version=$version"
+        template_path = None
+        path = Path("out.txt")
+
+    assert (
+        generate_file_contents(Gen(), fake_metadata)  # type: ignore[arg-type]
+        == "name=test_pkg, version=1.2.3"
     )
-    assert generate_file_contents(gen, fake_metadata) == "name=test_pkg, version=1.2.3"
 
 
 def test_generate_from_template_path(tmp_path: Path, fake_metadata) -> None:
     template_file = tmp_path / "template.txt"
     template_file.write_text("version=$version")
 
-    gen = type(
-        "Gen",
-        (),
-        {
-            "template": None,
-            "template_path": template_file,
-            "path": "out.txt",
-        },
+    class Gen:
+        template = None
+        template_path = template_file
+        path = Path("out.txt")
+
+    assert (
+        generate_file_contents(Gen(), fake_metadata)  # type: ignore[arg-type]
+        == "version=1.2.3"
     )
-    assert generate_file_contents(gen, fake_metadata) == "version=1.2.3"
 
 
 def test_generate_missing_template(fake_metadata) -> None:
-    gen = type(
-        "Gen",
-        (),
-        {
-            "template": None,
-            "template_path": None,
-            "path": "out.txt",
-        },
-    )
+    class Gen:
+        template = None
+        template_path = None
+        path = Path("out.txt")
+
     with pytest.raises(AssertionError):
-        generate_file_contents(gen, fake_metadata)
+        generate_file_contents(Gen(), fake_metadata)  # type: ignore[arg-type]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path  # noqa: TC003
+
+import pytest
+
+from scikit_build_core.build.generate import generate_file_contents
+
+
+@pytest.fixture
+def fake_metadata():
+    @dataclasses.dataclass
+    class FakeMetadata:
+        name: str = "test_pkg"
+        version: str = "1.2.3"
+
+    return FakeMetadata()
+
+
+def test_generate_from_template(fake_metadata) -> None:
+    gen = type(
+        "Gen",
+        (),
+        {
+            "template": "name=$name, version=$version",
+            "template_path": None,
+            "path": "out.txt",
+        },
+    )
+    assert generate_file_contents(gen, fake_metadata) == "name=test_pkg, version=1.2.3"
+
+
+def test_generate_from_template_path(tmp_path: Path, fake_metadata) -> None:
+    template_file = tmp_path / "template.txt"
+    template_file.write_text("version=$version")
+
+    gen = type(
+        "Gen",
+        (),
+        {
+            "template": None,
+            "template_path": template_file,
+            "path": "out.txt",
+        },
+    )
+    assert generate_file_contents(gen, fake_metadata) == "version=1.2.3"
+
+
+def test_generate_missing_template(fake_metadata) -> None:
+    gen = type(
+        "Gen",
+        (),
+        {
+            "template": None,
+            "template_path": None,
+            "path": "out.txt",
+        },
+    )
+    with pytest.raises(AssertionError):
+        generate_file_contents(gen, fake_metadata)

--- a/tests/test_generator_default.py
+++ b/tests/test_generator_default.py
@@ -1,4 +1,27 @@
-from scikit_build_core.builder.generator import parse_help_default
+from __future__ import annotations
+
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scikit_build_core.builder.generator import (
+    get_default,
+    get_default_from_cmake,
+    parse_help_default,
+    set_environment_for_gen,
+)
+from scikit_build_core.errors import NinjaNotFoundError
+from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+if TYPE_CHECKING:
+    from scikit_build_core.cmake import CMake
+
+_FAKE_CMAKE: CMake = SimpleNamespace(cmake_path=Path("/fake/cmake"))  # type: ignore[assignment]
 
 UNIX_OUTPUT = """\
 Usage
@@ -269,3 +292,132 @@ def test_best_gen_windows():
 def test_best_gen_older_windows():
     """Test best_gen() on older Windows."""
     assert parse_help_default(OLDER_WINDOWS_OUTPUT) == "Visual Studio 15 2017"
+
+
+def test_parse_help_default_no_match():
+    """parse_help_default returns None when no default generator is marked."""
+    assert parse_help_default("No generators listed here") is None
+    assert parse_help_default("") is None
+
+
+NINJA_MC_OUTPUT = """\
+Generators
+
+The following generators are available on this platform (* marks default):
+* Ninja Multi-Config             = Generates build-<Config>.ninja files.
+  Ninja                          = Generates build.ninja files.
+"""
+
+
+def test_get_default_non_unix_makefiles(monkeypatch):
+    """get_default returns a non-Unix-Makefiles generator as-is."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: SimpleNamespace(returncode=0, stdout=NINJA_MC_OUTPUT),
+    )
+    result = get_default(_FAKE_CMAKE)
+    assert result == "Ninja Multi-Config"
+
+
+def test_get_default_from_cmake_failure(monkeypatch):
+    """get_default_from_cmake returns None when cmake exits non-zero."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: SimpleNamespace(returncode=1, stdout=""),
+    )
+    result = get_default_from_cmake(_FAKE_CMAKE)
+    assert result is None
+
+
+def test_get_default_non_msvc_windows(monkeypatch):
+    """On Windows with a non-MSVC Python platform, Ninja is always required."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: SimpleNamespace(returncode=0, stdout=UNIX_OUTPUT),
+    )
+    result = get_default(_FAKE_CMAKE)
+    assert result == "Ninja"
+
+
+def test_set_env_explicit_generator_no_ninja(monkeypatch):
+    """Explicit 'Ninja' generator with no ninja binary raises NinjaNotFoundError."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.best_program", lambda *_a, **_kw: None
+    )
+    env: dict[str, str] = {}
+    with pytest.raises(NinjaNotFoundError):
+        set_environment_for_gen(
+            "Ninja",
+            _FAKE_CMAKE,
+            env,
+            NinjaSettings(make_fallback=True),
+        )
+
+
+def test_set_env_make_fallback(monkeypatch):
+    """When no ninja is found and make_fallback=True, make is used."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.best_program", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.get_make_programs",
+        lambda: iter([Path("/usr/bin/make")]),
+    )
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.get_default", lambda _cmake: None
+    )
+    env: dict[str, str] = {}
+    result = set_environment_for_gen(
+        None,
+        _FAKE_CMAKE,
+        env,
+        NinjaSettings(make_fallback=True),
+    )
+    assert result.get("CMAKE_MAKE_PROGRAM") == "/usr/bin/make"
+    assert env.get("CMAKE_GENERATOR") == "Unix Makefiles"
+
+
+def test_set_env_no_ninja_no_make(monkeypatch):
+    """When no ninja or make is available and make_fallback=True, raise NinjaNotFoundError."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.best_program", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.get_make_programs", lambda: iter([])
+    )
+    monkeypatch.setattr(
+        "scikit_build_core.builder.generator.get_default", lambda _cmake: None
+    )
+    env: dict[str, str] = {}
+    with pytest.raises(NinjaNotFoundError):
+        set_environment_for_gen(
+            None,
+            _FAKE_CMAKE,
+            env,
+            NinjaSettings(make_fallback=True),
+        )
+
+
+def test_set_env_visual_studio(monkeypatch):
+    """Visual Studio generator is set directly via env vars, not cmake_make_program."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-amd64")
+    env: dict[str, str] = {}
+    result = set_environment_for_gen(
+        "Visual Studio 17 2022",
+        _FAKE_CMAKE,
+        env,
+        NinjaSettings(),
+    )
+    assert env.get("CMAKE_GENERATOR") == "Visual Studio 17 2022"
+    assert "CMAKE_GENERATOR_PLATFORM" in env
+    assert result == {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_main_cli():
+    result = subprocess.run(
+        [sys.executable, "-m", "scikit_build_core"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "A top level CLI is not currently provided" in result.stdout
+    assert "scikit_build_core.build requires" in result.stdout

--- a/tests/test_metadata_unit.py
+++ b/tests/test_metadata_unit.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from scikit_build_core.metadata.regex import dynamic_metadata as regex_metadata
+from scikit_build_core.metadata.template import dynamic_metadata as template_metadata
+
+# ---- template tests ----
+
+
+def test_template_missing_result():
+    with pytest.raises(RuntimeError, match="Must contain the 'result'"):
+        template_metadata("version", {}, {})
+
+
+def test_template_extra_keys():
+    with pytest.raises(RuntimeError, match=r"Only .* settings allowed"):
+        template_metadata("version", {"result": "{version}", "extra": "nope"}, {})
+
+
+def test_template_basic():
+    result = template_metadata(
+        "version", {"result": "v={project[version]}"}, project={"version": "1.0"}
+    )
+    assert result == "v=1.0"
+
+
+# ---- regex tests ----
+
+
+def test_regex_missing_input():
+    with pytest.raises(RuntimeError, match="Must contain the 'input' setting"):
+        regex_metadata("version", {"regex": r"v=(.*)"})
+
+
+def test_regex_extra_keys():
+    with pytest.raises(RuntimeError, match=r"Only .* settings allowed"):
+        regex_metadata(
+            "version",
+            {
+                "input": "x",
+                "regex": r"v=(.*)",
+                "result": "{1}",
+                "remove": "",
+                "extra": "nope",
+            },
+        )
+
+
+def test_regex_non_string_setting():
+    with pytest.raises(RuntimeError, match="Setting 'input' must be a string"):
+        regex_metadata("version", {"input": 123})
+
+
+def test_regex_missing_regex_for_non_version():
+    with pytest.raises(RuntimeError, match="Must contain the 'regex' setting"):
+        regex_metadata("readme", {"input": "version.py"})
+
+
+def test_regex_no_match(tmp_path):
+    f = tmp_path / "version.py"
+    f.write_text("no version here")
+    with pytest.raises(RuntimeError, match="Couldn't find"):
+        regex_metadata("version", {"input": str(f)})
+
+
+def test_regex_default_version_pattern(tmp_path):
+    f = tmp_path / "version.py"
+    f.write_text('__version__ = "1.2.3"')
+    result = regex_metadata("version", {"input": str(f)})
+    assert result == "1.2.3"
+
+
+def test_regex_custom_pattern(tmp_path):
+    f = tmp_path / "version.py"
+    f.write_text("release: v=1.0.0")
+    result = regex_metadata(
+        "version", {"input": str(f), "regex": r"v=(?P<val>.*)", "result": "{val}"}
+    )
+    assert result == "1.0.0"
+
+
+def test_regex_remove(tmp_path):
+    f = tmp_path / "version.py"
+    f.write_text('__version__ = "1.2.3-alpha"')
+    result = regex_metadata("version", {"input": str(f), "remove": r"-alpha"})
+    assert result == "1.2.3"
+
+
+# ---- setuptools_scm tests ----
+
+
+def test_setuptools_scm_only_version():
+    from scikit_build_core.metadata.setuptools_scm import dynamic_metadata
+
+    with pytest.raises(ValueError, match="Only the 'version' field"):
+        dynamic_metadata("readme")
+
+
+def test_setuptools_scm_no_settings():
+    from scikit_build_core.metadata.setuptools_scm import dynamic_metadata
+
+    with pytest.raises(ValueError, match="No inline configuration"):
+        dynamic_metadata("version", {"something": "else"})
+
+
+def test_setuptools_scm_get_requires():
+    from scikit_build_core.metadata.setuptools_scm import (
+        get_requires_for_dynamic_metadata,
+    )
+
+    assert get_requires_for_dynamic_metadata() == ["setuptools-scm"]
+
+
+# ---- fancy_pypi_readme tests ----
+
+
+def test_fancy_pypi_readme_only_readme():
+    from scikit_build_core.metadata.fancy_pypi_readme import dynamic_metadata
+
+    with pytest.raises(ValueError, match="Only the 'readme' field"):
+        dynamic_metadata("version", {}, {})
+
+
+def test_fancy_pypi_readme_no_settings():
+    from scikit_build_core.metadata.fancy_pypi_readme import dynamic_metadata
+
+    with pytest.raises(ValueError, match="No inline configuration"):
+        dynamic_metadata("readme", {"something": "else"}, {})
+
+
+def test_fancy_pypi_readme_get_requires():
+    from scikit_build_core.metadata.fancy_pypi_readme import (
+        get_requires_for_dynamic_metadata,
+    )
+
+    assert get_requires_for_dynamic_metadata() == ["hatch-fancy-pypi-readme>=23.2"]

--- a/tests/test_setuptools_build_meta_unit.py
+++ b/tests/test_setuptools_build_meta_unit.py
@@ -30,7 +30,9 @@ def test_get_requires_for_build_sdist_no_cmake(monkeypatch):
     monkeypatch.setattr(
         bm,
         "GetRequires",
-        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+        type(
+            "GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}
+        ),
     )
     reqs = bm.get_requires_for_build_sdist()
     assert "cmake>=3.15" not in reqs
@@ -57,7 +59,9 @@ def test_get_requires_for_build_sdist_with_cmake(monkeypatch):
     monkeypatch.setattr(
         bm,
         "GetRequires",
-        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+        type(
+            "GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}
+        ),
     )
     reqs = bm.get_requires_for_build_sdist()
     assert "cmake>=3.15" in reqs
@@ -84,7 +88,9 @@ def test_get_requires_for_build_wheel(monkeypatch):
     monkeypatch.setattr(
         bm,
         "GetRequires",
-        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+        type(
+            "GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}
+        ),
     )
     reqs = bm.get_requires_for_build_wheel()
     assert "wheel" in reqs
@@ -115,7 +121,9 @@ def test_get_requires_for_build_editable(monkeypatch):
     monkeypatch.setattr(
         bm,
         "GetRequires",
-        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+        type(
+            "GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}
+        ),
     )
     reqs = bm.get_requires_for_build_editable()
     assert "wheel" in reqs

--- a/tests/test_setuptools_build_meta_unit.py
+++ b/tests/test_setuptools_build_meta_unit.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import setuptools.build_meta
+
+from scikit_build_core.setuptools import build_meta as bm
+
+
+def test_dir():
+    assert "build_wheel" in bm.__dir__()
+
+
+def test_get_requires_for_build_sdist_no_cmake(monkeypatch):
+    monkeypatch.setattr(
+        setuptools.build_meta, "get_requires_for_build_sdist", lambda _cs: []
+    )
+
+    class FakeSettings:
+        class sdist:  # noqa: N801
+            cmake = False
+
+    class FakeRequires:
+        settings = FakeSettings()
+
+        def cmake(self):
+            return ["cmake>=3.15"]
+
+        def ninja(self):
+            return ["ninja>=1.5"]
+
+    monkeypatch.setattr(
+        bm,
+        "GetRequires",
+        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+    )
+    reqs = bm.get_requires_for_build_sdist()
+    assert "cmake>=3.15" not in reqs
+
+
+def test_get_requires_for_build_sdist_with_cmake(monkeypatch):
+    monkeypatch.setattr(
+        setuptools.build_meta, "get_requires_for_build_sdist", lambda _cs: []
+    )
+
+    class FakeSettings:
+        class sdist:  # noqa: N801
+            cmake = True
+
+    class FakeRequires:
+        settings = FakeSettings()
+
+        def cmake(self):
+            return ["cmake>=3.15"]
+
+        def ninja(self):
+            return ["ninja>=1.5"]
+
+    monkeypatch.setattr(
+        bm,
+        "GetRequires",
+        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+    )
+    reqs = bm.get_requires_for_build_sdist()
+    assert "cmake>=3.15" in reqs
+    assert "ninja>=1.5" in reqs
+
+
+def test_get_requires_for_build_wheel(monkeypatch):
+    monkeypatch.setattr(
+        setuptools.build_meta, "get_requires_for_build_wheel", lambda _cs: ["wheel"]
+    )
+
+    class FakeSettings:
+        pass
+
+    class FakeRequires:
+        settings = FakeSettings()
+
+        def cmake(self):
+            return ["cmake>=3.15"]
+
+        def ninja(self):
+            return ["ninja>=1.5"]
+
+    monkeypatch.setattr(
+        bm,
+        "GetRequires",
+        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+    )
+    reqs = bm.get_requires_for_build_wheel()
+    assert "wheel" in reqs
+    assert "cmake>=3.15" in reqs
+    assert "ninja>=1.5" in reqs
+
+
+def test_get_requires_for_build_editable(monkeypatch):
+    if not hasattr(setuptools.build_meta, "get_requires_for_build_editable"):
+        return
+
+    monkeypatch.setattr(
+        setuptools.build_meta, "get_requires_for_build_editable", lambda _cs: ["wheel"]
+    )
+
+    class FakeSettings:
+        pass
+
+    class FakeRequires:
+        settings = FakeSettings()
+
+        def cmake(self):
+            return ["cmake>=3.15"]
+
+        def ninja(self):
+            return ["ninja>=1.5"]
+
+    monkeypatch.setattr(
+        bm,
+        "GetRequires",
+        type("GR", (), {"from_config_settings": staticmethod(lambda _cs: FakeRequires())}),
+    )
+    reqs = bm.get_requires_for_build_editable()
+    assert "wheel" in reqs
+    assert "cmake>=3.15" in reqs

--- a/tests/test_setuptools_wrapper.py
+++ b/tests/test_setuptools_wrapper.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from scikit_build_core.setuptools.wrapper import setup
+
+
+def test_wrapper_basic():
+    with patch("setuptools.setup") as mock_setup:
+        setup(cmake_source_dir=".")
+    mock_setup.assert_called_once_with(
+        cmake_source_dir=".", cmake_args=(), distclass=pytest.importorskip("setuptools").Distribution
+    )
+
+
+def test_wrapper_unsupported_cmake_install_dir():
+    with pytest.raises(AssertionError, match="cmake_install_dir not supported"):
+        setup(cmake_install_dir="build")
+
+
+def test_wrapper_unsupported_cmake_with_sdist():
+    with pytest.raises(AssertionError, match="cmake_with_sdist not supported"):
+        setup(cmake_with_sdist=True)
+
+
+def test_wrapper_unsupported_manifest_hook():
+    with pytest.raises(AssertionError, match="cmake_process_manifest_hook not supported"):
+        setup(cmake_process_manifest_hook=lambda f: f)
+
+
+def test_wrapper_unsupported_install_target():
+    with pytest.raises(AssertionError, match="cmake_install_target not supported"):
+        setup(cmake_install_target="all")
+
+
+def test_wrapper_deprecated_cmake_languages():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with patch("setuptools.setup"):
+            setup(cmake_languages=["C++"])
+    assert len(w) == 1
+    assert "cmake_languages no longer has any effect" in str(w[0].message)
+
+
+def test_wrapper_deprecated_cmake_minimum_version():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with patch("setuptools.setup"):
+            setup(cmake_minimum_required_version="3.15")
+    assert len(w) == 1
+    assert "Set via pyproject.toml" in str(w[0].message)

--- a/tests/test_setuptools_wrapper.py
+++ b/tests/test_setuptools_wrapper.py
@@ -12,7 +12,9 @@ def test_wrapper_basic():
     with patch("setuptools.setup") as mock_setup:
         setup(cmake_source_dir=".")
     mock_setup.assert_called_once_with(
-        cmake_source_dir=".", cmake_args=(), distclass=pytest.importorskip("setuptools").Distribution
+        cmake_source_dir=".",
+        cmake_args=(),
+        distclass=pytest.importorskip("setuptools").Distribution,
     )
 
 
@@ -27,7 +29,9 @@ def test_wrapper_unsupported_cmake_with_sdist():
 
 
 def test_wrapper_unsupported_manifest_hook():
-    with pytest.raises(AssertionError, match="cmake_process_manifest_hook not supported"):
+    with pytest.raises(
+        AssertionError, match="cmake_process_manifest_hook not supported"
+    ):
         setup(cmake_process_manifest_hook=lambda f: f)
 
 

--- a/tests/test_sysconfig.py
+++ b/tests/test_sysconfig.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+import sysconfig
+
+import pytest
+
+from scikit_build_core.builder.sysconfig import (
+    get_abi_flags,
+    get_cmake_platform,
+    get_platform,
+    get_soabi,
+)
+
+
+def test_get_platform_vscmd_arg_tgt_arch(monkeypatch):
+    """VSCMD_ARG_TGT_ARCH should map to the corresponding Python platform name."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-amd64")
+    assert get_platform({"VSCMD_ARG_TGT_ARCH": "x86"}) == "win32"
+    assert get_platform({"VSCMD_ARG_TGT_ARCH": "x64"}) == "win-amd64"
+    assert get_platform({"VSCMD_ARG_TGT_ARCH": "arm64"}) == "win-arm64"
+
+
+def test_get_platform_vscmd_unknown_arch(monkeypatch):
+    """An unknown VSCMD_ARG_TGT_ARCH falls back to the host platform."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-amd64")
+    assert get_platform({"VSCMD_ARG_TGT_ARCH": "unknownarch"}) == "win-amd64"
+
+
+def test_get_platform_setuptools_ext_suffix_arm64(monkeypatch):
+    """arm64 in SETUPTOOLS_EXT_SUFFIX selects win-arm64."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-amd64")
+    assert (
+        get_platform({"SETUPTOOLS_EXT_SUFFIX": ".cp312-win-arm64.pyd"}) == "win-arm64"
+    )
+
+
+def test_get_cmake_platform_mapped(monkeypatch):
+    """get_cmake_platform converts Python platform names to CMake equivalents."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-amd64")
+    assert get_cmake_platform(None) == "x64"
+
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win32")
+    assert get_cmake_platform(None) == "Win32"
+
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "win-arm64")
+    assert get_cmake_platform(None) == "ARM64"
+
+
+def test_get_cmake_platform_passthrough(monkeypatch):
+    """Platforms not in PLAT_TO_CMAKE are returned as-is."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    assert get_cmake_platform(None) == "linux-x86_64"
+
+
+def test_get_soabi_setuptools_ext_suffix():
+    """SETUPTOOLS_EXT_SUFFIX overrides the detected SOABI."""
+    env = {"SETUPTOOLS_EXT_SUFFIX": ".cpython-312-x86_64-linux-gnu.so"}
+    result = get_soabi(env)
+    assert result == "cpython-312-x86_64-linux-gnu"
+
+
+def test_get_soabi_abi3_non_windows(monkeypatch):
+    """abi3=True on a non-Windows platform returns 'abi3'."""
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux-x86_64")
+    assert get_soabi({}, abi3=True) == "abi3"
+
+
+@pytest.mark.skipif(
+    not sysconfig.get_platform().startswith("win"), reason="Windows only"
+)
+def test_get_soabi_abi3_windows():
+    """abi3=True on Windows returns an empty string."""
+    assert get_soabi({}, abi3=True) == ""
+
+
+def test_get_abi_flags_returns_string():
+    """get_abi_flags always returns a string."""
+    result = get_abi_flags()
+    assert isinstance(result, str)
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython" or not sys.platform.startswith("win"),
+    reason="CPython Windows only",
+)
+def test_get_abi_flags_windows_cpython():
+    """On Windows CPython, abi flags are derived from packaging.tags."""
+    result = get_abi_flags()
+    assert isinstance(result, str)

--- a/tests/test_utils_typing.py
+++ b/tests/test_utils_typing.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Annotated, Dict, List, Optional, Union
+
+import pytest
+
+from scikit_build_core.utils.typing import (
+    get_inner_type,
+    get_target_raw_type,
+    is_union_type,
+    process_annotated,
+    process_union,
+)
+
+
+def test_process_union_basic():
+    assert process_union(Union[str, int]) == Union[str, int]
+
+
+def test_process_union_with_none():
+    assert process_union(Optional[str]) is str  # type: ignore[comparison-overlap]
+
+
+def test_process_union_only_none():
+    assert process_union(type(None)) is type(None)
+
+
+def test_process_annotated_basic():
+    assert process_annotated(Annotated[str, "meta"]) == (str, ("meta",))
+
+
+def test_process_annotated_not_annotated():
+    assert process_annotated(str) == (str, ())
+
+
+def test_get_target_raw_type_optional():
+    assert get_target_raw_type(Optional[str]) is str
+
+
+def test_get_target_raw_type_dict():
+    assert get_target_raw_type(Dict[str, int]) is dict
+
+
+def test_is_union_type():
+    assert is_union_type(Union) is True
+
+
+def test_get_inner_type_list():
+    assert get_inner_type(List[str]) is str
+
+
+def test_get_inner_type_dict():
+    assert get_inner_type(Dict[str, int]) is int
+
+
+def test_get_inner_type_invalid():
+    with pytest.raises(AssertionError, match="Expected a list or dict"):
+        get_inner_type(str)

--- a/tests/test_utils_typing.py
+++ b/tests/test_utils_typing.py
@@ -18,7 +18,7 @@ def test_process_union_basic():
 
 
 def test_process_union_with_none():
-    assert process_union(Optional[str]) is str  # type: ignore[comparison-overlap]
+    assert process_union(Optional[str]) is str
 
 
 def test_process_union_only_none():
@@ -26,7 +26,7 @@ def test_process_union_only_none():
 
 
 def test_process_annotated_basic():
-    assert process_annotated(Annotated[str, "meta"]) == (str, ("meta",))
+    assert process_annotated(Annotated[str, "meta"]) == (str, ("meta",))  # type: ignore[arg-type]
 
 
 def test_process_annotated_not_annotated():

--- a/tests/test_utils_typing.py
+++ b/tests/test_utils_typing.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import pytest
 
+from scikit_build_core._compat.typing import Annotated
 from scikit_build_core.utils.typing import (
     get_inner_type,
     get_target_raw_type,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import scikit_build_core
+
+
+def test_version():
+    assert isinstance(scikit_build_core.__version__, str)
+    assert len(scikit_build_core.__version__) > 0
+
+
+def test_all():
+    assert scikit_build_core.__all__ == ["__version__"]


### PR DESCRIPTION
Adding coverage.

- **tests: increase coverage for version, main, generate, setuptools, metadata, errors, format, auto-requires, auto-cmake-version, and typing utilities**

:robot: Assisted-by: Copilot:Kimi-K2.6

- **tests: more tests**

:robot: Assisted-by: Copilot:GPT-5.4

