### PR TITLE
test: remove now-unused lipo registrations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,6 +408,26 @@ def protect_get_requires(fp, monkeypatch):
     monkeypatch.setattr(importlib.util, "find_spec", find_spec)
 
 
+@pytest.fixture(autouse=True)
+def _stub_macos_arch_probe(request: pytest.FixtureRequest) -> None:
+    """
+    ``program_search.compute_timeout`` shells out to ``lipo`` on macOS arm64
+    (when ``CI`` is unset) to detect x86 binaries. Tests that fake subprocesses
+    with the ``fp`` fixture don't register that call, so it raises
+    ``ProcessNotRegisteredError`` locally (CI passes only because the ``CI`` env
+    var short-circuits the probe). Stub it out for fake-subprocess tests; real
+    tests still exercise the genuine ``lipo`` path.
+    """
+    if "fp" not in request.fixturenames:
+        return
+
+    from scikit_build_core import program_search
+
+    monkeypatch = request.getfixturevalue("monkeypatch")
+    monkeypatch.setattr(program_search, "_macos_binary_is_x86", lambda _path: False)
+    program_search.compute_timeout.cache_clear()
+
+
 @pytest.fixture
 def pybind11():
     return pytest.importorskip("pybind11")

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -245,10 +245,6 @@ def test_get_cmake_via_envvar(monkeypatch: pytest.MonkeyPatch, fp):
     fp.register(
         [cmake_path, "-E", "capabilities"], stdout='{"version":{"string":"3.20.0"}}'
     )
-    fp.register(
-        ["lipo", "-info", "some-prog"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     monkeypatch.setenv("CMAKE_EXECUTABLE", str(cmake_path))
     result = CMake.default_search(env=os.environ)
     assert result.cmake_path == cmake_path

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -31,10 +31,6 @@ def test_get_requires_parts(fp: FakeProcess):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert set(GetRequires().cmake()) == {"cmake>=3.15"}
     assert set(GetRequires().ninja()) == {*ninja}
 
@@ -44,10 +40,6 @@ def test_get_requires_parts_unneeded(fp: FakeProcess):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.18.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert set(GetRequires().cmake()) == set()
     assert set(GetRequires().ninja()) == {*ninja}
 
@@ -56,10 +48,6 @@ def test_get_requires_parts_settings(fp: FakeProcess):
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.18.0"}}',
-    )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
     )
     config = {"cmake.version": ">=3.20"}
     assert set(GetRequires.from_config_settings(config).cmake()) == {"cmake>=3.20"}
@@ -79,10 +67,6 @@ def test_get_requires_parts_pyproject(
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.18.0"}}',
-    )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
     )
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
@@ -105,10 +89,6 @@ def test_get_requires_parts_pyproject_old(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.18.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
 
     assert set(GetRequires().cmake()) == {"cmake>=3.21"}
     assert set(GetRequires().ninja()) == {*ninja}
@@ -119,10 +99,6 @@ def test_get_requires_for_build_sdist(fp: FakeProcess):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert set(get_requires_for_build_sdist({})) == set()
 
 
@@ -131,10 +107,6 @@ def test_get_requires_for_build_sdist_cmake(fp: FakeProcess):
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
-    )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
     )
     assert set(get_requires_for_build_sdist({"sdist.cmake": "True"})) == expected
 
@@ -165,10 +137,6 @@ def test_get_requires_for_build_with_variant(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert "variantlib" in hook(config)
 
 
@@ -178,10 +146,6 @@ def test_get_requires_for_build_wheel(fp: FakeProcess):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert set(get_requires_for_build_wheel({})) == expected
 
 
@@ -189,10 +153,6 @@ def test_get_requires_for_build_wheel_pure(fp: FakeProcess):
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
-    )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
     )
     assert set(get_requires_for_build_wheel({"wheel.cmake": "False"})) == set()
 
@@ -203,10 +163,6 @@ def test_get_requires_for_build_editable(fp: FakeProcess):
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     assert set(get_requires_for_build_editable({})) == expected
 
 
@@ -214,9 +170,5 @@ def test_get_requires_for_build_editable_pure(fp: FakeProcess):
     fp.register(
         [Path("cmake/path"), "-E", "capabilities"],
         stdout='{"version":{"string":"3.14.0"}}',
-    )
-    fp.register(
-        ["lipo", "-info", "cmake/path"],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
     )
     assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == set()

--- a/tests/test_prepare_metadata.py
+++ b/tests/test_prepare_metadata.py
@@ -25,14 +25,6 @@ def test_prepare_metadata_for_build(fp, editable):
     fp.pass_command([sys.executable, fp.any()])
     fp.pass_command([fp.program("cmake"), "-E", "capabilities"])
     fp.pass_command([fp.program("cmake3"), "-E", "capabilities"])
-    fp.register(
-        ["lipo", "-info", fp.program("cmake")],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
-    fp.register(
-        ["lipo", "-info", fp.program("cmake3")],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
 
     if editable:
         assert (
@@ -106,14 +98,6 @@ def test_prepare_metadata_for_build_wheel_variant(fp, monkeypatch, tmp_path):
     fp.pass_command([sys.executable, fp.any()])
     fp.pass_command([fp.program("cmake"), "-E", "capabilities"])
     fp.pass_command([fp.program("cmake3"), "-E", "capabilities"])
-    fp.register(
-        ["lipo", "-info", fp.program("cmake")],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
-    fp.register(
-        ["lipo", "-info", fp.program("cmake3")],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
 
     variantlib: Any = types.ModuleType("variantlib")
     variantlib.__path__ = []  # mark as a package so submodule imports resolve

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -49,14 +49,6 @@ def test_get_cmake_programs_all(monkeypatch, fp):
         [cmake3_path, "-E", "capabilities"],
         stdout='{"version":{"string":"3.19.0"}}',
     )
-    fp.register(
-        ["lipo", "-info", cmake_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
-    fp.register(
-        ["lipo", "-info", cmake3_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     programs = list(get_cmake_programs(module=False))
     assert len(programs) == 2
     assert programs[0].path.name == "cmake3"
@@ -79,14 +71,6 @@ def test_get_ninja_programs_all(monkeypatch, fp):
     ninja_build_path = Path("ninja-build")
     fp.register([ninja_path, "--version"], stdout="1.10.1.git.kitware.jobserver-1")
     fp.register([ninja_build_path, "--version"], stdout="1.8.2")
-    fp.register(
-        ["lipo", "-info", ninja_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
-    fp.register(
-        ["lipo", "-info", ninja_build_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     programs = list(get_ninja_programs(module=False))
     assert len(programs) == 2
     assert programs[0].path.name == "ninja-build"
@@ -110,14 +94,6 @@ def test_get_cmake_programs_malformed(monkeypatch, fp, caplog):
     cmake3_path = Path("cmake3")
     fp.register([cmake_path, "-E", "capabilities"], stdout="scrambled output\n")
     fp.register([cmake3_path, "-E", "capabilities"], stdout="{}")
-    fp.register(
-        ["lipo", "-info", cmake_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
-    fp.register(
-        ["lipo", "-info", cmake3_path],
-        stdout="Architectures in the fat file: ... are: x86_64 arm64",
-    )
     programs = list(get_cmake_programs(module=False))
     assert caplog.records
     assert "Could not determine CMake version" in str(caplog.records[0].msg)

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -801,10 +801,6 @@ def test_system_cmake(
             [Path("cmake/path"), "-E", "capabilities"],
             stdout=f'{{"version":{{"string": "{cmake_version}"}}}}',
         )
-        fp.register(
-            ["lipo", "-info", Path("cmake/path")],
-            stdout="Non-fat file: cmake/path is architecture: arm64",
-        )
 
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1313 (stacked on it).

With the autouse fixture from #1313 stubbing the macOS arch probe for fake-subprocess (`fp`) tests, the per-test `fp.register(["lipo", "-info", ...])` calls are never consumed. This removes the now-dead registrations:

| File | Removed |
| --- | --- |
| `test_get_requires.py` | 12 |
| `test_program_search.py` | 6 |
| `test_prepare_metadata.py` | 4 |
| `test_settings_overrides.py` | 1 |
| `test_cmake_config.py` | 1 |
| **Total** | **24** (96 lines) |

No library code change. Removal was done structurally (verifying each block was exactly `fp.register([...lipo...], stdout=..., )`).

### Verification

- All five affected files: 116 passed, 2 skipped
- `prek -a` clean

Note: the base of this PR is `fix-lipo-test` (#1313), since the cleanup only holds once that fixture is merged. Rebase onto `main` after #1313 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)