### PR TITLE
fix: accept override-only settings via config-settings (#1261)

### DIFF
--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -139,9 +139,19 @@ def _handle_move(
 def _validate_overrides(
     settings: ScikitBuildSettings,
     overrides: dict[str, OverrideRecord],
-    sources: tuple[Source, ...],
+    *,
+    dynamic_sources: tuple[Source, ...],
+    toml_sources: tuple[Source, ...],
 ) -> None:
-    """Validate all fields with any override information."""
+    """
+    Validate all fields with any override information.
+
+    ``dynamic_sources`` are the sources that may legitimately set
+    ``override_only`` fields at build time (env vars and PEP 517
+    config-settings); ``toml_sources`` are the static ``pyproject.toml`` (and
+    ``extra_settings``) tables where ``override_only`` fields are forbidden
+    outside of an ``[[overrides]]`` section.
+    """
 
     def validate_field(
         field: dataclasses.Field[Any],
@@ -157,23 +167,23 @@ def _validate_overrides(
             # "metadata" is the one dict-valued override-only field; has_item
             # needs to know to use dict-presence semantics for it.
             is_dict = field.name == "metadata"
-            # override-only fields are also allowed via env vars and
-            # config-settings (sources[:3]); only pyproject.toml is forbidden.
+            # override-only fields may be set dynamically via env vars or
+            # config-settings; only static pyproject.toml values are forbidden.
             if any(
                 source.has_item(*path, field.name, is_dict=is_dict)
-                for source in sources[:3]
+                for source in dynamic_sources
             ):
                 return
 
             # Decide whether the value was actually hard-coded in pyproject.toml.
             # We can't rely on `value is not None`, since some override-only
             # fields have non-None falsy defaults (e.g. [] or False), so we ask
-            # the TOML sources (sources[3:]) whether the key is really present.
+            # the TOML sources whether the key is really present.
             if record is not None:
                 original_value = record.original_value
             elif any(
                 source.has_item(*path, field.name, is_dict=is_dict)
-                for source in sources[3:]
+                for source in toml_sources
             ):
                 original_value = value
             else:
@@ -282,10 +292,18 @@ class SettingsReader:
         remaining = {
             k: v for k, v in config_settings.items() if not k.startswith("skbuild.")
         }
-        self.sources = SourceChain(
+        # Sources that may legitimately set override-only fields at build time.
+        dynamic_srcs: list[Source] = [
             EnvSource("SKBUILD", env=env),
             ConfSource("skbuild", settings=prefixed, verify=verify_conf),
             ConfSource(settings=remaining, verify=verify_conf),
+        ]
+        # Static pyproject.toml (and extra_settings) tables; override-only fields
+        # are forbidden here outside of an [[overrides]] section.
+        self._dynamic_srcs = tuple(dynamic_srcs)
+        self._toml_srcs = tuple(toml_srcs)
+        self.sources = SourceChain(
+            *dynamic_srcs,
             *toml_srcs,
             prefixes=["tool", "scikit-build"],
         )
@@ -454,7 +472,12 @@ class SettingsReader:
                 self.print_suggestions()
                 raise SystemExit(7)
             logger.warning("Unrecognized options: {}", ", ".join(unrecognized))
-        _validate_overrides(self.settings, self.overridden_items, self.sources.sources)
+        _validate_overrides(
+            self.settings,
+            self.overridden_items,
+            dynamic_sources=self._dynamic_srcs,
+            toml_sources=self._toml_srcs,
+        )
 
         for key, value in self.settings.metadata.items():
             if "provider" not in value:

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -70,6 +70,43 @@ def test_disallow_hardcoded(
     assert "is not allowed to be hard-coded in the pyproject.toml file" in out
 
 
+def test_override_only_allowed_dynamically(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """override_only fields are allowed via config-settings / env vars (#1261)."""
+    caplog.set_level(logging.WARNING)
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build]
+            strict-config = true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Via PEP 517 config-settings
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml,
+        {"cmake.toolchain-file": "foo.cmake", "wheel.tags": "cp312-abi3-win_amd64"},
+        state="wheel",
+    )
+    settings_reader.validate_may_exit()
+    assert settings_reader.settings.cmake.toolchain_file == Path("foo.cmake")
+    assert settings_reader.settings.wheel.tags == ["cp312-abi3-win_amd64"]
+    assert not [r for r in caplog.records if "hard-coded" in str(r.msg)]
+
+    # Via environment variables
+    monkeypatch.setenv("SKBUILD_CMAKE_TOOLCHAIN_FILE", "bar.cmake")
+    settings_reader = SettingsReader.from_file(pyproject_toml, {}, state="wheel")
+    settings_reader.validate_may_exit()
+    assert settings_reader.settings.cmake.toolchain_file == Path("bar.cmake")
+    assert not [r for r in caplog.records if "hard-coded" in str(r.msg)]
+
+
 @pytest.mark.parametrize("python_version", ["3.9", "3.10"])
 def test_skbuild_overrides_pyver(
     python_version: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
:robot:

Closes #1261. Closes #1262.

## Problem

`override_only` fields such as `cmake.toolchain-file` and `wheel.tags` are meant to be:

- **rejected** when hard-coded in `[tool.scikit-build]`
- **accepted** via `[[tool.scikit-build.overrides]]` and PEP 517 config-settings (`-C...`)

The validation in `_validate_overrides` distinguished "dynamic" (env vars / config-settings) sources from the static TOML sources using fragile positional slicing — `sources[:3]` for env/conf and `sources[3:]` for TOML. That silently depends on the exact construction order of the `SourceChain` and is easy to break.

## Fix

Split the env/conf ("dynamic") sources from the `*toml_srcs` explicitly in `SettingsReader.__init__`, store both groups (`self._dynamic_srcs` / `self._toml_srcs`), and pass them as named arguments to `_validate_overrides`. The check now reads directly: present in a dynamic source → allowed; otherwise look at the TOML sources for a genuinely hard-coded value. Runtime behavior of the assembled `SourceChain` is unchanged.

## Behavior (all verified)

| Source | override_only field |
| --- | --- |
| `-Ccmake.toolchain-file=...` (config-settings) | ✅ accepted |
| `SKBUILD_*` env var | ✅ accepted |
| `[[overrides]]` section | ✅ accepted |
| hard-coded in `[tool.scikit-build]` | ❌ rejected |

## Tests

Added `test_override_only_allowed_dynamically` covering the regression: `cmake.toolchain-file` and `wheel.tags` accepted via config-settings and `SKBUILD_*` env vars under `strict-config = true`, asserting no "hard-coded" warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)