### PR TITLE
refactor: simplification cleanups from a repo sweep

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -242,15 +242,13 @@ class Builder:
                         py_api,
                         target_minor_version,
                     )
-            else:
-                # Classic stable ABI (abi3)
-                target_minor_version = int(py_api[3:])
-                if gil_disabled:
-                    logger.info(
-                        "Free-threaded Python doesn't support the classic Limited API, ignoring"
-                    )
-                elif target_minor_version <= sys.version_info.minor:
-                    sabi = _SabiMode.ABI3
+            # Classic stable ABI (abi3)
+            elif gil_disabled:
+                logger.info(
+                    "Free-threaded Python doesn't support the classic Limited API, ignoring"
+                )
+            elif target_minor_version <= sys.version_info.minor:
+                sabi = _SabiMode.ABI3
 
         python_library = get_python_library(self.config.env, abi3=False)
         python_sabi_library = None

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -60,12 +60,12 @@ def get_default(cmake: CMake) -> str | None:
     """
     Returns the computed default for the current platform.
     """
-    generator = get_default_from_cmake(cmake)
-
     # Non-MSVC Windows platforms require Ninja
     is_msvc_platform = sysconfig.get_platform().startswith("win")
     if sys.platform.startswith("win") and not is_msvc_platform:
         return "Ninja"
+
+    generator = get_default_from_cmake(cmake)
 
     # Try Ninja if it is available, even if make is CMake default
     if generator == "Unix Makefiles":

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -261,12 +261,12 @@ def info_print(
         color=color,
     )
     rich_print(
-        "{color}Detected ABI3 SOABI:",
+        "{bold}Detected ABI3 SOABI:",
         get_soabi(os.environ, abi3=True),
         color=color,
     )
     rich_print(
-        "{color}Detected ABI3T SOABI:",
+        "{bold}Detected ABI3T SOABI:",
         get_soabi(os.environ, abi3t=True),
         color=color,
     )

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -200,9 +200,10 @@ class CMaker:
                         f'set({pkg}_ROOT [===[{paths_str}]===] CACHE PATH "" FORCE)\n'
                     )
                     # Available since CMake 3.27 with CMP0144
-                    f.write(
-                        f'set({pkg.upper()}_ROOT [===[{paths_str}]===] CACHE PATH "" FORCE)\n'
-                    )
+                    if pkg != pkg.upper():
+                        f.write(
+                            f'set({pkg.upper()}_ROOT [===[{paths_str}]===] CACHE PATH "" FORCE)\n'
+                        )
 
         contents = self.init_cache_file.read_text(encoding="utf-8").strip()
         logger.debug(

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -16,7 +16,6 @@ from ..utils.typing import (
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
 from .model.codemodel import CodeModel, Target
-from .model.directory import Directory
 from .model.index import Index
 
 __all__ = ["load_reply_dir"]
@@ -56,7 +55,7 @@ class Converter:
         Convert a dict to a dataclass. Automatically load a few nested jsonFile classes.
         """
         if (
-            target in {CodeModel, Target, Cache, CMakeFiles, Directory}
+            target in {CodeModel, Target, Cache, CMakeFiles}
             and "jsonFile" in data
             and data["jsonFile"] is not None
         ):

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -366,9 +366,6 @@ class EnvSource(Source):
         if raw_target is bool:
             return _process_bool(item)
 
-        if is_union_type(raw_target) and str in get_args(target):
-            return item
-
         if is_union_type(raw_target):
             args = {get_target_raw_type(t): t for t in get_args(target)}
             if str in args:


### PR DESCRIPTION
:robot: Non-behavioral cleanups found alongside #1311 (the bug-fix sweep). Each is independent and low-risk; no functional change intended.

### Cleanups

1. **`settings/sources.py`** — removed a redundant `is_union_type(...) and str in get_args(target)` early-return. The following union block re-checks `is_union_type` and returns `item` for the same `str` case, so the early return was dead.

2. **`builder/builder.py`** — removed a redundant `target_minor_version = int(py_api[3:])` in the classic-abi3 branch. It was already computed identically a few lines up (`int(py_api[3:].rstrip("t"))`, and the trailing-`t` case is handled by an earlier `elif`).

3. **`builder/generator.py`** — moved the `cmake --help` subprocess after the non-MSVC-Windows early return, since on MinGW/MSYS the result is discarded (always `Ninja`). Avoids a wasted subprocess there.

4. **`builder/sysconfig.py`** — the "Detected ABI3 SOABI" / "ABI3T SOABI" lines used a `{color}` prefix instead of `{bold}`, so they rendered without the bold styling every other line in `info_print` gets. Cosmetic.

5. **`cmake.py`** — only emit the uppercase `<PKG>_ROOT` cache entry when it differs from the original name, avoiding an identical duplicate `set(...)` line when the package name is already uppercase.

6. **`file_api/reply.py`** — `model.directory.Directory` was in the `make_class` auto-resolve set but has no `jsonFile` field (the class with one is `codemodel.Directory`, intentionally not resolved), so the entry never fired. Removed it and its now-unused import.

### Verification

- `prek -a` clean (ruff + mypy)
- `test_fileapi`, `test_skbuild_settings`, `test_builder`, `test_generator_default` all pass

(Note: `test_cmake_config` has pre-existing failures on `main` in this environment — an unregistered `lipo -info` call under pytest_subprocess — unrelated to these changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)