### PR TITLE
fix(editable): recognize Cython `__init__.pxd`/`.pyx` as package indicators

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -58,11 +58,16 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     """
     Convert a mapping of files to modules to a mapping of modules to installed files.
     """
-    return {
-        path_to_module(Path(v).relative_to(libdir)): str(Path(k).resolve())
-        for k, v in mapping.items()
-        if is_valid_module(Path(v).relative_to(libdir))
-    }
+    result: dict[str, str] = {}
+    for k, v in mapping.items():
+        rel = Path(v).relative_to(libdir)
+        if not is_valid_module(rel):
+            continue
+        module = path_to_module(rel)
+        # Prefer .py/.pyc over other extensions (e.g. .pxd, .pyx) for the same module
+        if module not in result or rel.suffix in (".py", ".pyc"):
+            result[module] = str(Path(k).resolve())
+    return result
 
 
 def libdir_to_installed(libdir: Path) -> dict[str, str]:

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -110,7 +110,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 # Strip the last element of the module
                 parent = ".".join(module.split(".")[:-1])
                 # Check if it is a package
-                if "__init__.py" in file:
+                if os.path.basename(file).partition(".")[0] == "__init__":
                     parent = module
                     pkgs.append(parent)
                 # Skip if it's a root module (there are no search paths for these)
@@ -151,7 +151,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 fullname,
                 os.path.join(self.dir, redir),
                 submodule_search_locations=submodule_search_locations
-                if redir.endswith(("__init__.py", "__init__.pyc"))
+                if fullname in self.pkgs
                 else None,
             )
         if fullname in self.known_source_files:
@@ -160,7 +160,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 fullname,
                 redir,
                 submodule_search_locations=submodule_search_locations
-                if redir.endswith(("__init__.py", "__init__.pyc"))
+                if fullname in self.pkgs
                 else None,
             )
         return None

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -128,7 +128,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                     parent_path = os.path.join(self.dir, parent_path)
                 submodule_search_locations[parent].add(parent_path)
         self.submodule_search_locations = submodule_search_locations
-        self.pkgs = pkgs
+        self.pkgs = frozenset(pkgs)
 
     def find_spec(
         self,

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -67,7 +67,7 @@ def test_editable_redirect():
             },
         }
     )
-    assert finder.pkgs == ["pkg", "pkg.subpkg"]
+    assert finder.pkgs == frozenset(["pkg", "pkg.subpkg"])
 
 
 def test_editable_redirect_pxd():

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -71,14 +71,27 @@ def test_editable_redirect():
 
 
 def test_editable_redirect_pxd():
-    """Test that .pxd/__init__.pxd files are recognized as packages."""
+    """Test that .pxd/.pyx __init__ files are recognized as packages.
+
+    This mirrors real-world Cython projects (e.g. cuVS) where packages have
+    both __init__.py and __init__.pxd, and where the file scanner may pick up
+    the .pxd as the representative file for the package init.
+    The key fix: the parent package's __path__ must NOT be polluted with the
+    child package's directory.
+    """
     known_source_files = process_dict(
         {
+            "pkg": "/source/pkg/__init__.py",
+            "pkg.module": "/source/pkg/module.py",
+            # Cython subpackage whose init was picked up as .pxd (not .py)
             "pkg.cython_subpkg": "/source/pkg/cython_subpkg/__init__.pxd",
+            "pkg.cython_subpkg.impl": "/source/pkg/cython_subpkg/impl.pyx",
+            # Pyx subpackage
             "pkg.pyx_subpkg": "/source/pkg/pyx_subpkg/__init__.pyx",
+            "pkg.pyx_subpkg.module": "/source/pkg/pyx_subpkg/module.py",
         }
     )
-    known_wheel_files = process_dict({})
+    known_wheel_files = process_dict({"pkg.cython_subpkg.compiled": "pkg/cython_subpkg/compiled.abi3.so"})
 
     finder = ScikitBuildRedirectingFinder(
         known_source_files=known_source_files,
@@ -92,23 +105,22 @@ def test_editable_redirect_pxd():
         install_dir="",
     )
 
-    # Bug 1: .pxd/.pyx files are not recognized as packages
+    # Fix A: .pxd/.pyx init files should be recognized as packages
     assert "pkg.cython_subpkg" in finder.pkgs
     assert "pkg.pyx_subpkg" in finder.pkgs
 
-    # Bug 1: .pxd/.pyx packages should have their own search locations
+    # Fix A: Cython subpackages must have their OWN search locations
     assert "pkg.cython_subpkg" in finder.submodule_search_locations
     assert "pkg.pyx_subpkg" in finder.submodule_search_locations
 
-    # Bug 2: find_spec should recognize .pxd/.pyx as packages
-    spec_pxd = finder.find_spec("pkg.cython_subpkg")
-    assert spec_pxd is not None
-    assert spec_pxd.submodule_search_locations is not None
-
-    spec_pyx = finder.find_spec("pkg.pyx_subpkg")
-    assert spec_pyx is not None
-    assert spec_pyx.submodule_search_locations is not None
-
+    # Critical: parent pkg.__path__ must NOT be polluted with child package dirs
+    pkg_paths = finder.submodule_search_locations.get("pkg", set())
+    assert not any("cython_subpkg" in p for p in pkg_paths), (
+        f"pkg.__path__ is polluted with cython_subpkg: {pkg_paths}"
+    )
+    assert not any("pyx_subpkg" in p for p in pkg_paths), (
+        f"pkg.__path__ is polluted with pyx_subpkg: {pkg_paths}"
+    )
 
 def test_mapping_to_modules_prefers_py():
     """Test that mapping_to_modules prefers __init__.py over __init__.pxd."""

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -73,11 +73,8 @@ def test_editable_redirect():
 def test_editable_redirect_pxd():
     """Test that .pxd/.pyx __init__ files are recognized as packages.
 
-    This mirrors real-world Cython projects (e.g. cuVS) where packages have
-    both __init__.py and __init__.pxd, and where the file scanner may pick up
-    the .pxd as the representative file for the package init.
-    The key fix: the parent package's __path__ must NOT be polluted with the
-    child package's directory.
+    If packages have both __init__.py and __init__.pxd, the file scanner may pick up the
+    .pxd as the representative file for the package init and produce the wrong __path__.
     """
     known_source_files = process_dict(
         {
@@ -107,15 +104,15 @@ def test_editable_redirect_pxd():
         install_dir="",
     )
 
-    # Fix A: .pxd/.pyx init files should be recognized as packages
+    # .pxd/.pyx init files should be recognized as packages
     assert "pkg.cython_subpkg" in finder.pkgs
     assert "pkg.pyx_subpkg" in finder.pkgs
 
-    # Fix A: Cython subpackages must have their OWN search locations
+    # Cython subpackages must have their OWN search locations
     assert "pkg.cython_subpkg" in finder.submodule_search_locations
     assert "pkg.pyx_subpkg" in finder.submodule_search_locations
 
-    # Critical: parent pkg.__path__ must NOT be polluted with child package dirs
+    # parent pkg.__path__ must NOT be polluted with child package dirs
     pkg_paths = finder.submodule_search_locations.get("pkg", set())
     assert not any("cython_subpkg" in p for p in pkg_paths), (
         f"pkg.__path__ is polluted with cython_subpkg: {pkg_paths}"

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -68,3 +68,59 @@ def test_editable_redirect():
         }
     )
     assert finder.pkgs == ["pkg", "pkg.subpkg"]
+
+
+def test_editable_redirect_pxd():
+    """Test that .pxd/__init__.pxd files are recognized as packages."""
+    known_source_files = process_dict(
+        {
+            "pkg.cython_subpkg": "/source/pkg/cython_subpkg/__init__.pxd",
+            "pkg.pyx_subpkg": "/source/pkg/pyx_subpkg/__init__.pyx",
+        }
+    )
+    known_wheel_files = process_dict({})
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files=known_source_files,
+        known_wheel_files=known_wheel_files,
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(Path("/sitepackages")),
+        install_dir="",
+    )
+
+    # Bug 1: .pxd/.pyx files are not recognized as packages
+    assert "pkg.cython_subpkg" in finder.pkgs
+    assert "pkg.pyx_subpkg" in finder.pkgs
+
+    # Bug 1: .pxd/.pyx packages should have their own search locations
+    assert "pkg.cython_subpkg" in finder.submodule_search_locations
+    assert "pkg.pyx_subpkg" in finder.submodule_search_locations
+
+    # Bug 2: find_spec should recognize .pxd/.pyx as packages
+    spec_pxd = finder.find_spec("pkg.cython_subpkg")
+    assert spec_pxd is not None
+    assert spec_pxd.submodule_search_locations is not None
+
+    spec_pyx = finder.find_spec("pkg.pyx_subpkg")
+    assert spec_pyx is not None
+    assert spec_pyx.submodule_search_locations is not None
+
+
+def test_mapping_to_modules_prefers_py():
+    """Test that mapping_to_modules prefers __init__.py over __init__.pxd."""
+    from scikit_build_core.build._editable import mapping_to_modules
+
+    libdir = Path("/site-packages")
+    mapping = {
+        "/source/pkg/__init__.py": "/site-packages/pkg/__init__.py",
+        "/source/pkg/__init__.pxd": "/site-packages/pkg/__init__.pxd",
+        "/source/pkg/module.py": "/site-packages/pkg/module.py",
+    }
+    result = mapping_to_modules(mapping, libdir)
+
+    # Bug 3: .py should win over .pxd (currently .pxd overwrites .py)
+    assert result["pkg"].endswith("__init__.py")

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -91,7 +91,9 @@ def test_editable_redirect_pxd():
             "pkg.pyx_subpkg.module": "/source/pkg/pyx_subpkg/module.py",
         }
     )
-    known_wheel_files = process_dict({"pkg.cython_subpkg.compiled": "pkg/cython_subpkg/compiled.abi3.so"})
+    known_wheel_files = process_dict(
+        {"pkg.cython_subpkg.compiled": "pkg/cython_subpkg/compiled.abi3.so"}
+    )
 
     finder = ScikitBuildRedirectingFinder(
         known_source_files=known_source_files,
@@ -121,6 +123,7 @@ def test_editable_redirect_pxd():
     assert not any("pyx_subpkg" in p for p in pkg_paths), (
         f"pkg.__path__ is polluted with pyx_subpkg: {pkg_paths}"
     )
+
 
 def test_mapping_to_modules_prefers_py():
     """Test that mapping_to_modules prefers __init__.py over __init__.pxd."""


### PR DESCRIPTION
Fixes #1291.

Three targeted fixes for editable installs of Cython projects where packages have `__init__.pxd` or `__init__.pyx` files alongside (or instead of) `__init__.py`:

**`_editable_redirect.py` — package detection (line 113):**
`"__init__.py" in file` → `os.path.basename(file).partition(".")[0] == "__init__"` — matches any `__init__.*` extension, consistent with `path_to_module()` which already handles this correctly.

**`_editable_redirect.py` — `find_spec` (lines 154/163):**
`redir.endswith(("__init__.py", "__init__.pyc"))` → `fullname in self.pkgs` — uses the already-computed package list rather than re-checking file extensions.

**`_editable.py` — `mapping_to_modules`:**
Dict comprehension → explicit loop that prefers `.py`/`.pyc` when multiple source files (e.g. `__init__.py` + `__init__.pxd`) map to the same module key.