### PR TITLE
fix: test isolation and schema/warning robustness (#1298)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ filterwarnings = [
     "ignore:Config variable '.*' is unset, Python ABI tag may be incorrect:RuntimeWarning",
     "default:pkg_resources is deprecated as an API:DeprecationWarning:wheel",  # Caused by wheel<0.41 in tests
     "default:The 'wheel' package is no longer the canonical location:DeprecationWarning",  # Caused by wheel also
+    "default:The 'wheel' package is no longer the canonical location:FutureWarning",  # Newer wheel/setuptools emit this as a FutureWarning
     "default:onerror argument is deprecated, use onexc instead:DeprecationWarning:wheel", # Caused by wheel<0.41 & Python 3.12
     "default:The distutils package is deprecated and slated for removal:DeprecationWarning",  # Caused by setuptools sometimes
     "default:The distutils.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning",  # Caused by setuptools sometimes

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -31,20 +31,16 @@
             ".+": {
               "oneOf": [
                 {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 {
                   "type": "object",

--- a/src/scikit_build_core/settings/json_schema.py
+++ b/src/scikit_build_core/settings/json_schema.py
@@ -47,19 +47,23 @@ def to_json_schema(dclass: type[Any], *, normalize_keys: bool) -> dict[str, Any]
                     get_args(field.type)[0], normalize_keys=normalize_keys
                 )
                 types = full["patternProperties"][".+"]
+                env_branch = {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["env"],
+                    "properties": {
+                        "env": {"type": "string", "minLength": 1},
+                        "default": types,
+                    },
+                }
+                # Flatten a nested oneOf (e.g. Union[str, bool, List[str]]) into
+                # the combined oneOf instead of nesting oneOf inside oneOf. The
+                # branches are mutually exclusive by JSON type, so this is
+                # equivalent and more robust across validate_pyproject /
+                # fastjsonschema versions.
+                value_branches = types["oneOf"] if list(types) == ["oneOf"] else [types]
                 full["patternProperties"][".+"] = {
-                    "oneOf": [
-                        types,
-                        {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "required": ["env"],
-                            "properties": {
-                                "env": {"type": "string", "minLength": 1},
-                                "default": types,
-                            },
-                        },
-                    ]
+                    "oneOf": [*value_branches, env_branch]
                 }
                 props[field.name] = full
                 continue

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -47,8 +47,10 @@ def test_requires_command(
     (tmp_path / "pyproject.toml").write_text(PYPROJECT_1)
     monkeypatch.chdir(tmp_path)
 
-    main()
+    # rich_warning is memoized; clear before main() so the warning is emitted
+    # even if an earlier test in the same worker already triggered it (xdist).
     rich_warning.cache_clear()
+    main()
     out, err = capsys.readouterr()
     assert "CMakeLists.txt not found" in err
     jout = json.loads(out)


### PR DESCRIPTION
:robot:

Addresses the test failures reported in #1298. Of the 7 failures + 16 errors, most are environment-specific on the reporter's FreeBSD box (NumPy 1.x/2.x ABI mismatch, newer setuptools rejecting `project.license`), but a few are genuine robustness issues fixed here.

## Changes

- **`tests/test_build_cli.py`** — `rich_warning` is `lru_cache`-memoized, so the `"CMakeLists.txt not found"` warning is emitted at most once per process. `test_requires_command` cleared the cache *after* `main()`, so under xdist an earlier test in the same worker could suppress the warning, leaving `err == ''` (the reporter's `assert 'CMakeLists.txt not found' in ''`). Now cleared *before* `main()`.

- **`src/scikit_build_core/settings/json_schema.py`** — flatten the `oneOf`-in-`oneOf` generated for `EnvVar`-annotated `Union` fields (e.g. `cmake.define`). The branches are mutually exclusive by JSON type (string/bool/array/object), so the flat `oneOf` is semantically identical but avoids a `validate_pyproject`/`fastjsonschema` version quirk that reported "0 matches found" for `cmake.define` lists. Schema regenerated via `nox -t gen`.

- **`pyproject.toml`** — add the `FutureWarning` variant of the existing `"The 'wheel' package is no longer the canonical location"` filter. The old filter only matched `DeprecationWarning`; newer wheel/setuptools raise it as a `FutureWarning`, which `filterwarnings=error` promoted to a failure in the setuptools tests.

## Not addressed (reporter's environment, not fixable here)

- Fortran `test_pep517_wheel` — NumPy 1.x/2.4.4 ABI mismatch in the build env.
- 16 collection errors — `invalid pyproject.toml config: 'project.license'` from a newer setuptools rejecting the sample packages' license format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)