### PR TITLE
chore: ignore a CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ Thumbs.db
 .vscode/
 uv.lock
 *pylock
+
+# Symlink to AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ It is built with **hatchling** and stored under `src/scikit_build_core/`.
   shims (`tomllib`, `typing.Self`, `importlib.metadata`, etc.) and
   `scikit_build_core._vendor.pyproject_metadata` — never the direct modules. See
   `tool.ruff.lint.flake8-tidy-imports.banned-api` in `pyproject.toml`.
-- **`src/scikit_build_core/_vendor/` is vendored** (`pyproject_metadata`). Do not
-  lint or hand-edit it.
+- **`src/scikit_build_core/_vendor/` is vendored** (`pyproject_metadata`). Do
+  not lint or hand-edit it.
 - **Generated files** — editing the settings model or docstrings requires
   `nox -t gen`. This regenerates cog sections in `README.md` and
   `docs/reference/configs.md`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,22 @@ It is built with **hatchling** and stored under `src/scikit_build_core/`.
   `validate-pyproject`, JSON schema checks, typos, shellcheck, and
   `sp-repo-review`.
 
+## Things that bite
+
+- **Banned imports are enforced by Ruff.** Use `scikit_build_core._compat.*`
+  shims (`tomllib`, `typing.Self`, `importlib.metadata`, etc.) and
+  `scikit_build_core._vendor.pyproject_metadata` — never the direct modules. See
+  `tool.ruff.lint.flake8-tidy-imports.banned-api` in `pyproject.toml`.
+- **`src/scikit_build_core/_vendor/` is vendored** (`pyproject_metadata`). Do not
+  lint or hand-edit it.
+- **Generated files** — editing the settings model or docstrings requires
+  `nox -t gen`. This regenerates cog sections in `README.md` and
+  `docs/reference/configs.md`, and
+  `src/scikit_build_core/resources/scikit-build.schema.json`.
+- **`tests/packages/`** are sample build fixtures and are excluded from pytest
+  recursion (`norecursedirs`). `tests/utils` is on `pythonpath`.
+- mypy is **strict** for `scikit_build_core.*`, relaxed for tests.
+
 ## Generated files
 
 - `README.md` and `docs/reference/configs.md` contain cog-generated sections.


### PR DESCRIPTION
We might also just add one eventually, but keeping the symlink out is better for now.

I tried to generate a CLAUDE.md and it mostly copied the existing AGENTS.md. I preserved the new bits here.

Assisted-by: ClaudeCode:claude-opus-4.8
