### PR TITLE
feat: Add PEP 770 SBOM files support (wheel.sbom-files setting)

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -572,6 +572,15 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: wheel.sbom-files
+  :type: ``list[str]``
+
+  A list of Software Bill of Materials files to include in the wheel.
+
+  Files are copied into the ``*.dist-info/sboms`` directory.
+```
+
+```{eval-rst}
 .. confval:: wheel.packages
   :type: ``list[str]``
   :default: ["src/<package>", "python/<package>", "<package>"]

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -364,6 +364,19 @@ def _build_wheel_impl_impl(
                 "No license files found, set wheel.license-files to [] to suppress this warning"
             )
 
+        sbom_paths: list[Path] = []
+        for sbom_file in settings.wheel.sbom_files or []:
+            sbom_path = Path(sbom_file)
+            if not sbom_path.is_file():
+                msg = f"SBOM file not found: {sbom_file}"
+                raise FileNotFoundError(msg)
+            sbom_paths.append(sbom_path)
+
+        for sbom_path in sbom_paths:
+            path = wheel_dirs["metadata"] / "sboms" / sbom_path.name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(sbom_path, path)
+
         for gen in settings.generate:
             if gen.location == "source":
                 contents = generate_file_contents(gen, metadata)

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -237,6 +237,13 @@
           },
           "description": "A list of license files to include in the wheel. Supports glob patterns."
         },
+        "sbom-files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Software Bill of Materials files to include in the wheel."
+        },
         "cmake": {
           "type": "boolean",
           "default": true,
@@ -583,6 +590,9 @@
                     "$ref": "#/$defs/inherit"
                   },
                   "license-files": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "sbom-files": {
                     "$ref": "#/$defs/inherit"
                   },
                   "exclude": {

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -331,6 +331,13 @@ class WheelSettings:
        Must not be set if ``project.license-files`` is set.
     """
 
+    sbom_files: Optional[List[str]] = None
+    """
+    A list of Software Bill of Materials files to include in the wheel.
+
+    Files are copied into the ``*.dist-info/sboms`` directory.
+    """
+
     cmake: bool = True
     """
     Run CMake as part of building the wheel.

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -313,34 +313,6 @@ def test_pep517_wheel_source_dir(virtualenv, tmp_path: Path):
     assert add.strip() == "3"
 
 
-@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
-@pytest.mark.usefixtures("package")
-def test_pep517_wheel_sbom_files(tmp_path: Path):
-    sbom_dir = Path("sbom_inputs")
-    sbom_dir.mkdir()
-    sbom_file = sbom_dir / "project.spdx.json"
-    sbom_content = '{"spdxVersion": "SPDX-2.3"}'
-    sbom_file.write_text(sbom_content, encoding="utf-8")
-
-    dist = tmp_path / "dist"
-    build_wheel(str(dist), {"wheel.sbom-files": [str(sbom_file)]})
-
-    (wheel,) = dist.glob("purelib_example-0.0.1-*.whl")
-    wheel = wheel.resolve()
-    with zipfile.ZipFile(wheel) as zf:
-        sbom_path = "purelib_example-0.0.1.dist-info/sboms/project.spdx.json"
-        assert sbom_path in set(zf.namelist())
-        assert zf.read(sbom_path).decode("utf-8") == sbom_content
-
-
-@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
-@pytest.mark.usefixtures("package")
-def test_pep517_wheel_sbom_file_missing(tmp_path: Path):
-    dist = tmp_path / "dist"
-    with pytest.raises(FileNotFoundError, match="SBOM file not found: missing.spdx.json"):
-        build_wheel(str(dist), {"wheel.sbom-files": ["missing.spdx.json"]})
-
-
 @pytest.mark.skip(reason="Doesn't work yet")
 @pytest.mark.compile
 @pytest.mark.configure

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -337,7 +337,9 @@ def test_pep517_wheel_sbom_files(tmp_path: Path):
 @pytest.mark.usefixtures("package")
 def test_pep517_wheel_sbom_file_missing(tmp_path: Path):
     dist = tmp_path / "dist"
-    with pytest.raises(FileNotFoundError, match="SBOM file not found: missing.spdx.json"):
+    with pytest.raises(
+        FileNotFoundError, match="SBOM file not found: missing.spdx.json"
+    ):
         build_wheel(str(dist), {"wheel.sbom-files": ["missing.spdx.json"]})
 
 

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -313,6 +313,34 @@ def test_pep517_wheel_source_dir(virtualenv, tmp_path: Path):
     assert add.strip() == "3"
 
 
+@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_pep517_wheel_sbom_files(tmp_path: Path):
+    sbom_dir = Path("sbom_inputs")
+    sbom_dir.mkdir()
+    sbom_file = sbom_dir / "project.spdx.json"
+    sbom_content = '{"spdxVersion": "SPDX-2.3"}'
+    sbom_file.write_text(sbom_content, encoding="utf-8")
+
+    dist = tmp_path / "dist"
+    build_wheel(str(dist), {"wheel.sbom-files": [str(sbom_file)]})
+
+    (wheel,) = dist.glob("purelib_example-0.0.1-*.whl")
+    wheel = wheel.resolve()
+    with zipfile.ZipFile(wheel) as zf:
+        sbom_path = "purelib_example-0.0.1.dist-info/sboms/project.spdx.json"
+        assert sbom_path in set(zf.namelist())
+        assert zf.read(sbom_path).decode("utf-8") == sbom_content
+
+
+@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_pep517_wheel_sbom_file_missing(tmp_path: Path):
+    dist = tmp_path / "dist"
+    with pytest.raises(FileNotFoundError, match="SBOM file not found: missing.spdx.json"):
+        build_wheel(str(dist), {"wheel.sbom-files": ["missing.spdx.json"]})
+
+
 @pytest.mark.skip(reason="Doesn't work yet")
 @pytest.mark.compile
 @pytest.mark.configure

--- a/tests/test_pyproject_pep770.py
+++ b/tests/test_pyproject_pep770.py
@@ -1,0 +1,44 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.build import build_wheel
+
+SPDX_CONTENT = '{"spdxVersion": "SPDX-2.3", "SPDXID": "SPDXRef-DOCUMENT"}'
+CYCLONEDX_CONTENT = '{"bomFormat": "CycloneDX", "specVersion": "1.5"}'
+
+
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        ("project.spdx.json", SPDX_CONTENT),
+        ("bom.json", CYCLONEDX_CONTENT),
+    ],
+    ids=["spdx", "cyclonedx"],
+)
+@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_pep770_wheel_sbom_files(tmp_path: Path, filename: str, content: str):
+    sbom_dir = Path("sbom_inputs")
+    sbom_dir.mkdir()
+    sbom_file = sbom_dir / filename
+    sbom_file.write_text(content, encoding="utf-8")
+
+    dist = tmp_path / "dist"
+    build_wheel(str(dist), {"wheel.sbom-files": [str(sbom_file)]})
+
+    (wheel,) = dist.glob("purelib_example-0.0.1-*.whl")
+    wheel = wheel.resolve()
+    with zipfile.ZipFile(wheel) as zf:
+        sbom_path = f"purelib_example-0.0.1.dist-info/sboms/{filename}"
+        assert sbom_path in set(zf.namelist())
+        assert zf.read(sbom_path).decode("utf-8") == content
+
+
+@pytest.mark.parametrize("package", ["simple_purelib_package"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_pep770_wheel_sbom_file_missing(tmp_path: Path):
+    dist = tmp_path / "dist"
+    with pytest.raises(FileNotFoundError, match="SBOM file not found: missing_sbom.json"):
+        build_wheel(str(dist), {"wheel.sbom-files": ["missing_sbom.json"]})

--- a/tests/test_pyproject_pep770.py
+++ b/tests/test_pyproject_pep770.py
@@ -40,5 +40,7 @@ def test_pep770_wheel_sbom_files(tmp_path: Path, filename: str, content: str):
 @pytest.mark.usefixtures("package")
 def test_pep770_wheel_sbom_file_missing(tmp_path: Path):
     dist = tmp_path / "dist"
-    with pytest.raises(FileNotFoundError, match=r"SBOM file not found: missing_sbom\.json"):
+    with pytest.raises(
+        FileNotFoundError, match=r"SBOM file not found: missing_sbom\.json"
+    ):
         build_wheel(str(dist), {"wheel.sbom-files": ["missing_sbom.json"]})

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -641,7 +641,12 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.targets == ["a", "b", "c", "d"]
         assert settings.wheel.packages == ["a", "b", "c", "d"]
         assert settings.wheel.license_files == ["a.txt", "b.txt", "c.txt", "d.txt"]
-        assert settings.wheel.sbom_files == ["a.spdx.json", "b.cdx.json", "c.spdx.json", "d.cdx.json"]
+        assert settings.wheel.sbom_files == [
+            "a.spdx.json",
+            "b.cdx.json",
+            "c.spdx.json",
+            "d.cdx.json",
+        ]
         assert settings.wheel.exclude == ["x", "y", "xx", "yy"]
         assert settings.install.components == ["a", "b", "c", "d"]
         assert settings.cmake.define == {"a": "A", "b": "X", "c": "C"}
@@ -650,7 +655,12 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.targets == ["c", "d", "a", "b"]
         assert settings.wheel.packages == ["c", "d", "a", "b"]
         assert settings.wheel.license_files == ["c.txt", "d.txt", "a.txt", "b.txt"]
-        assert settings.wheel.sbom_files == ["c.spdx.json", "d.cdx.json", "a.spdx.json", "b.cdx.json"]
+        assert settings.wheel.sbom_files == [
+            "c.spdx.json",
+            "d.cdx.json",
+            "a.spdx.json",
+            "b.cdx.json",
+        ]
         assert settings.wheel.exclude == ["xx", "yy", "x", "y"]
         assert settings.install.components == ["c", "d", "a", "b"]
         assert settings.cmake.define == {"a": "A", "b": "B", "c": "C"}

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -596,6 +596,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
             cmake.targets = ["a", "b"]
             wheel.packages = ["a", "b"]
             wheel.license-files = ["a.txt", "b.txt"]
+            wheel.sbom-files = ["a.spdx.json", "b.cdx.json"]
             wheel.exclude = ["x", "y"]
             install.components = ["a", "b"]
             cmake.define = {{a="A", b="B"}}
@@ -606,6 +607,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
             inherit.cmake.targets = "{inherit}"
             inherit.wheel.packages = "{inherit}"
             inherit.wheel.license-files = "{inherit}"
+            inherit.wheel.sbom-files = "{inherit}"
             inherit.wheel.exclude = "{inherit}"
             inherit.install.components = "{inherit}"
             inherit.cmake.define = "{inherit}"
@@ -613,6 +615,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
             cmake.targets = ["c", "d"]
             wheel.packages = ["c", "d"]
             wheel.license-files = ["c.txt", "d.txt"]
+            wheel.sbom-files = ["c.spdx.json", "d.cdx.json"]
             wheel.exclude = ["xx", "yy"]
             install.components = ["c", "d"]
             cmake.define = {{b="X", c="C"}}
@@ -629,6 +632,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.targets == ["c", "d"]
         assert settings.wheel.packages == ["c", "d"]
         assert settings.wheel.license_files == ["c.txt", "d.txt"]
+        assert settings.wheel.sbom_files == ["c.spdx.json", "d.cdx.json"]
         assert settings.wheel.exclude == ["xx", "yy"]
         assert settings.install.components == ["c", "d"]
         assert settings.cmake.define == {"b": "X", "c": "C"}
@@ -637,6 +641,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.targets == ["a", "b", "c", "d"]
         assert settings.wheel.packages == ["a", "b", "c", "d"]
         assert settings.wheel.license_files == ["a.txt", "b.txt", "c.txt", "d.txt"]
+        assert settings.wheel.sbom_files == ["a.spdx.json", "b.cdx.json", "c.spdx.json", "d.cdx.json"]
         assert settings.wheel.exclude == ["x", "y", "xx", "yy"]
         assert settings.install.components == ["a", "b", "c", "d"]
         assert settings.cmake.define == {"a": "A", "b": "X", "c": "C"}
@@ -645,6 +650,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.targets == ["c", "d", "a", "b"]
         assert settings.wheel.packages == ["c", "d", "a", "b"]
         assert settings.wheel.license_files == ["c.txt", "d.txt", "a.txt", "b.txt"]
+        assert settings.wheel.sbom_files == ["c.spdx.json", "d.cdx.json", "a.spdx.json", "b.cdx.json"]
         assert settings.wheel.exclude == ["xx", "yy", "x", "y"]
         assert settings.install.components == ["c", "d", "a", "b"]
         assert settings.cmake.define == {"a": "A", "b": "B", "c": "C"}

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -187,6 +187,7 @@ def test_skbuild_settings_config_settings(
         "wheel.py-api": "cp39",
         "wheel.expand-macos-universal-tags": "True",
         "wheel.license-files": ["a", "b", "c"],
+        "wheel.sbom-files": ["sbom1.spdx.json", "sbom2.cdx.json"],
         "wheel.exclude": ["b", "y", "e"],
         "wheel.build-tag": "1foo",
         "backport.find-python": "0",
@@ -231,6 +232,7 @@ def test_skbuild_settings_config_settings(
     assert settings.wheel.py_api == "cp39"
     assert settings.wheel.expand_macos_universal_tags
     assert settings.wheel.license_files == ["a", "b", "c"]
+    assert settings.wheel.sbom_files == ["sbom1.spdx.json", "sbom2.cdx.json"]
     assert settings.wheel.exclude == ["b", "y", "e"]
     assert settings.wheel.build_tag == "1foo"
     assert settings.backport.find_python == Version("0")


### PR DESCRIPTION
## Description

Implements [PEP 770 – Software Bill of Materials (SBOM)](https://peps.python.org/pep-0770/) support for scikit-build-core wheels. Users can include SBOM files in their wheel distributions via the `wheel.sbom-files` configuration option. Files are copied into the `*.dist-info/sboms/` directory, format-agnostic (SPDX and CycloneDX both work).

## Changes

1. **Settings model** — `sbom_files: Optional[List[str]] = None` in `WheelSettings`, with override inheritance support (`none`/`append`/`prepend`)
2. **JSON schema** — `wheel.sbom-files` array property + override inheritance wiring
3. **Wheel building** — SBOM files validated and copied into `*.dist-info/sboms/`; raises `FileNotFoundError` for missing files
4. **Documentation** — `docs/reference/configs.md` entry, mirrors `wheel.license-files` style
5. **Tests** — in `tests/test_pyproject_pep770.py`, parametrized over SPDX and CycloneDX

## Key design decision: copy timing

SBOM files are copied **after `builder.install()`**, not at settings-load time. This means a CMake target can generate the SBOM file into the build directory and `wheel.sbom-files` can point to that path — the file will exist by the time the check runs.

This was motivated by looking at how [onnx/onnx implements PEP 770](https://github.com/onnx/onnx/pull/7859): they generate a CycloneDX SBOM dynamically from `FetchContent_Declare` blocks in `CMakeLists.txt` during the build. With a pre-CMake placement that workflow would have failed with `FileNotFoundError`.

## Discussion points

### 1. The `evidence.occurrences` gap

onnx annotates each SBOM component with `evidence.occurrences` — the paths of the compiled `.so`/`.pyd` binaries that contain the statically-linked dependency. This annotation only makes sense *after* CMake installs the binaries into `wheel_dirs`. The current implementation has no hook between `builder.install()` and `WheelWriter` where user code could inspect `wheel_dirs` and mutate the SBOM.

For onnx's specific case this is workable (the binary name is known at configure time, so CMake can write a fully-annotated SBOM directly). But the general pattern — inspect what actually landed in the wheel, then annotate — would require a post-install hook. Should scikit-build-core expose one?

### 2. SBOM generation as a first-class concern

Both hatchling (`initialize()` hook) and the onnx approach (custom `bdist_wheel` subclass) treat SBOM *generation* as part of the build, not just inclusion of pre-existing files. A future `wheel.post-install` hook receiving `wheel_dirs` would let projects generate or annotate SBOMs with full knowledge of the wheel contents, which is what PEP 770's `evidence` fields are designed for.

### 3. `[project]` table standardisation

There is [ongoing discussion](https://discuss.python.org/t/can-we-have-sbom-files-in-project-table/106769) about whether `sbom-files` should live in the `[project]` table (like `license-files` in PEP 639) rather than in tool-specific sections. This is deferred pending PEP 808 (dynamic metadata). The current `[tool.scikit-build.wheel]` placement is consistent with how hatchling handles it today.
