### PR TITLE
ci: secure GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
           - "*"
     cooldown:
       default-days: 7
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      pre-commit:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,22 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: 3
 
@@ -13,16 +17,18 @@ permissions: {}
 
 jobs:
   dist:
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
   deploy:
+    name: Deploy to PyPI
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: [dist]
     runs-on: ubuntu-latest
@@ -30,20 +36,20 @@ jobs:
       name: pypi
       url: https://pypi.org/p/scikit-build-core
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write # Needed for PyPI trusted publishing
+      attestations: write # Needed for artifact attestation
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "dist/*"
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install nox
         run: uv tool install nox
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files
       - name: Run PyLint
@@ -121,20 +121,20 @@ jobs:
             cmake-version: "4.0"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           architecture: ${{ matrix.architecture }}
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Setup CMake ${{ matrix.cmake-version }}
-        uses: jwlawson/actions-setup-cmake@v2.2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
           cmake-version: ${{ matrix.cmake-version }}
 
@@ -149,7 +149,7 @@ jobs:
           auto --durations=20
 
       - name: Test package (two attempts)
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         if: "contains(matrix.python_version, 'pypy')"
         with:
           max_attempts: 2
@@ -160,7 +160,7 @@ jobs:
             --durations=20 -n auto
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           name:
             ${{ runner.os }}-${{ matrix.python-version }}-${{
@@ -180,15 +180,15 @@ jobs:
         runs-on: [ubuntu-latest, macos-15-intel, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       # The min requirements are not compatible with some of the extra test
       # deps, so limit to just built-in deps.
@@ -200,14 +200,14 @@ jobs:
           uv pip install -e. --group=test --group=test-schema --resolution=lowest-direct --system
 
       - name: Setup CMake 3.15
-        uses: jwlawson/actions-setup-cmake@v2.2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         if: runner.os != 'Windows'
         with:
           cmake-version: "3.15.x"
 
         # First version to support VS 17.0
       - name: Setup CMake 3.21
-        uses: jwlawson/actions-setup-cmake@v2.2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         if: runner.os == 'Windows'
         with:
           cmake-version: "3.21.x"
@@ -222,9 +222,9 @@ jobs:
     name: Manylinux on 🐍 3.13 • Free-threaded
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: quay.io/pypa/musllinux_1_2_x86_64:latest
+    container: quay.io/pypa/musllinux_1_2_x86_64@sha256:cb1d34fa8b14b96661e589014e9782f1434cbbf6c6b7c3595b656659da12d8cc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -244,12 +244,12 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: cygwin/cygwin-install-action@v6
+      - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
         with:
           platform: x86_64
           packages:
@@ -276,7 +276,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: UCRT64
           path-type: minimal
@@ -286,7 +286,7 @@ jobs:
           pacboy: >-
             python:p python-pip:p gcc:p cmake:p
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -309,7 +309,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: mingw64
           path-type: minimal
@@ -319,7 +319,7 @@ jobs:
           pacboy: >-
             python:p python-pip:p gcc:p cmake:p
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -340,12 +340,12 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
   docs:
     name: Docs on ${{ matrix.runs-on }}
@@ -357,14 +357,14 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest] # Windows command output issue (wrong Python selected)
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - uses: wntrblm/nox@2026.04.10
+      - uses: wntrblm/nox@903fd97f0c3e19a39c3e0847072b652639044d30 # v0.19.1
         with:
           python-versions: "3.12"
 
@@ -388,12 +388,13 @@ jobs:
           git diff --exit-code
 
   pass:
+    name: CI pass
     if: always()
     needs: [lint, checks, min, cygwin, dist, docs]
     runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - uses: wntrblm/nox@ 97e345e6a26bb2c5aacff9cc4327bd4ac1b00ce6 # 2026.04.10
+      - uses: wntrblm/nox@97e345e6a26bb2c5aacff9cc4327bd4ac1b00ce6 # 2026.04.10
         with:
           python-versions: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,10 @@ jobs:
         run: pytest -n auto -ra --showlocals -Wdefault
 
   manylinux:
-    name: Manylinux on 🐍 3.13 • Free-threaded
+    name: Manylinux on 🐍 3.14 • Free-threaded
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: quay.io/pypa/musllinux_1_2_x86_64@sha256:36bd94f44a613d006b5255f8393ab262d86a3bc016feedb91dc0b520a1b51e50  # 2026.05.17-1
+    container: quay.io/pypa/musllinux_1_2_x86_64@sha256:36bd94f44a613d006b5255f8393ab262d86a3bc016feedb91dc0b520a1b51e50 # 2026.05.17-1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare venv
-        run: python3.13t -m venv /venv
+        run: python3.14t -m venv /venv
 
       - name: Install deps
         run: /venv/bin/pip install -e . --group=test ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
     name: Manylinux on 🐍 3.13 • Free-threaded
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: quay.io/pypa/musllinux_1_2_x86_64@sha256:cb1d34fa8b14b96661e589014e9782f1434cbbf6c6b7c3595b656659da12d8cc
+    container: quay.io/pypa/musllinux_1_2_x86_64@sha256:36bd94f44a613d006b5255f8393ab262d86a3bc016feedb91dc0b520a1b51e50  # 2026.05.17-1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - uses: wntrblm/nox@903fd97f0c3e19a39c3e0847072b652639044d30 # v0.19.1
+      - uses: wntrblm/nox@ 97e345e6a26bb2c5aacff9cc4327bd4ac1b00ce6 # 2026.04.10
         with:
           python-versions: "3.12"
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,16 +19,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install tooling
         run: |

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -11,25 +11,32 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build_wheel:
     name: Build and upload wheel
     if: github.repository_owner == 'scikit-build'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
   upload_nightly_wheels:
     name: Upload nightly wheels to Anaconda Cloud
     if: github.repository_owner == 'scikit-build'
     needs: [build_wheel]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -33,8 +33,6 @@ jobs:
     if: github.repository_owner == 'scikit-build'
     needs: [build_wheel]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,4 @@
+rules:
+  concurrency-limits:
+    ignore:
+      - copilot-setup-steps.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: ^src/scikit_build_core/_vendor
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,33 +25,33 @@ repos:
         exclude: "^tests"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: 6fec9b7edb08fd9989088709d864a7826dc74e80 # frozen: v0.15.12
     hooks:
       - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
+    rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316 # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.20.0
+    rev: fda77690955e9b63c6687d8806bafd56a526e45f # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==25.*]
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.13
+    rev: e2c2116d86a80e72e7146a06e68b7c228afc6319 # frozen: v0.6.13
     hooks:
       - id: cmake-format
         exclude: ^src/scikit_build_core/resources/find_python
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.3"
+    rev: "515f543f5718ebfd6ce22e16708bb32c68ff96e1" # frozen: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -59,7 +59,7 @@ repos:
         exclude: "^tests|src/scikit_build_core/resources/scikit-build.schema.json|^docs/projects.md"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: d2823d321df3af8f878f7ee3414dc94d037145b9 # frozen: v2.1.0
     hooks:
       - id: mypy
         exclude: |
@@ -69,7 +69,7 @@ repos:
             tests/packages/.*/setup.py
           )
         files: ^(src|tests|noxfile.py)
-        args: []
+        args: ["--python-version=3.10"]
         additional_dependencies:
           - build<1.5 # Requires Python 3.10+
           - cattrs<26.1 # Requires Python 3.10+
@@ -91,7 +91,7 @@ repos:
           - types-setuptools>=80.9
 
   - repo: https://github.com/henryiii/check-sdist
-    rev: "v1.4.0"
+    rev: "8d786ae74939ac1d9b12681bc43f72a0980283dd" # frozen: v1.4.0
     hooks:
       - id: check-sdist
         args: [--inject-junk]
@@ -100,14 +100,14 @@ repos:
           - hatch-vcs
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.46.0
+    rev: 5374cbf686e897b15713110e233094e2874de7ef # frozen: v1.46.1
     hooks:
       - id: typos
         args: []
         exclude: ^(LICENSE$|src/scikit_build_core/resources/find_python|tests/test_skbuild_settings.py$)
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -133,12 +133,12 @@ repos:
         additional_dependencies: ["cogapp>=3.5"]
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.04.26
+    rev: a18e62629cfba1fb2d16eb417e5442cd7b962a67 # frozen: 2026.05.13
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: f805888065fdb6162e1f800e50bb9460cbd223d6 # frozen: 0.37.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
@@ -151,7 +151,14 @@ repos:
     hooks:
       - id: validate-cff
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51 # frozen: v1.24.1
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]
+
   - repo: https://github.com/scientific-python/cookie
-    rev: 2026.04.04
+    rev: 04d0e44c1d3b036e9714aca375d965504ba5ea4a # frozen: 2026.04.04
     hooks:
       - id: sp-repo-review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ build.targets.sdist.exclude = [".git"]
 
 
 [tool.uv]
+exclude-newer = "7 days"
 workspace.members = ["tmp/hello/hello"]
 
 
@@ -218,7 +219,7 @@ exclude = [
     '^tests/packages/extensionlib/*',
 ]
 mypy_path = ["$MYPY_CONFIG_FILE_DIR/src", "$MYPY_CONFIG_FILE_DIR/tests/utils"]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 warn_unreachable = false
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -371,7 +371,7 @@ def test_prepare_metadata_for_build_wheel_by_hand(tmp_path):
     }
 
     for k, b in answer.items():
-        assert metadata.get(k, None) == b
+        assert metadata[k] == b
 
     assert len(metadata) == len(answer)
 


### PR DESCRIPTION
Used [my secure-ci skill](https://github.com/henryiii/skills/blob/main/secure-ci/SKILL.md), and tweaked a bit.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Secures GitHub Actions workflows following zizmor pedantic audit and best practices.

### Changes

- **Pin all GHA actions to SHA** with version comments (38 actions across 4 workflows) using `actions-up`
- **Pin `codecov/codecov-action`** to SHA `e79a6962e0d4c0c17b229090214935d2e33f8354` (was unpinned `@v6`)
- **Pin `musllinux` container image** to SHA digest (was `:latest`)
- **Add zizmor pre-commit hook** with `--persona=pedantic`
- **Add `.github/zizmor.yaml`** config to ignore copilot-setup-steps concurrency (special file per zizmor docs)
- **Add concurrency group** to `cd.yml`
- **Add `name:` labels** to `dist`, `deploy` (cd.yml) and `pass` (ci.yml) jobs
- **Add explanatory comments** to `cd.yml` deploy job permissions (`id-token: write`, `attestations: write`)
- **Add `permissions: {}`** to `nightlies.yml` at workflow level and `contents: read` at job level
- **Add `persist-credentials: false`** to checkout in nightlies.yml
- **Freeze all pre-commit hooks to SHA** via `prek auto-update --freeze --cooldown-days 7`
- **Update `dependabot.yml`**: monthly schedule, renamed group to `github-actions`, added `pre-commit` ecosystem, added 7-day cooldowns
- **Add `exclude-newer = "7 days"`** to `[tool.uv]` in pyproject.toml
- **Update mypy `python_version`** from `3.9` to `3.10` (required by mypy 2.1.0)
- **Fix mypy `PackageMetadata.get` error** in test file

Assisted-by: OpenCode:glm-5