### PR TITLE
fix: correct several latent bugs found in a repo sweep

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -169,7 +169,7 @@ def _build_wheel_impl(
                 pyproject=pyproject,
             )
         except FailedLiveProcessError as err2:
-            err2.msg = settings_reader.settings.messages.after_failure.format()
+            err2.msg = settings_reader.settings.messages.after_failure
             raise
 
 
@@ -291,12 +291,15 @@ def _build_wheel_impl_impl(
         if metadata.license_files:
             license_paths = metadata.license_files
         else:
-            license_file_globs = settings.wheel.license_files or [
-                "LICEN[CS]E*",
-                "COPYING*",
-                "NOTICE*",
-                "AUTHORS*",
-            ]
+            if settings.wheel.license_files is None:
+                license_file_globs = [
+                    "LICEN[CS]E*",
+                    "COPYING*",
+                    "NOTICE*",
+                    "AUTHORS*",
+                ]
+            else:
+                license_file_globs = list(settings.wheel.license_files)
             if (
                 metadata.license
                 and not isinstance(metadata.license, str)

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -263,7 +263,7 @@ class Builder:
 
         # Warning for CPython 3.13.4 Windows bug
         if (
-            sys.implementation.name == "CPython"
+            sys.implementation.name == "cpython"
             and sys.version_info[:3] == (3, 13, 4)
             and sys.platform.startswith("win32")
             and not sysconfig.get_config_var("Py_GIL_DISABLED")

--- a/src/scikit_build_core/file_api/model/codemodel.py
+++ b/src/scikit_build_core/file_api/model/codemodel.py
@@ -128,7 +128,7 @@ class Target:
     id: str
     type: str
     paths: Paths
-    sources = List[Source]
+    sources: List[Source] = dataclasses.field(default_factory=list)
     nameOnDisk: Optional[Path] = None
     artifacts: List[Artifact] = dataclasses.field(default_factory=list)
     isGeneratorProvided: Optional[bool] = None

--- a/src/scikit_build_core/file_api/model/directory.py
+++ b/src/scikit_build_core/file_api/model/directory.py
@@ -20,7 +20,7 @@ class Target:
 @dataclasses.dataclass(frozen=True)
 class InstallRule:
     component: str
-    type = str
+    type: str
     destination: Optional[Path] = None
     paths: List[Union[str, Paths]] = dataclasses.field(default_factory=list)
     isExcludeFromAll: bool = False

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -448,10 +448,17 @@ class SettingsReader:
         return result
 
     def print_suggestions(self) -> None:
-        for index in (1, 2, 3):
-            name = {1: "config-settings", 2: "config-settings", 3: "pyproject.toml"}[
-                index
-            ]
+        # Index 0 is the env source (skipped); the config-settings sources follow,
+        # then the TOML sources. The last TOML source is always pyproject.toml;
+        # any earlier ones are extra settings injected by a plugin (e.g. hatch).
+        n_dynamic = len(self._dynamic_srcs)
+        names = dict.fromkeys(range(1, n_dynamic), "config-settings")
+        for offset in range(len(self._toml_srcs)):
+            is_pyproject = offset == len(self._toml_srcs) - 1
+            names[n_dynamic + offset] = (
+                "pyproject.toml" if is_pyproject else "extra settings"
+            )
+        for index, name in names.items():
             suggestions_dict = self.suggestions(index)
             if suggestions_dict:
                 rich_print(

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -360,7 +360,7 @@ class EnvSource(Source):
                 cls.convert(i.strip(), get_inner_type(target)) for i in item.split(";")
             ]
         if raw_target is dict:
-            items = (i.strip().split("=") for i in item.split(";"))
+            items = (i.strip().split("=", 1) for i in item.split(";"))
             return {k: cls.convert(v, get_inner_type(target)) for k, v in items}
 
         if raw_target is bool:
@@ -374,7 +374,7 @@ class EnvSource(Source):
             if str in args:
                 return item
             if dict in args and "=" in item:
-                items = (i.strip().split("=") for i in item.split(";"))
+                items = (i.strip().split("=", 1) for i in item.split(";"))
                 return {k: cls.convert(v, get_inner_type(args[dict])) for k, v in items}
             if list in args:
                 return [


### PR DESCRIPTION
:robot: A sweep of the repository turned up a handful of latent bugs. Each is a small, independent fix.

### Bugs fixed

1. **File API fields silently dropped** (`file_api/model/codemodel.py`, `directory.py`) — `Target.sources` and `InstallRule.type` used `=` instead of `:`, making them plain class attributes rather than dataclass fields. The corresponding CMake File API data was parsed and discarded. Now declared as proper fields.

2. **`cmake.define` env var breaks on `=` in values** (`settings/sources.py`) — the env-source dict parser split on every `=`, so a value like `FOO=-DBAR=1` raised `ValueError: too many values to unpack`. Now splits on the first `=` only (matching the config-settings path).

3. **CPython 3.13.4 Windows warning never fired** (`builder/builder.py`) — the guard compared `sys.implementation.name == "CPython"`, but that attribute is always lowercase `"cpython"`, so the warning was dead code.

4. **`wheel.license-files = []` did not disable license collection** (`build/wheel.py`) — an explicit empty list is falsy, so the default globs still ran and bundled license files the user meant to suppress. Now distinguishes `None` (unset) from `[]`. Also stops mutating the shared settings list in place.

5. **Double-formatted retry failure message** (`build/wheel.py`) — the retry path called `.format()` on `messages.after-failure`, but `rich_print` already formats it, so a `{`/`}` in the message would raise or mangle only on retry. Dropped the redundant `.format()`.

6. **`print_suggestions` mislabeled sources with `extra_settings`** (`settings/skbuild_read_settings.py`) — indices `(1,2,3)` were hard-coded assuming TOML at index 3, but the hatch plugin inserts an extra TOML source, pushing the real `pyproject.toml` to index 4 (never scanned, mislabeled). Indices are now derived from the source layout.

### Verification

- `prek -a` clean (ruff + mypy)
- file_api / settings / prepare-metadata / json-schema / wheelfile test groups pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)