### PR TITLE
fix(setuptools): wrapper path compatibility with scikit-build (classic)

### DIFF
--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -515,13 +515,13 @@ class BuildCMake(setuptools.Command):
         use_wrapper_classic_layout_compat = (
             self._wrapper_classic_layout_compat_enabled()
         )
-        cmake_install_dir = (
+        cmake_install_prefix = (
             build_temp / "cmake-install" / install_subdir
             if use_wrapper_classic_layout_compat
             else install_dir
         )
         installed_before = _collect_recursive_files(install_dir)
-        defines = {"CMAKE_INSTALL_PREFIX": cmake_install_dir}
+        defines = {"CMAKE_INSTALL_PREFIX": cmake_install_prefix}
 
         builder.configure(
             name=dist.get_name(),
@@ -541,20 +541,20 @@ class BuildCMake(setuptools.Command):
             build_args.append(f"-j{self.parallel}")
 
         builder.build(build_args=build_args)
-        builder.install(install_dir=cmake_install_dir)
+        builder.install(install_dir=cmake_install_prefix)
 
-        cmake_manifest = _read_cmake_install_manifests(build_temp, cmake_install_dir)
+        cmake_manifest = _read_cmake_install_manifests(build_temp, cmake_install_prefix)
         if cmake_manifest is None:
             installed_after = _collect_recursive_files(install_dir)
             cmake_manifest = sorted(installed_after - installed_before)
 
         process_manifest = getattr(dist, "cmake_process_manifest_hook", None)
         processed_manifest = _process_manifest(cmake_manifest, process_manifest)
-        _prune_manifest(cmake_install_dir, cmake_manifest, processed_manifest)
-        self._record_installed_files(build_temp, cmake_install_dir, processed_manifest)
+        _prune_manifest(cmake_install_prefix, cmake_manifest, processed_manifest)
+        self._record_installed_files(build_temp, cmake_install_prefix, processed_manifest)
         if use_wrapper_classic_layout_compat:
             self._apply_wrapper_classic_layout_compat(
-                staged_install_dir=cmake_install_dir, install_subdir=install_subdir
+                staged_install_dir=cmake_install_prefix, install_subdir=install_subdir
             )
 
     def get_outputs(self) -> list[str]:

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -551,7 +551,9 @@ class BuildCMake(setuptools.Command):
         process_manifest = getattr(dist, "cmake_process_manifest_hook", None)
         processed_manifest = _process_manifest(cmake_manifest, process_manifest)
         _prune_manifest(cmake_install_prefix, cmake_manifest, processed_manifest)
-        self._record_installed_files(build_temp, cmake_install_prefix, processed_manifest)
+        self._record_installed_files(
+            build_temp, cmake_install_prefix, processed_manifest
+        )
         if use_wrapper_classic_layout_compat:
             self._apply_wrapper_classic_layout_compat(
                 staged_install_dir=cmake_install_prefix, install_subdir=install_subdir

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal
@@ -36,6 +37,8 @@ __all__ = [
 ]
 
 WRAPPER_CMAKE_INSTALL_DIR_COMPAT = "_scikit_build_wrapper_cmake_install_dir_compat"
+WRAPPER_CLASSIC_LAYOUT_COMPAT = "_scikit_build_wrapper_classic_layout_compat"
+ORIGINAL_DATA_FILES = "_scikit_build_original_data_files"
 
 
 def __dir__() -> list[str]:
@@ -229,6 +232,57 @@ def _prune_manifest(
         _remove_empty_parents(path, install_dir)
 
 
+def _package_paths(dist: Distribution) -> set[Path]:
+    return {
+        Path(*package.split(".")) for package in getattr(dist, "packages", None) or []
+    }
+
+
+def _package_source_roots(dist: Distribution) -> list[Path]:
+    packages = list(getattr(dist, "packages", None) or [])
+    if not packages:
+        return [_package_base_dir(dist)]
+
+    roots: set[Path] = set()
+    for package in packages:
+        package_source_dir = _package_source_dir(dist, package)
+        package_parts = package.split(".")
+        if package_parts == list(package_source_dir.parts[-len(package_parts) :]):
+            roots.add(Path(*package_source_dir.parts[: -len(package_parts)]))
+        else:
+            roots.add(package_source_dir.parent)
+
+    return sorted(roots, key=lambda path: (-len(path.parts), os.fspath(path)))
+
+
+def _classify_wrapper_package_file(dist: Distribution, path: Path) -> Path | None:
+    package_paths = _package_paths(dist)
+    if not package_paths:
+        return None
+
+    candidates = [path]
+    for root in _package_source_roots(dist):
+        if not root.parts:
+            continue
+        try:
+            candidates.append(path.relative_to(root))
+        except ValueError:
+            continue
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if any(
+            candidate == package_path or package_path in candidate.parents
+            for package_path in package_paths
+        ):
+            return candidate
+
+    return None
+
+
 class BuildCMake(setuptools.Command):
     source_dir: str | None = None
     cmake_args: list[str] | str | None = None
@@ -312,6 +366,18 @@ class BuildCMake(setuptools.Command):
         source_root = package_dir.get("", ".")
         return Path(source_root).resolve() / install_subdir
 
+    def _set_generated_data_files(
+        self, data_files: list[tuple[str, list[str]]] | None = None
+    ) -> None:
+        dist = self.distribution
+        if not hasattr(dist, ORIGINAL_DATA_FILES):
+            setattr(
+                dist, ORIGINAL_DATA_FILES, list(getattr(dist, "data_files", []) or [])
+            )
+
+        original_data_files = list(getattr(dist, ORIGINAL_DATA_FILES))
+        dist.data_files = [*original_data_files, *(data_files or [])]
+
     def _record_installed_files(
         self,
         build_dir: Path,
@@ -338,6 +404,54 @@ class BuildCMake(setuptools.Command):
                 if line
             )
 
+    def _wrapper_classic_layout_compat_enabled(self) -> bool:
+        return bool(
+            not self.editable_mode
+            and getattr(self.distribution, WRAPPER_CLASSIC_LAYOUT_COMPAT, False)
+        )
+
+    def _apply_wrapper_classic_layout_compat(
+        self, *, staged_install_dir: Path, install_subdir: Path
+    ) -> None:
+        assert self.build_lib is not None
+
+        build_lib = Path(self.build_lib).resolve()
+        staged_install_dir = staged_install_dir.resolve()
+        generated_data_files: defaultdict[str, list[str]] = defaultdict(list)
+        package_outputs: list[Path] = []
+
+        for staged_path in self._installed_files:
+            relative_output = staged_path.relative_to(staged_install_dir)
+            effective_output = (
+                install_subdir / relative_output
+                if install_subdir.parts
+                else relative_output
+            )
+            package_output = _classify_wrapper_package_file(
+                self.distribution, effective_output
+            )
+
+            if package_output is None:
+                data_dir = (
+                    os.fspath(effective_output.parent)
+                    if effective_output.parent.parts
+                    else ""
+                )
+                generated_data_files[data_dir].append(os.fspath(staged_path))
+                continue
+
+            destination = build_lib / package_output
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(staged_path, destination)
+            package_outputs.append(destination)
+
+        self._installed_files = sorted(package_outputs)
+        data_files = [
+            (directory, sorted(files))
+            for directory, files in sorted(generated_data_files.items())
+        ]
+        self._set_generated_data_files(data_files)
+
     def run(self) -> None:
         assert self.build_lib is not None
         assert self.build_temp is not None
@@ -351,6 +465,7 @@ class BuildCMake(setuptools.Command):
         build_temp = build_tmp_folder / "_skbuild"
         self._installed_files = []
         self._editable_install_dir = None
+        self._set_generated_data_files()
 
         dist = self.distribution
         dist_source_dir = getattr(self.distribution, "cmake_source_dir", None)
@@ -395,9 +510,18 @@ class BuildCMake(setuptools.Command):
 
         # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
         # Otherwise `cmake --install --prefix` would work by itself
+        install_subdir = self._get_install_subdir()
         install_dir = self._get_install_dir()
+        use_wrapper_classic_layout_compat = (
+            self._wrapper_classic_layout_compat_enabled()
+        )
+        cmake_install_dir = (
+            build_temp / "cmake-install" / install_subdir
+            if use_wrapper_classic_layout_compat
+            else install_dir
+        )
         installed_before = _collect_recursive_files(install_dir)
-        defines = {"CMAKE_INSTALL_PREFIX": install_dir}
+        defines = {"CMAKE_INSTALL_PREFIX": cmake_install_dir}
 
         builder.configure(
             name=dist.get_name(),
@@ -417,17 +541,21 @@ class BuildCMake(setuptools.Command):
             build_args.append(f"-j{self.parallel}")
 
         builder.build(build_args=build_args)
-        builder.install(install_dir=install_dir)
+        builder.install(install_dir=cmake_install_dir)
 
-        cmake_manifest = _read_cmake_install_manifests(build_temp, install_dir)
+        cmake_manifest = _read_cmake_install_manifests(build_temp, cmake_install_dir)
         if cmake_manifest is None:
             installed_after = _collect_recursive_files(install_dir)
             cmake_manifest = sorted(installed_after - installed_before)
 
         process_manifest = getattr(dist, "cmake_process_manifest_hook", None)
         processed_manifest = _process_manifest(cmake_manifest, process_manifest)
-        _prune_manifest(install_dir, cmake_manifest, processed_manifest)
-        self._record_installed_files(build_temp, install_dir, processed_manifest)
+        _prune_manifest(cmake_install_dir, cmake_manifest, processed_manifest)
+        self._record_installed_files(build_temp, cmake_install_dir, processed_manifest)
+        if use_wrapper_classic_layout_compat:
+            self._apply_wrapper_classic_layout_compat(
+                staged_install_dir=cmake_install_dir, install_subdir=install_subdir
+            )
 
     def get_outputs(self) -> list[str]:
         if self.editable_mode:

--- a/src/scikit_build_core/setuptools/wrapper.py
+++ b/src/scikit_build_core/setuptools/wrapper.py
@@ -9,7 +9,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 from .._compat.typing import TypeVar
-from .build_cmake import WRAPPER_CMAKE_INSTALL_DIR_COMPAT
+from .build_cmake import (
+    WRAPPER_CLASSIC_LAYOUT_COMPAT,
+    WRAPPER_CMAKE_INSTALL_DIR_COMPAT,
+)
 
 __all__ = ["setup"]
 
@@ -52,7 +55,10 @@ def setup(
         type(
             "DistributionClass",
             (distclass,),
-            {WRAPPER_CMAKE_INSTALL_DIR_COMPAT: True},
+            {
+                WRAPPER_CLASSIC_LAYOUT_COMPAT: True,
+                WRAPPER_CMAKE_INSTALL_DIR_COMPAT: True,
+            },
         ),
     )
 

--- a/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15...3.26)
+project(
+  "${SKBUILD_PROJECT_NAME}"
+  LANGUAGES CXX
+  VERSION "${SKBUILD_PROJECT_VERSION}")
+
+find_package(pybind11 CONFIG REQUIRED)
+pybind11_add_module(_core src/main.cpp)
+
+target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
+
+install(TARGETS _core LIBRARY DESTINATION python/classic_layout_example)
+install(FILES data/example.h DESTINATION include/classic_layout_example)

--- a/tests/packages/wrapper_setuptools_classic_layout/data/example.h
+++ b/tests/packages/wrapper_setuptools_classic_layout/data/example.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/packages/wrapper_setuptools_classic_layout/pyproject.toml
+++ b/tests/packages/wrapper_setuptools_classic_layout/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "scikit_build_core",
+    "setuptools",
+    "pybind11",
+]
+build-backend = "scikit_build_core.setuptools.build_meta"
+
+[tool.scikit-build]
+editable.mode = "inplace"

--- a/tests/packages/wrapper_setuptools_classic_layout/python/classic_layout_example/__init__.py
+++ b/tests/packages/wrapper_setuptools_classic_layout/python/classic_layout_example/__init__.py
@@ -1,0 +1,3 @@
+from ._core import add  # type: ignore[import-not-found]
+
+__all__ = ["add"]

--- a/tests/packages/wrapper_setuptools_classic_layout/setup.py
+++ b/tests/packages/wrapper_setuptools_classic_layout/setup.py
@@ -1,0 +1,13 @@
+from setuptools import find_packages
+
+from scikit_build_core.setuptools.wrapper import setup
+
+setup(
+    name="wrapper-classic-layout",
+    version="0.0.1",
+    cmake_source_dir=".",
+    package_dir={"": "python"},
+    packages=find_packages(where="python"),
+    zip_safe=False,
+    python_requires=">=3.8",
+)

--- a/tests/packages/wrapper_setuptools_classic_layout/src/main.cpp
+++ b/tests/packages/wrapper_setuptools_classic_layout/src/main.cpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+
+int add(int i, int j) {
+    return i + j;
+}
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_core, m) {
+    m.def("add", &add);
+}

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -355,6 +355,41 @@ def test_cmake_install_dir_wheel(
 
 @pytest.mark.compile
 @pytest.mark.configure
+@pytest.mark.xfail(
+    sys.platform.startswith("cygwin"),
+    reason="Cygwin fails here with ld errors",
+    strict=False,
+)
+@pytest.mark.parametrize(
+    "package", ["wrapper_setuptools_classic_layout"], indirect=True
+)
+@pytest.mark.usefixtures("package", "pybind11")
+def test_wrapper_classic_layout_wheel(tmp_path: Path):
+    dist = tmp_path / "dist"
+    out = build_wheel(str(dist))
+    wheel = (dist / out).resolve()
+
+    with zipfile.ZipFile(wheel) as zf:
+        file_names = set(zf.namelist())
+
+    assert "classic_layout_example/__init__.py" in file_names
+    assert any(name.startswith("classic_layout_example/_core.") for name in file_names)
+    assert any(
+        name.endswith(".data/data/include/classic_layout_example/example.h")
+        for name in file_names
+    )
+    assert not any(
+        name.startswith("python/classic_layout_example/") for name in file_names
+    )
+    assert not any(name.startswith("include/") for name in file_names)
+
+    venv = VEnv(tmp_path / "classic-layout-venv")
+    venv.install(str(wheel))
+    _assert_extension_import(venv, "classic_layout_example")
+
+
+@pytest.mark.compile
+@pytest.mark.configure
 @pytest.mark.skipif(
     build_editable is None, reason="Requires setuptools editable support"
 )


### PR DESCRIPTION
I tried swapping this out on taichi-dev/taichi, and got differing wheels. I had Kimi-K2.6 prepare a report of the differences, then fed that into GPT 5.4. I made this wrapper-only. I was using #1285 as well (that's why I picked that repo).

I set up a docker build for Taichi, since it doesn't support modern LLVM or even ARM Linux.

<details><summary>Dockerfile</summary>

```docker
# syntax=docker/dockerfile:1

FROM ubuntu:22.04

# Prevent interactive prompts during apt install
ENV DEBIAN_FRONTEND=noninteractive

# Install system dependencies
RUN apt-get update && apt-get install -y \
    build-essential curl git python3-dev \
    llvm clang zlib1g-dev libzstd-dev \
    libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
    mesa-common-dev \
    && rm -rf /var/lib/apt/lists/*

# Install uv (astral package manager)
RUN curl -LsSf https://astral.sh/uv/install.sh | sh
ENV PATH="/root/.local/bin:${PATH}"

# Create workdir and clone taichi
# This will be overwritten if you mount a local directory to /root/taichi
WORKDIR /root/taichi

# Default shell for interactive use
CMD ["/bin/bash"]
```

</details>

I even got a docker-compose, since I asked Kimi-K2.6 to make sure Ollama could be reached (didn't use it yet):

<details>
<summary>docker-compose.yml:</summary>

```yaml
services:
  taichi-dev:
    build:
      context: .
      dockerfile: Dockerfile
    container_name: taichi-dev
    # Keep the container running interactively
    stdin_open: true
    tty: true
    # Mount your local project directory for live edits
    volumes:
      - ./taichi:/root/taichi/tachi
    # Connect to Ollama running on the host machine
    # 'host.docker.internal' works on Docker Desktop (Mac/Windows).
    # On Linux, you may need to use 'host' network mode or the host's LAN IP.
    extra_hosts:
      - "host.docker.internal:host-gateway"
    # Pass through your local environment variable
    environment:
      # Point to the host Ollama endpoint
      - OLLAMA_HOST=http://host.docker.internal:11434
    # Use host networking on Linux if host.docker.internal is unavailable
    # network_mode: host
```

</details>

<details><summary>README.md</summary>
<p>

# Taichi Development Container

A Docker setup for working interactively on the [Taichi](https://github.com/taichi-dev/taichi) project.

## What's included

- Ubuntu 22.04
- Build essentials (`build-essential`, `curl`, `llvm`, `git`)
- [uv](https://github.com/astral-sh/uv) Python environment manager
- Pre-cloned Taichi repository with initialized submodules
- Core dependencies

## Prerequisites

- [Docker](https://docs.docker.com/get-docker/)
- (Optional) [Docker Compose](https://docs.docker.com/compose/install/)

## Quick Start

### Using Docker Compose

1. Build and start the container:
   ```bash
   docker compose up --build
   ```

2. If you want to run the container in the background and drop into a shell on demand:
   ```bash
   docker compose up --build -d
   docker exec -it taichi-dev bash
   ```

### Using Docker directly

```bash
# Build the image
docker build -t taichi-dev .

# Run interactively
docker run --rm -it \
  -v "$(pwd)/taichi:/root/taichi" \
  -e EXAMPLE_VARIABLE="your_value" \
  -e OLLAMA_HOST="http://host.docker.internal:11434" \
  taichi-dev
```

## Connecting to Ollama

The container is configured to reach Ollama running on your host machine.

- **macOS / Windows**: Use `http://host.docker.internal:11434` (automatically set via `OLLAMA_HOST`).
- **Linux**: If `host.docker.internal` does not resolve, uncomment the `network_mode: host` line in `docker-compose.yml` and use `http://localhost:11434` instead.

## Environment Variables

| Variable | Description |
|----------|-------------|
| `OLLAMA_HOST` | Points to the Ollama API endpoint on your host. |


## Build

Run:

```bash
cd taichi
uv venv --clear
CMAKE_POLICY_VERSION_MINIMUM=3.5 CMAKE_BUILD_PARALLEL_LEVEL=8 CXX=clang++ CC=clang uv pip install -v .
```

</p>
</details> 

You need `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose up --build -d` to get Intel. You need to check out Taichi in this directory, and it will be mounted. venv does show up on host too, unfortunately. Use `uv build --wheel` to build wheels for comparison.

:robot: Assisted-by: Copilot:GPT-5.4
