### PR TITLE
fix(setuptools): protect SetupError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,7 @@ docstring-code-format = true
 "importlib.resources".msg = "Use scikit_build_core._compat.importlib.resources instead."
 "importlib_resources".msg = "Use scikit_build_core._compat.importlib.resources instead."
 "pyproject_metadata".msg = "Use scikit_build_core._vendor.pyproject_metadata instead."
+"setuptools.errors".msg = "Use scikit_build_core._compat.setuptools.errors instead."
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/scikit_build_core/_compat/setuptools/__init__.py
+++ b/src/scikit_build_core/_compat/setuptools/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/scikit_build_core/_compat/setuptools/errors.py
+++ b/src/scikit_build_core/_compat/setuptools/errors.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from setuptools.errors import SetupError
+else:
+    try:
+        from setuptools.errors import SetupError
+    except ImportError:
+        # pylint: disable-next=deprecated-module
+        from distutils.errors import (
+            DistutilsError as SetupError,  # type: ignore[assignment, misc]
+        )
+
+__all__ = ["SetupError"]
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import setuptools
-import setuptools.errors
 from packaging.version import Version
 
 from .._compat import tomllib
+from .._compat.setuptools.errors import SetupError
 from .._logging import LEVEL_VALUE, raw_logger
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
@@ -375,7 +375,7 @@ def cmake_args(
     _cmake_extension(dist)
     if not isinstance(value, list):
         msg = "cmake_args must be a list"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)
 
 
 def cmake_install_dir(
@@ -385,12 +385,12 @@ def cmake_install_dir(
     _cmake_extension(dist)
     if not isinstance(value, str):
         msg = "cmake_install_dir must be a string"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)
     # Reject path traversal and drive components to prevent escaping build_lib
     p = Path(value)
     if p.is_absolute() or ".." in p.parts or p.drive:
         msg = f"cmake_install_dir must be a relative path without '..' components, got: {value!r}"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)
 
 
 def cmake_source_dir(
@@ -399,11 +399,11 @@ def cmake_source_dir(
     assert attr == "cmake_source_dir"
     if get_source_dir_from_pyproject_toml() is not None:
         msg = "cmake_source_dir is already defined in pyproject.toml"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)
     _cmake_extension(dist)
     if not Path(value).is_dir():
         msg = "cmake_source_dir must be an existing directory"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)
 
 
 def cmake_install_target(
@@ -413,7 +413,7 @@ def cmake_install_target(
     assert value is not None
     _cmake_extension(dist)
     msg = "cmake_install_target is not supported - please use components and build targets instead"
-    raise setuptools.errors.SetupError(msg)
+    raise SetupError(msg)
 
 
 def cmake_with_sdist(
@@ -424,4 +424,4 @@ def cmake_with_sdist(
     assert attr == "cmake_with_sdist"
     if value:
         msg = "cmake_with_sdist must not be set to True"
-        raise setuptools.errors.SetupError(msg)
+        raise SetupError(msg)


### PR DESCRIPTION
This protects the SetupError import (at least until we drop older setuptools support).

:robot: Assisted-by: OpenCode:Qwen-3.5:397B
