### PR TITLE
test: stub macOS lipo arch probe for fake-subprocess tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,6 +408,26 @@ def protect_get_requires(fp, monkeypatch):
     monkeypatch.setattr(importlib.util, "find_spec", find_spec)
 
 
+@pytest.fixture(autouse=True)
+def _stub_macos_arch_probe(request: pytest.FixtureRequest) -> None:
+    """
+    ``program_search.compute_timeout`` shells out to ``lipo`` on macOS arm64
+    (when ``CI`` is unset) to detect x86 binaries. Tests that fake subprocesses
+    with the ``fp`` fixture don't register that call, so it raises
+    ``ProcessNotRegisteredError`` locally (CI passes only because the ``CI`` env
+    var short-circuits the probe). Stub it out for fake-subprocess tests; real
+    tests still exercise the genuine ``lipo`` path.
+    """
+    if "fp" not in request.fixturenames:
+        return
+
+    from scikit_build_core import program_search
+
+    monkeypatch = request.getfixturevalue("monkeypatch")
+    monkeypatch.setattr(program_search, "_macos_binary_is_x86", lambda _path: False)
+    program_search.compute_timeout.cache_clear()
+
+
 @pytest.fixture
 def pybind11():
     return pytest.importorskip("pybind11")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Several `test_cmake_config` / `test_*` tests fail locally on macOS Apple Silicon with:

```
pytest_subprocess.exceptions.ProcessNotRegisteredError: The process 'lipo -info /opt/homebrew/bin/cmake' was not registered.
```

### Root cause

`program_search.compute_timeout` shells out to `lipo -info <exe>` on macOS arm64 to detect x86 (Rosetta) binaries and triple the timeout. This only happens when the `CI` env var is **unset** — on CI the function short-circuits before the probe, which is why CI is green but local runs are red.

Tests that fake subprocesses via the `fp` (pytest_subprocess) fixture don't register that `lipo` call. To make matters worse, `compute_timeout` is `@lru_cache`d, so whether a given test actually triggers `lipo` depends on test ordering within a worker — making the failures intermittent and confusing.

### Fix

Add an autouse fixture that, **only for tests using the `fp` fixture**, stubs `_macos_binary_is_x86` to `False` and clears the `compute_timeout` cache. Real, non-`fp` tests still exercise the genuine `lipo` path unchanged.

This is test-only; no library code changes.

### Verification

- The previously-failing `test_cmake_config` parametrizations now pass.
- `test_program_search`, `test_get_requires`, `test_prepare_metadata`, `test_settings_overrides` (which register `lipo` explicitly) still pass — their registrations simply go unused.
- Full non-virtualenv suite: 496 passed, `prek -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)