### PR TITLE
fix: format/logging/editable-redirect bugs and cleanups

### DIFF
--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -8,11 +8,6 @@ if sys.version_info < (3, 9):
 else:
     from typing import Annotated, get_args, get_origin
 
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
-
 if sys.version_info < (3, 11):
     if typing.TYPE_CHECKING:
         from typing_extensions import Self, assert_never
@@ -43,7 +38,6 @@ else:
 __all__ = [
     "Annotated",
     "Self",
-    "TypeAlias",
     "TypeVar",
     "assert_never",
     "get_args",

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -119,8 +119,9 @@ def colors() -> bool:
     # Pip reroutes sys.stdout, so FORCE_COLOR is required there
     if os.environ.get("FORCE_COLOR", ""):
         return True
-    # Avoid ValueError: I/O operation on closed file
-    with contextlib.suppress(ValueError):
+    # sys.stdout can be None (e.g. pythonw / embedded interpreters); avoid
+    # AttributeError as well as ValueError: I/O operation on closed file.
+    with contextlib.suppress(ValueError, AttributeError):
         # Assume sys.stderr is similar to sys.stdout
         isatty = sys.stdout.isatty()
         if isatty and not sys.platform.startswith("win"):

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import os
-import stat
 import subprocess
 from typing import TYPE_CHECKING, ClassVar
 
@@ -84,17 +83,3 @@ class Run:
         if k in self._prev_env and k not in self.env:
             return "-"
         return " "
-
-
-def _fix_all_permissions(directory: str) -> None:
-    """
-    Makes sure the write permission is set. Only run this on Windows.
-    """
-    with os.scandir(directory) as it:
-        for entry in it:
-            if entry.is_dir():
-                _fix_all_permissions(entry.path)
-                continue
-            mode = stat.S_IMODE(entry.stat().st_mode)
-            if not mode & stat.S_IWRITE:
-                os.chmod(entry.path, mode | stat.S_IWRITE)  # noqa: PTH101

--- a/src/scikit_build_core/errors.py
+++ b/src/scikit_build_core/errors.py
@@ -66,8 +66,12 @@ class FailedProcessError(Exception):
         for stream_name in ("stdout", "stderr"):
             stream = getattr(self.exception, stream_name)
             if stream:
+                # Subprocesses run with text=True (str streams), but decode bytes
+                # defensively in case a caller captured binary output.
+                if isinstance(stream, bytes):
+                    stream = stream.decode()
                 description += f"\n  {stream_name}:\n"
-                description += textwrap.indent(stream.decode(), "    ")
+                description += textwrap.indent(stream, "    ")
         return description
 
 

--- a/src/scikit_build_core/format.py
+++ b/src/scikit_build_core/format.py
@@ -44,6 +44,24 @@ class PyprojectFormatter(TypedDict, total=False):
     """Root path of the current project."""
 
 
+class _AnySpecDummy:
+    """A dummy value whose ``__format__`` accepts any spec and returns ``"*"``.
+
+    Used for dummy-mode formatting of keys that take a format spec (e.g.
+    ``{root:uri}``), so that ``"{root:uri}".format(...)`` does not raise.
+    """
+
+    def __format__(self, fmt: str) -> str:
+        return "*"
+
+    def __str__(self) -> str:
+        return "*"
+
+
+# Keys in PyprojectFormatter whose values accept a format spec (e.g. ``root``).
+_SPEC_TAKING_KEYS = ("root",)
+
+
 @typing.overload
 def pyproject_format(
     *,
@@ -71,7 +89,15 @@ def pyproject_format(
     """Generate :py:class:`PyprojectFormatter` dictionary to use in f-string format."""
     if dummy:
         # Return a dict with all the known keys but with values replaced with dummy values
-        return dict.fromkeys(PyprojectFormatter.__annotations__, "*")
+        res_dummy: dict[str, object] = dict.fromkeys(
+            PyprojectFormatter.__annotations__, "*"
+        )
+        # Keys that accept a format spec (e.g. ``{root:uri}``) must use a value
+        # whose ``__format__`` accepts any spec, otherwise dummy formatting of a
+        # build-dir like ``{root:uri}`` raises ValueError.
+        for key in _SPEC_TAKING_KEYS:
+            res_dummy[key] = _AnySpecDummy()
+        return typing.cast("dict[str, str]", res_dummy)
 
     assert settings is not None
     # First set all known values
@@ -99,6 +125,9 @@ class RootPathResolver:
 
     def __post_init__(self) -> None:
         self.path = self.path.resolve()
+
+    def __str__(self) -> str:
+        return str(self.path)
 
     def __format__(self, fmt: str) -> str:
         command, _, rest = fmt.partition(":")

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -44,9 +44,10 @@ class FileLockIfUnix:
 
         while True:
             os.makedirs(os.path.dirname(self.lock_file), exist_ok=True)
-            open_flags = os.O_RDWR | os.O_TRUNC
-            if not os.path.exists(self.lock_file):
-                open_flags |= os.O_CREAT
+            # O_CREAT without O_EXCL is a no-op on an existing file, so always
+            # request it; checking os.path.exists() first only adds a TOCTOU race
+            # (the file could be removed between the check and the open).
+            open_flags = os.O_RDWR | os.O_TRUNC | os.O_CREAT
 
             fd = os.open(self.lock_file, open_flags, 0o644)
             with contextlib.suppress(PermissionError):  # Lock is not owned by this UID
@@ -382,27 +383,31 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         if verbose:
             print(f"Running cmake --build & --install in {self.path}")  # noqa: T201
 
-        lock = FileLockIfUnix(os.path.join(self.path, "editable_rebuild.lock"))
-
-        try:
-            lock.acquire()
-
+        def run_checked(command: list[str]) -> None:
             result = subprocess.run(
-                ["cmake", "--build", ".", *self.build_options],
+                command,
                 cwd=self.path,
                 stdout=sys.stderr if verbose else subprocess.PIPE,
                 env=env,
                 check=False,
                 text=True,
             )
-            if result.returncode and verbose:
+            # When verbose, output was already streamed live to stderr. When not
+            # verbose, stdout was captured, so surface it here so build errors
+            # (e.g. from MSBuild, which writes to stdout) are not lost.
+            if result.returncode and not verbose:
                 print(  # noqa: T201
                     f"ERROR: {result.stdout}",
                     file=sys.stderr,
                 )
             result.check_returncode()
 
-            result = subprocess.run(
+        lock = FileLockIfUnix(os.path.join(self.path, "editable_rebuild.lock"))
+
+        try:
+            lock.acquire()
+            run_checked(["cmake", "--build", ".", *self.build_options])
+            run_checked(
                 [
                     "cmake",
                     "--install",
@@ -410,19 +415,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                     "--prefix",
                     self.install_dir,
                     *self.install_options,
-                ],
-                cwd=self.path,
-                stdout=sys.stderr if verbose else subprocess.PIPE,
-                env=env,
-                check=False,
-                text=True,
+                ]
             )
-            if result.returncode and verbose:
-                print(  # noqa: T201
-                    f"ERROR: {result.stdout}",
-                    file=sys.stderr,
-                )
-            result.check_returncode()
         finally:
             lock.release()
 

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -186,6 +187,78 @@ def test_install_multiple_packages():
     install(*pkg_a, None)
     install(*pkg_b, None)
     assert count_finders() == 2
+
+
+def _make_finder(tmp_path: Path, *, verbose: bool) -> ScikitBuildRedirectingFinder:
+    return ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={},
+        path=str(tmp_path),
+        rebuild=True,
+        verbose=verbose,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path),
+        install_dir="",
+    )
+
+
+def test_rebuild_failure_surfaces_stdout_when_not_verbose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """Regression: a failed non-verbose build captured stdout but never printed it.
+
+    The error branch used ``and verbose`` (verbose already streams live), so the
+    captured stdout from the failing build (e.g. MSBuild writes to stdout) was
+    silently dropped. It should print when *not* verbose.
+    """
+
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        assert kwargs["stdout"] == subprocess.PIPE
+        return subprocess.CompletedProcess(
+            command, returncode=1, stdout="boom build error", stderr=""
+        )
+
+    monkeypatch.setattr(
+        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
+    )
+
+    finder = _make_finder(tmp_path, verbose=False)
+    with pytest.raises(subprocess.CalledProcessError):
+        finder.rebuild()
+
+    captured = capsys.readouterr()
+    assert "boom build error" in captured.err
+    # Must not print the literal "None" (the old verbose branch did this).
+    assert "ERROR: None" not in captured.err
+
+
+def test_rebuild_success_runs_build_and_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,  # noqa: ARG001
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
+    )
+
+    finder = _make_finder(tmp_path, verbose=False)
+    finder.rebuild()
+
+    assert calls[0][:2] == ["cmake", "--build"]
+    assert calls[1][:2] == ["cmake", "--install"]
 
 
 def test_mapping_to_modules_prefers_py():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+
+from scikit_build_core.errors import FailedProcessError
+
+
+def _make_error(stdout: str | bytes, stderr: str | bytes) -> FailedProcessError:
+    exc = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["cmake", "--build", "."],
+        output=stdout,
+        stderr=stderr,
+    )
+    return FailedProcessError(exc, "Build failed")
+
+
+def test_failed_process_error_str_text() -> None:
+    # Subprocesses run with text=True, so streams are str. Regression: __str__
+    # previously called .decode() unconditionally and raised AttributeError.
+    msg = str(_make_error("out text", "err text"))
+    assert "Build failed" in msg
+    assert "out text" in msg
+    assert "err text" in msg
+    assert "return code 1" in msg
+
+
+def test_failed_process_error_str_bytes() -> None:
+    # Bytes streams are still decoded defensively.
+    msg = str(_make_error(b"out bytes", b"err bytes"))
+    assert "out bytes" in msg
+    assert "err bytes" in msg

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from scikit_build_core.format import RootPathResolver, pyproject_format
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -51,12 +54,20 @@ def test_dummy_plain_keys() -> None:
     assert "{wheel_tag}".format(**dummy) == "*"
 
 
-def test_dummy_root_spec() -> None:
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("{root}", "*"),
+        ("{root:uri}", "*"),
+        ("{root:parent:uri}", "*"),
+        ("build/{root:uri}/x", "build/*/x"),
+    ],
+)
+def test_dummy_root_spec(spec: str, expected: str) -> None:
     # Regression: dummy mode mapped root to the plain string "*", so any
     # build-dir containing a spec like {root:uri} raised
     # "ValueError: Invalid format specifier 'uri' for object of type 'str'".
+    # The spec is kept out of a literal .format() call so linters don't try to
+    # validate the custom :uri spec against a plain str.
     dummy = pyproject_format(dummy=True)
-    assert "{root}".format(**dummy) == "*"
-    assert "{root:uri}".format(**dummy) == "*"
-    assert "{root:parent:uri}".format(**dummy) == "*"
-    assert "build/{root:uri}/x".format(**dummy) == "build/*/x"
+    assert spec.format(**dummy) == expected

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.format import RootPathResolver, pyproject_format
+
+
+@pytest.fixture
+def resolver(tmp_path: Path) -> RootPathResolver:
+    return RootPathResolver(tmp_path)
+
+
+def test_root_plain_format(resolver: RootPathResolver) -> None:
+    # Regression: a bare {root} used to fall through to repr() and emit
+    # "RootPathResolver(path=...)" instead of the path itself.
+    formatted = "{root}".format(root=resolver)
+    assert formatted == str(resolver.path)
+    assert "RootPathResolver" not in formatted
+
+
+def test_root_str(resolver: RootPathResolver) -> None:
+    assert str(resolver) == str(resolver.path)
+
+
+def test_root_parent_format(resolver: RootPathResolver) -> None:
+    # Regression: a terminal {root:parent} used to emit the repr.
+    formatted = "{root:parent}".format(root=resolver)
+    assert formatted == str(resolver.path.parent)
+    assert "RootPathResolver" not in formatted
+
+
+def test_root_uri_format(resolver: RootPathResolver) -> None:
+    assert "{root:uri}".format(root=resolver) == resolver.path.as_uri()
+
+
+def test_root_parent_uri_format(resolver: RootPathResolver) -> None:
+    assert (
+        "{root:parent:uri}".format(root=resolver) == resolver.path.parent.as_uri()
+    )
+
+
+def test_root_invalid_format(resolver: RootPathResolver) -> None:
+    with pytest.raises(ValueError, match="Could not handle format"):
+        "{root:nonsense}".format(root=resolver)
+
+
+def test_dummy_plain_keys() -> None:
+    dummy = pyproject_format(dummy=True)
+    # All known keys are present and produce "*" for a plain format.
+    assert dummy["wheel_tag"] == "*"
+    assert "{wheel_tag}".format(**dummy) == "*"
+
+
+def test_dummy_root_spec() -> None:
+    # Regression: dummy mode mapped root to the plain string "*", so any
+    # build-dir containing a spec like {root:uri} raised
+    # "ValueError: Invalid format specifier 'uri' for object of type 'str'".
+    dummy = pyproject_format(dummy=True)
+    assert "{root}".format(**dummy) == "*"
+    assert "{root:uri}".format(**dummy) == "*"
+    assert "{root:parent:uri}".format(**dummy) == "*"
+    assert "build/{root:uri}/x".format(**dummy) == "build/*/x"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -15,7 +15,7 @@ def resolver(tmp_path: Path) -> RootPathResolver:
 def test_root_plain_format(resolver: RootPathResolver) -> None:
     # Regression: a bare {root} used to fall through to repr() and emit
     # "RootPathResolver(path=...)" instead of the path itself.
-    formatted = "{root}".format(root=resolver)
+    formatted = f"{resolver}"
     assert formatted == str(resolver.path)
     assert "RootPathResolver" not in formatted
 
@@ -26,24 +26,22 @@ def test_root_str(resolver: RootPathResolver) -> None:
 
 def test_root_parent_format(resolver: RootPathResolver) -> None:
     # Regression: a terminal {root:parent} used to emit the repr.
-    formatted = "{root:parent}".format(root=resolver)
+    formatted = f"{resolver:parent}"
     assert formatted == str(resolver.path.parent)
     assert "RootPathResolver" not in formatted
 
 
 def test_root_uri_format(resolver: RootPathResolver) -> None:
-    assert "{root:uri}".format(root=resolver) == resolver.path.as_uri()
+    assert f"{resolver:uri}" == resolver.path.as_uri()
 
 
 def test_root_parent_uri_format(resolver: RootPathResolver) -> None:
-    assert (
-        "{root:parent:uri}".format(root=resolver) == resolver.path.parent.as_uri()
-    )
+    assert f"{resolver:parent:uri}" == resolver.path.parent.as_uri()
 
 
 def test_root_invalid_format(resolver: RootPathResolver) -> None:
     with pytest.raises(ValueError, match="Could not handle format"):
-        "{root:nonsense}".format(root=resolver)
+        f"{resolver:nonsense}"
 
 
 def test_dummy_plain_keys() -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,7 +9,16 @@ if TYPE_CHECKING:
 
 import scikit_build_core._logging
 from scikit_build_core import __version__
-from scikit_build_core._logging import Style, rich_print
+from scikit_build_core._logging import Style, colors, rich_print
+
+
+def test_colors_no_stdout(monkeypatch: MonkeyPatch):
+    # Regression: sys.stdout can be None (pythonw / embedded interpreters).
+    # colors() must not raise AttributeError at import time.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setattr(sys, "stdout", None)
+    assert colors() is False
 
 
 def test_rich_print_nocolor(capsys: CaptureFixture[str], monkeypatch: MonkeyPatch):

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from scikit_build_core._shutil import _fix_all_permissions
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -43,8 +41,3 @@ def test_broken_all_permissions(make_dir_with_ro: Path) -> None:
             shutil.rmtree(make_dir_with_ro)
     else:
         shutil.rmtree(make_dir_with_ro)
-
-
-def test_fix_all_permissions(make_dir_with_ro: Path) -> None:
-    _fix_all_permissions(str(make_dir_with_ro))
-    shutil.rmtree(make_dir_with_ro)


### PR DESCRIPTION
Autogenerated from #1317.

:robot: _AI text below_ :robot:

A reviewed set of fixes for top-level utility modules and the editable-install redirect shim, each with regression tests.

## Bug fixes

1. **`format.py` — `RootPathResolver` had no `__str__`.** A plain `{root}` (and a terminal `{root:parent}`) fell through to `__format__("")` → `str(self)`, which returned the dataclass repr (`RootPathResolver(path=...)`) instead of the path. This affected `build-dir`, `build.requires`, etc. Added `__str__` returning `str(self.path)`.

2. **`resources/_editable_redirect.py` — `rebuild()` swallowed/garbled build errors.** The error branch used `and verbose`, but verbose already streams output live, so it printed the literal `ERROR: None`; when not verbose (the default) the captured stdout was never printed and `check_returncode()` raised without it, hiding errors that tools like MSBuild write to stdout. Flipped to `and not verbose` and factored the two near-identical run+check blocks into a small local helper. Stays stdlib-only and does not import `scikit_build_core`.

3. **`resources/_editable_redirect.py` — `FileLockIfUnix.acquire` TOCTOU.** Conditionally adding `O_CREAT` based on `os.path.exists()` is equivalent to always passing it (`O_CREAT` without `O_EXCL` is a no-op on existing files) but adds a race: if the lock file is removed between the check and the open, the import-time open raises an uncaught `FileNotFoundError`. Now always includes `O_CREAT`.

4. **`format.py` — dummy mode broke on spec-taking keys.** `pyproject_format(dummy=True)` mapped `root` to the plain string `"*"`, so a build-dir containing `{root:uri}` raised `ValueError: Invalid format specifier 'uri' for object of type 'str'`. Spec-taking keys now map to a tiny helper whose `__format__` accepts any spec and returns `"*"`.

5. **`_logging.py` — `colors()` could AttributeError at import.** It called `sys.stdout.isatty()` guarded only against `ValueError`, but `sys.stdout` can be `None` (pythonw/embedded). Since `Style` uses `colors()` as a default factory and `_style = Style()` runs at import, this could break importing the backend. Now suppresses `AttributeError` too.

6. **`errors.py` — `FailedProcessError.__str__` would AttributeError.** Every subprocess runs with `text=True` (str streams), but `__str__` called `.decode()` unconditionally. Now decodes only when the stream is bytes. `FailedProcessError`/`CMakeAccessError` are public API and were kept.

## Cleanups

7. **Removed dead `_fix_all_permissions`** from `_shutil.py` (and its only consumer, its own test). It has been dead since Python ≤3.7 support was dropped.

8. **Removed the unused `TypeAlias` shim** from `_compat/typing.py` and its `__all__` — no consumers in `src/` or `tests/`.

## Tests

Added/updated regression tests in `tests/test_format.py` (new), `tests/test_errors.py` (new), `tests/test_logging.py`, and `tests/test_editable_redirect.py`. All 32 targeted tests pass; `ruff` and `mypy` (strict) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)