### PR TITLE
fix(builder): cmake generator detection, archs cross-compile, and program search robustness

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -18,7 +18,12 @@ from .._compat import tomllib
 from .._compat.typing import assert_never
 from .._logging import LEVEL_VALUE, logger, rich_error, rich_print
 from .._variants import get_wheel_variant
-from ..builder.builder import Builder, archs_to_tags, get_archs
+from ..builder.builder import (
+    Builder,
+    archs_to_tags,
+    get_archs,
+    get_cmake_args_from_settings,
+)
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMaker
 from ..errors import FailedLiveProcessError
@@ -235,7 +240,11 @@ def _build_wheel_impl_impl(
         wheel_variant = get_wheel_variant(settings, pyproject, metadata)
 
         tags = WheelTag.compute_best(
-            archs_to_tags(get_archs(os.environ)),
+            archs_to_tags(
+                get_archs(
+                    os.environ, get_cmake_args_from_settings(settings, os.environ)
+                )
+            ),
             settings.wheel.py_api,
             expand_macos=settings.wheel.expand_macos_universal_tags,
             root_is_purelib=targetlib == "purelib",

--- a/src/scikit_build_core/builder/__main__.py
+++ b/src/scikit_build_core/builder/__main__.py
@@ -31,7 +31,12 @@ def main() -> None:
 
     if Path("pyproject.toml").is_file():
         req = GetRequires()
-        all_req = [*req.cmake(), *req.ninja(), *req.dynamic_metadata()]
+        all_req = [
+            *req.cmake(),
+            *req.ninja(),
+            *req.dynamic_metadata(),
+            *req.variants(),
+        ]
         rich_print(f"{{bold.red}}Get Requires:{{normal}} {all_req!r}")
 
     ip_program_search(color="magenta")

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -31,7 +31,12 @@ if TYPE_CHECKING:
     from ..cmake import CMaker
     from ..settings.skbuild_model import ScikitBuildSettings
 
-__all__ = ["Builder", "archs_to_tags", "get_archs"]
+__all__ = [
+    "Builder",
+    "archs_to_tags",
+    "get_archs",
+    "get_cmake_args_from_settings",
+]
 
 DIR = Path(__file__).parent.resolve()
 
@@ -92,6 +97,25 @@ def _filter_env_cmake_args(env_cmake_args: list[str]) -> Generator[str, None, No
             yield arg
 
 
+def get_cmake_args_from_settings(
+    settings: ScikitBuildSettings, env: Mapping[str, str]
+) -> list[str]:
+    """
+    Get CMake args from the settings and environment (settings ``cmake.args``
+    plus the filtered ``CMAKE_ARGS`` environment variable).
+    """
+    # Adding CMake arguments set as environment variable
+    # (needed e.g. to build for ARM OSX on conda-forge)
+    env_cmake_args: list[str] = list(
+        filter(None, shlex.split(env.get("CMAKE_ARGS", "")))
+    )
+
+    if env_cmake_args:
+        logger.debug("Env CMAKE_ARGS: {}", env_cmake_args)
+
+    return [*settings.cmake.args, *_filter_env_cmake_args(env_cmake_args)]
+
+
 def _sanitize_path(path: Any) -> list[Path]:
     # This handles classes like:
     # MultiplexedPath from importlib.resources.readers (3.11+)
@@ -113,16 +137,7 @@ class Builder:
         """
         Get CMake args from the settings and environment.
         """
-        # Adding CMake arguments set as environment variable
-        # (needed e.g. to build for ARM OSX on conda-forge)
-        env_cmake_args: list[str] = list(
-            filter(None, shlex.split(self.config.env.get("CMAKE_ARGS", "")))
-        )
-
-        if env_cmake_args:
-            logger.debug("Env CMAKE_ARGS: {}", env_cmake_args)
-
-        return [*self.settings.cmake.args, *_filter_env_cmake_args(env_cmake_args)]
+        return get_cmake_args_from_settings(self.settings, self.config.env)
 
     def get_generator(self, *args: str) -> str | None:
         return self.config.get_generator(
@@ -320,8 +335,9 @@ class Builder:
         self.config.init_cache(cache_config)
 
         if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = get_archs(self.config.env)
+            # Cross-compile support for macOS - respect ARCHFLAGS if set,
+            # unless CMAKE_SYSTEM_PROCESSOR is in the cmake args (conda, #207)
+            archs = get_archs(self.config.env, self.get_cmake_args())
             if archs:
                 cmake_defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
 

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -120,11 +120,11 @@ def set_environment_for_gen(
         if cxx:
             env["CXX"] = cxx
 
-    if (generator or "Ninja") == "Ninja":
+    if "Ninja" in (generator or "Ninja"):
         ninja = best_program(get_ninja_programs(), version=ninja_settings.version)
 
         if ninja is not None:
-            env.setdefault("CMAKE_GENERATOR", "Ninja")
+            env.setdefault("CMAKE_GENERATOR", generator or "Ninja")
             logger.debug("CMAKE_GENERATOR: Using ninja: {}", ninja.path)
             return {"CMAKE_MAKE_PROGRAM": str(ninja.path)}
 

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -46,13 +46,12 @@ def get_macosx_deployment_target(*, arm: bool) -> MacOSVer:
         logger.debug("MACOSX_DEPLOYMENT_TARGET not set, using {}", plat_target)
         return plat_target
 
-    env_target = ".".join(target.split(".")[:2]) if "." in target else f"{target}.0"
     try:
-        norm_env_target = normalize_macos_version(env_target, arm=arm)
+        norm_env_target = normalize_macos_version(target, arm=arm)
     except ValueError:
         msg = "MACOSX_DEPLOYMENT_TARGET not readable ({}), using {} instead"
-        logger.warning(msg, env_target, plat_target)
+        logger.warning(msg, target, plat_target)
         return plat_target
 
-    logger.debug("MACOSX_DEPLOYMENT_TARGET is set to {}", env_target)
+    logger.debug("MACOSX_DEPLOYMENT_TARGET is set to {}", target)
     return norm_env_target

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -67,7 +67,7 @@ class CMake:
             msg = f"Could not find CMake with version {version}"
             raise CMakeNotFoundError(msg)
         if cmake_program.version is None:
-            msg = "CMake version undetermined @ {program.path}"
+            msg = f"CMake version undetermined @ {cmake_program.path}"
             raise CMakeNotFoundError(msg)
 
         return cls(version=cmake_program.version, cmake_path=cmake_program.path)
@@ -269,7 +269,7 @@ class CMaker:
         _cmake_args = self._compute_cmake_args(defines or {}, toolchain)
         all_args = [*_cmake_args, *cmake_args]
 
-        gen = self.get_generator(*all_args)
+        gen = self.get_generator(*all_args, defines=defines or {})
         if gen:
             self.single_config = gen == "Ninja" or "Makefiles" in gen
 

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -23,7 +23,12 @@ from ..build._editable import (
 )
 from ..build._init import setup_logging
 from ..build._pathutil import packages_to_file_mapping, scantree
-from ..builder.builder import Builder, archs_to_tags, get_archs
+from ..builder.builder import (
+    Builder,
+    archs_to_tags,
+    get_archs,
+    get_cmake_args_from_settings,
+)
 from ..builder.get_requires import GetRequires
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMaker
@@ -166,7 +171,11 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         wheel_dir = self.__tmp_dir / "wheel"
 
         tags = WheelTag.compute_best(
-            archs_to_tags(get_archs(os.environ)),
+            archs_to_tags(
+                get_archs(
+                    os.environ, get_cmake_args_from_settings(settings, os.environ)
+                )
+            ),
             settings.wheel.py_api,
             expand_macos=settings.wheel.expand_macos_universal_tags,
             build_tag=settings.wheel.build_tag,

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -133,19 +133,24 @@ def get_cmake_program(cmake_path: Path) -> Program:
     None if it cannot be determined.
     """
     try:
-        result = Run(timeout=compute_timeout(cmake_path)).capture(
-            cmake_path, "-E", "capabilities"
-        )
         try:
-            version = Version(
-                json.loads(result.stdout)["version"]["string"].split("-")[0]
+            result = Run(timeout=compute_timeout(cmake_path)).capture(
+                cmake_path, "-E", "capabilities"
             )
-            logger.info("CMake version: {}", version)
-            return Program(cmake_path, version)
-        except (json.decoder.JSONDecodeError, KeyError, InvalidVersion):
-            logger.warning("Could not determine CMake version, got {!r}", result.stdout)
-    except subprocess.CalledProcessError:
-        try:
+            try:
+                version = Version(
+                    json.loads(result.stdout)["version"]["string"].split("-")[0]
+                )
+                logger.info("CMake version: {}", version)
+                return Program(cmake_path, version)
+            except (json.decoder.JSONDecodeError, KeyError, InvalidVersion):
+                logger.warning(
+                    "Could not determine CMake version, got {!r}", result.stdout
+                )
+        except subprocess.CalledProcessError:
+            # `cmake -E capabilities` is not available on very old CMakes, fall
+            # back to `--version`. This nested try ensures Permission/Timeout
+            # errors raised here are still handled by the outer handlers below.
             result = Run(timeout=compute_timeout(cmake_path)).capture(
                 cmake_path, "--version"
             )
@@ -160,12 +165,12 @@ def get_cmake_program(cmake_path: Path) -> Program:
                     "Could not determine CMake version via --version, got {!r}",
                     result.stdout,
                 )
-        except subprocess.CalledProcessError as err:
-            logger.warning(
-                "Could not determine CMake version via --version, got {!r} {!r}",
-                err.stdout,
-                err.stderr,
-            )
+    except subprocess.CalledProcessError as err:
+        logger.warning(
+            "Could not determine CMake version via --version, got {!r} {!r}",
+            err.stdout,
+            err.stderr,
+        )
     except PermissionError:
         logger.warning("Permissions Error getting CMake's version")
     except subprocess.TimeoutExpired:

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -563,7 +563,9 @@ class BuildCMake(setuptools.Command):
 
         # Setuptools requires this be specified if there's a mismatch.
         if sys.platform.startswith("darwin"):
-            arm_only = get_archs(builder.config.env) == ["arm64"]
+            arm_only = get_archs(builder.config.env, builder.get_cmake_args()) == [
+                "arm64"
+            ]
             orig_macos_str = self.plat_name.rsplit("-", 1)[0].split("-", 1)[1]
             orig_macos = normalize_macos_version(orig_macos_str, arm=arm_only)
             config.env.setdefault("MACOSX_DEPLOYMENT_TARGET", str(orig_macos))

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -143,6 +143,16 @@ def test_builder_macos_arch(monkeypatch, archs):
     assert get_archs({"ARCHFLAGS": archflags}) == archs
 
 
+def test_builder_macos_arch_cmake_system_processor(monkeypatch):
+    # If CMAKE_SYSTEM_PROCESSOR is in the cmake args, ARCHFLAGS is ignored (#207).
+    monkeypatch.setattr(sys, "platform", "darwin")
+    env = {"ARCHFLAGS": "-arch x86_64"}
+    cmake_args = ["-DCMAKE_SYSTEM_PROCESSOR=arm64"]
+    assert get_archs(env, cmake_args) == ["arm64"]
+    # Without the cmake arg, ARCHFLAGS wins.
+    assert get_archs(env) == ["x86_64"]
+
+
 def test_builder_macos_arch_extra(monkeypatch):
     archflags = "-arch arm64 -arch x86_64"
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -533,3 +543,47 @@ def test_generator_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         ),
     )
     assert builder.get_generator() == "Anything"
+
+
+@pytest.mark.parametrize("generator", ["Ninja", "Ninja Multi-Config"])
+def test_set_environment_for_gen_ninja_variants(
+    monkeypatch: pytest.MonkeyPatch, generator: str
+):
+    # Both "Ninja" and "Ninja Multi-Config" must trigger ninja handling: a
+    # CMAKE_MAKE_PROGRAM hint and the actual generator set in CMAKE_GENERATOR.
+    from scikit_build_core.builder import generator as gen_mod
+    from scikit_build_core.program_search import Program
+    from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+    fake_ninja = Program(Path("/usr/bin/ninja"), Version("1.11.0"))
+    monkeypatch.setattr(gen_mod, "get_ninja_programs", lambda: [fake_ninja])
+
+    env: dict[str, str] = {}
+    result = gen_mod.set_environment_for_gen(
+        generator,
+        CMake(Version("3.30"), Path("cmake")),
+        env,
+        NinjaSettings(),
+    )
+    assert result == {"CMAKE_MAKE_PROGRAM": str(fake_ninja.path)}
+    assert env["CMAKE_GENERATOR"] == generator
+
+
+def test_set_environment_for_gen_ninja_multi_config_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # An explicit Ninja Multi-Config generator with no ninja must raise rather
+    # than silently fall back to make.
+    from scikit_build_core.builder import generator as gen_mod
+    from scikit_build_core.errors import NinjaNotFoundError
+    from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+    monkeypatch.setattr(gen_mod, "get_ninja_programs", list)
+
+    with pytest.raises(NinjaNotFoundError):
+        gen_mod.set_environment_for_gen(
+            "Ninja Multi-Config",
+            CMake(Version("3.30"), Path("cmake")),
+            {},
+            NinjaSettings(),
+        )

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -171,6 +171,43 @@ def test_cmake_args(
 
 
 @pytest.mark.configure
+def test_cmake_multi_config_generator_via_define(
+    tmp_path: Path,
+    fp,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # A multi-config generator set via ``cmake.define.CMAKE_GENERATOR`` must be
+    # detected so that single_config is False (no -DCMAKE_BUILD_TYPE, --config
+    # is used for build/install).
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
+    fp.register(
+        [fp.program("cmake"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
+    fp.register(
+        [fp.program("cmake3"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.15.0"}}',
+    )
+
+    config = CMaker(
+        CMake.default_search(),
+        source_dir=DIR / "packages" / "simple_pure",
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+
+    # Register any configure call; we only care about the resulting state.
+    fp.register([fp.program("cmake"), fp.any()])
+    fp.register([fp.program("cmake3"), fp.any()])
+
+    config.configure(defines={"CMAKE_GENERATOR": "Ninja Multi-Config"})
+
+    assert config.single_config is False
+    configure_call = next(c for c in fp.calls if "-E" not in c)
+    assert not any("CMAKE_BUILD_TYPE" in arg for arg in configure_call)
+
+
+@pytest.mark.configure
 def test_cmake_paths(
     generator: str,
     tmp_path: Path,

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from packaging.version import Version
 
 from scikit_build_core.program_search import (
     best_program,
+    get_cmake_program,
     get_cmake_programs,
     get_ninja_programs,
 )
@@ -116,3 +118,29 @@ def test_get_cmake_programs_malformed(monkeypatch, fp, caplog):
 
     best_3_20 = best_program(programs, version=SpecifierSet(">=3.20"))
     assert best_3_20 is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.TimeoutExpired(["cmake"], 1),
+        PermissionError("nope"),
+    ],
+)
+def test_get_cmake_program_fallback_exception(monkeypatch, fp, caplog, exc):
+    # If `cmake -E capabilities` fails, the `--version` fallback runs inside the
+    # except handler. A TimeoutExpired/PermissionError raised there must be
+    # handled (yielding Program(path, None)), not propagate out and abort search.
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr("shutil.which", lambda x: x)
+    cmake_path = Path("cmake")
+
+    def raises(_process):
+        raise exc
+
+    fp.register([cmake_path, "-E", "capabilities"], returncode=1)
+    fp.register([cmake_path, "--version"], callback=raises)
+
+    program = get_cmake_program(cmake_path)
+    assert program.path == cmake_path
+    assert program.version is None


### PR DESCRIPTION
Autogenerated from #1317.

:robot: _AI text below_ :robot:

This PR fixes a reviewed set of bugs in `builder/`, `cmake.py`, and `program_search.py`, with regression tests. Each finding was verified against the source before fixing.

## Fixes

1. **`cmake.py` version-error message** — `"CMake version undetermined @ {program.path}"` was missing the `f` prefix and referenced an out-of-scope variable. Now `f"...{cmake_program.path}"`.

2. **`cmake.py` multi-config generator detection** — `CMaker.configure` called `get_generator(*all_args)` without forwarding `defines`, so a multi-config generator set via `cmake.define.CMAKE_GENERATOR` (e.g. `"Ninja Multi-Config"`, `"Xcode"`) was not detected. `single_config` stayed `True`, `-DCMAKE_BUILD_TYPE` was passed (ignored by multi-config generators) and `--config` was omitted from build/install — silently building the wrong config. Now passes `defines=defines or {}`. New test: `test_cmake_multi_config_generator_via_define`.

3. **`builder/generator.py` Ninja Multi-Config handling** — `set_environment_for_gen` used an exact-match (`(generator or "Ninja") == "Ninja"`), so an explicit `"Ninja Multi-Config"` skipped all ninja handling (no `CMAKE_MAKE_PROGRAM` hint, no `ninja.version` enforcement, no `NinjaNotFoundError`). Now matches any Ninja generator (mirroring `_uses_ninja_generator`) and records the actual generator name in `CMAKE_GENERATOR`. New tests: `test_set_environment_for_gen_ninja_variants`, `test_set_environment_for_gen_ninja_multi_config_missing`.

4. **`builder/builder.py` dead `get_archs` cross-compile path** — `get_archs(env, cmake_args=())` checks `cmake_args` for `CMAKE_SYSTEM_PROCESSOR` (added for conda cross-compiles in #207) and the docs document this, but no caller ever passed `cmake_args`. Wired the configured cmake args through the wheel-tag/arch paths (`Builder.configure`, `build/wheel.py`, `hatch/plugin.py`, `setuptools/build_cmake.py`) via a shared `get_cmake_args_from_settings` helper, so `-DCMAKE_SYSTEM_PROCESSOR` in `cmake.args`/`CMAKE_ARGS` now suppresses `ARCHFLAGS` handling on macOS as documented. All four call sites were safely wired through. New test: `test_builder_macos_arch_cmake_system_processor`. The docs (`docs/guide/crosscompile.md`) already matched the now-implemented behavior, so no doc change was needed.

5. **`builder/__main__.py` "Get Requires" diagnostic** — added the missing `*req.variants()` so the diagnostic matches the real hooks.

6. **`program_search.py` fallback error handling** — if `cmake -E capabilities` raised `CalledProcessError`, the `--version` fallback ran inside that handler; a `TimeoutExpired`/`PermissionError` raised there skipped the sibling `except` clauses and propagated out of `get_cmake_program`, aborting the whole search. Restructured with a nested `try` so those errors are handled the same way, yielding `Program(path, None)`. New test: `test_get_cmake_program_fallback_exception`.

7. **`builder/macos.py` simplification** — `get_macosx_deployment_target` manually re-normalized `env_target`, duplicating `normalize_macos_version`. Now passes the raw target through (behavior preserving aside from log text; covered by existing `test_macos_version`).

## Skipped

None — all seven findings were verified and fixed.

## Tests

```
uv run pytest tests/test_builder.py tests/test_program_search.py tests/test_cmake_config.py tests/test_get_requires.py -q -n auto
# 76 passed, 3 skipped, 1 xfailed
```

`prek -a --quiet` passes (ruff, ruff-format, mypy, etc.). The only failing hook is `check-sdist`, which fails identically on a clean checkout of `main` in this worktree (complains about an untracked `.claude/settings.local.json` and `uv.lock`); it is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
