### PR TITLE
feat: include plugin extras for setuptools/hatchling

### DIFF
--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -5,9 +5,9 @@ currently in a highly experimental state, but feedback is welcome.
 
 :::{warning}
 
-This plugin is experimental, and will probably be moved to a separate package.
-If using it, it is highly recommended to upper-cap scikit-build-core until it
-moves.
+Use the `[hatchling]` extra when using this plugin. It will ensure a proper
+version of hatchling, and will help protect you if the plugin moves to a
+separate package in the future.
 
 :::
 

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -5,8 +5,10 @@ enable scikit-build-core to be the build backend for scikit-build (classic).
 
 :::{warning}
 
-This plugin is experimental, and will probably be moved to a separate package.
-If using it, it is probably best to upper-cap scikit-build-core until it moves.
+Use the `[setuptools]` extra when using this plugin. It will ensure a proper
+version of setuptools, and will help protect you if the plugin moves to a
+separate package in the future. Use this even if you set a higher minimum
+version of setuptools (recommended!).
 
 :::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,15 @@ wheels = [
 wheel-free-setuptools = [
     'setuptools>=70.1; python_version>="3.8"',
 ]
+setuptools = [
+    'setuptools >=43; python_version<"3.9"',
+    'setuptools >=45; python_version=="3.9"',
+    'setuptools >=49; python_version>="3.10" and python_version<"3.12"',
+    'setuptools >=66.1; python_version>="3.12"',
+]
+hatchling = [
+    "hatchling >=1.24",
+]
 
 [project.urls]
 Changelog = "https://scikit-build-core.readthedocs.io/en/latest/changelog.html"


### PR DESCRIPTION
Adding these. If we do pull out the plugins in the future, this allows a path to keep older code working.
