### PR TITLE
fix(hatch,setuptools): correctness fixes in hatch and setuptools layers

### DIFF
--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -72,7 +72,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             msg = "Hatch support is experimental, must enable the experimental flag"
             raise ValueError(msg)
 
-        if not settings.wheel.cmake or settings.sdist.cmake:
+        if not settings.wheel.cmake:
             msg = "CMake is required for scikit-build"
             raise ValueError(msg)
 
@@ -171,13 +171,12 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             expand_macos=settings.wheel.expand_macos_universal_tags,
             build_tag=settings.wheel.build_tag,
         )
-        if settings.wheel.platlib is None:
-            targetlib = "platlib" if settings.wheel.cmake else "purelib"
-        else:
-            targetlib = "platlib" if settings.wheel.platlib else "purelib"
+        # _validate guarantees wheel.cmake is true and rejects a falsy
+        # wheel.platlib (purelib), so this is always a platlib build.
+        targetlib = "platlib"
 
         build_data["tag"] = str(tags)
-        build_data["pure_python"] = targetlib == "purelib"
+        build_data["pure_python"] = False
 
         if editable and settings.editable.mode == "inplace":
             build_dir = Path(settings.cmake.source_dir)
@@ -342,10 +341,15 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                 path.write_bytes(contents)
                 editable_force_include[str(path)] = filename
         else:
+            # CMake already installed into
+            # wheel_dirs[targetlib] / settings.wheel.install_dir, so the files
+            # under wheel_dirs[targetlib] already carry the install_dir prefix;
+            # mapping them relative to wheel_dirs[targetlib] keeps that single
+            # prefix (matching the editable branch above).
             for raw_path in wheel_dirs[targetlib].iterdir():
                 path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
                 build_data["force_include"][f"{path}"] = str(
-                    settings.wheel.install_dir / path.relative_to(wheel_dirs[targetlib])
+                    path.relative_to(wheel_dirs[targetlib])
                 )
 
         try:

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -49,30 +49,32 @@ def __dir__() -> list[str]:
 def _validate_settings(
     settings: ScikitBuildSettings, *, editable_mode: bool = False
 ) -> None:
-    assert not settings.wheel.expand_macos_universal_tags, (
-        "wheel.expand_macos_universal_tags is not supported in setuptools mode"
-    )
-    assert settings.logging.level == "WARNING", (
-        "Logging is not adjustable in setuptools mode yet"
-    )
-    assert not settings.wheel.py_api, (
-        "wheel.py_api is not supported in setuptools mode, use bdist_wheel options instead"
-    )
+    if settings.wheel.expand_macos_universal_tags:
+        msg = "wheel.expand_macos_universal_tags is not supported in setuptools mode"
+        raise SetupError(msg)
+    if settings.logging.level != "WARNING":
+        msg = "Logging is not adjustable in setuptools mode yet"
+        raise SetupError(msg)
+    if settings.wheel.py_api:
+        msg = "wheel.py_api is not supported in setuptools mode, use bdist_wheel options instead"
+        raise SetupError(msg)
     if editable_mode:
-        assert settings.editable.mode == "inplace", (
-            "setuptools editable installs require editable.mode = 'inplace'"
-        )
-        assert not settings.editable.rebuild, (
-            "editable.rebuild is not supported in setuptools mode"
-        )
+        if settings.editable.mode != "inplace":
+            msg = "setuptools editable installs require editable.mode = 'inplace'"
+            raise SetupError(msg)
+        if settings.editable.rebuild:
+            msg = "editable.rebuild is not supported in setuptools mode"
+            raise SetupError(msg)
 
 
-def _load_settings() -> ScikitBuildSettings:
+def _load_settings(
+    state: Literal["sdist", "wheel", "editable"] = "sdist",
+) -> ScikitBuildSettings:
     # setup.py-only projects (common with the classic scikit-build wrapper)
     # don't have a pyproject.toml.
     if not Path("pyproject.toml").is_file():
-        return SettingsReader({}, {}, state="sdist").settings
-    return SettingsReader.from_file("pyproject.toml").settings
+        return SettingsReader({}, {}, state=state).settings
+    return SettingsReader.from_file("pyproject.toml", state=state).settings
 
 
 def get_source_dir_from_pyproject_toml() -> str | None:
@@ -333,8 +335,6 @@ def _excluded_by_package_data(dist: Distribution, package_output: Path) -> bool:
 class BuildCMake(setuptools.Command):
     source_dir: str | None = None
     cmake_args: list[str] | str | None = None
-    cmake_install_dir: str | None = None
-    cmake_install_target: str | None = None
     _editable_install_dir: Path | None
     _installed_files: list[Path]
 
@@ -353,7 +353,6 @@ class BuildCMake(setuptools.Command):
         ("parallel=", "j", "number of parallel build jobs"),
         ("source-dir=", "s", "directory with CMakeLists.txt"),
         ("cmake-args=", "a", "extra arguments for CMake"),
-        ("cmake-install-target=", "", "CMake target to install"),
     ]
 
     def initialize_options(self) -> None:
@@ -365,8 +364,6 @@ class BuildCMake(setuptools.Command):
         self.plat_name = None
         self.source_dir = get_source_dir_from_pyproject_toml()
         self.cmake_args = None
-        self.cmake_install_dir = None
-        self.cmake_install_target = None
         self._editable_install_dir = None
         self._installed_files = []
 
@@ -520,7 +517,9 @@ class BuildCMake(setuptools.Command):
         assert self.plat_name is not None
 
         self.editable_mode = self._get_editable_mode()
-        settings = _load_settings()
+        # run() is always a wheel or editable build; pass the matching state so
+        # overrides (if.state = "wheel"/"editable") are applied correctly.
+        settings = _load_settings(state="editable" if self.editable_mode else "wheel")
         _validate_settings(settings, editable_mode=self.editable_mode)
 
         build_tmp_folder = Path(self.build_temp)
@@ -534,8 +533,10 @@ class BuildCMake(setuptools.Command):
         source_dir = self.source_dir if dist_source_dir is None else dist_source_dir
         assert source_dir is not None, "This should not be reachable"
 
-        configure_args = self.cmake_args or []
-        assert isinstance(configure_args, list)
+        assert self.cmake_args is None or isinstance(self.cmake_args, list)
+        # Copy to avoid mutating self.cmake_args in place (which would
+        # double-append the dist args if run() executes more than once).
+        configure_args = list(self.cmake_args or [])
         dist_cmake_args = getattr(self.distribution, "cmake_args", None)
         configure_args.extend(dist_cmake_args or [])
 
@@ -582,7 +583,7 @@ class BuildCMake(setuptools.Command):
             if use_wrapper_classic_layout_compat
             else install_dir
         )
-        installed_before = _collect_recursive_files(install_dir)
+        installed_before = _collect_recursive_files(cmake_install_prefix)
         defines = {"CMAKE_INSTALL_PREFIX": cmake_install_prefix}
 
         builder.configure(
@@ -607,7 +608,7 @@ class BuildCMake(setuptools.Command):
 
         cmake_manifest = _read_cmake_install_manifests(build_temp, cmake_install_prefix)
         if cmake_manifest is None:
-            installed_after = _collect_recursive_files(install_dir)
+            installed_after = _collect_recursive_files(cmake_install_prefix)
             cmake_manifest = sorted(installed_after - installed_before)
 
         process_manifest = getattr(dist, "cmake_process_manifest_hook", None)

--- a/src/scikit_build_core/setuptools/wrapper.py
+++ b/src/scikit_build_core/setuptools/wrapper.py
@@ -9,6 +9,7 @@ import setuptools
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+from .._compat.setuptools.errors import SetupError
 from .._compat.typing import TypeVar
 from .build_cmake import (
     WRAPPER_CLASSIC_LAYOUT_COMPAT,
@@ -42,8 +43,12 @@ def setup(
     distclass: type[_DistributionT] = setuptools.Distribution,  # type: ignore[assignment]
     **kw: Any,
 ) -> _DistributionT:
-    assert not cmake_with_sdist, "cmake_with_sdist not supported yet"
-    assert cmake_install_target == "install", "cmake_install_target not supported yet"
+    if cmake_with_sdist:
+        msg = "cmake_with_sdist not supported yet"
+        raise SetupError(msg)
+    if cmake_install_target != "install":
+        msg = "cmake_install_target not supported yet"
+        raise SetupError(msg)
 
     if cmake_languages is not None:
         warnings.warn("cmake_languages no longer has any effect", stacklevel=2)

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import sysconfig
 import tarfile
@@ -9,6 +11,26 @@ import pytest
 
 pytest.importorskip("hatchling")
 from hatchling.builders.wheel import WheelBuilder
+
+from scikit_build_core.hatch.plugin import ScikitBuildHook
+from scikit_build_core.settings.skbuild_read_settings import (
+    SettingsReader,
+)
+
+
+def _validate_settings(pyproject: dict[str, object]) -> None:
+    reader = SettingsReader(pyproject, {}, state="sdist")
+    # _validate only uses the settings_reader argument, not self.
+    ScikitBuildHook._validate(None, reader)  # type: ignore[arg-type]
+
+
+def test_hatchling_sdist_cmake_error_message() -> None:
+    pyproject = {
+        "project": {"name": "x", "version": "0.1.0"},
+        "tool": {"scikit-build": {"experimental": True, "sdist": {"cmake": True}}},
+    }
+    with pytest.raises(ValueError, match="Not currently supported for SDist builds"):
+        _validate_settings(pyproject)
 
 
 def set_hatchling_editable_mode(mode: str) -> None:
@@ -76,9 +98,17 @@ def test_hatchling_wheel(isolated, build_args, tmp_path: Path) -> None:
         "hatchling_example-0.1.0.dist-info/extra_metadata/metadata_file.txt",
         "hatchling_example/__init__.py",
         "hatchling_example/_core.pyi",
-        f"hatchling_example/hatchling_example/_core{ext_suffix}",
+        f"hatchling_example/_core{ext_suffix}",
     }
     assert "Root-Is-Purelib: false" in wheel_metadata
+
+    # The built wheel must be importable (regression test for the doubled
+    # install_dir prefix that produced an unimportable layout).
+    isolated.install(str(wheel), isolated=False)
+    assert (
+        isolated.execute("import hatchling_example; print(hatchling_example.add(1, 2))")
+        == "3"
+    )
 
 
 @pytest.mark.compile

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -461,6 +461,43 @@ def test_manifest_hook_must_be_callable():
         )
 
 
+def test_validate_settings_raises_setup_error():
+    # Must use a real exception (not bare assert) so it survives python -O.
+    settings = build_cmake._load_settings()
+    settings.wheel.py_api = "cp39"
+    with pytest.raises(SetupError, match=r"wheel\.py_api is not supported"):
+        build_cmake._validate_settings(settings)
+
+
+def test_wrapper_setup_raises_setup_error():
+    with pytest.raises(SetupError, match="cmake_with_sdist not supported"):
+        wrapper.setup(cmake_with_sdist=True)
+    with pytest.raises(SetupError, match="cmake_install_target not supported"):
+        wrapper.setup(cmake_install_target="custom")
+
+
+def test_load_settings_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            wheel.cmake = false
+
+            [[tool.scikit-build.overrides]]
+            if.state = "editable"
+            wheel.cmake = true
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    # Default state is sdist, so the editable override should not apply.
+    assert build_cmake._load_settings().wheel.cmake is False
+    assert build_cmake._load_settings(state="wheel").wheel.cmake is False
+    assert build_cmake._load_settings(state="editable").wheel.cmake is True
+
+
 def test_wrapper_forwards_manifest_hook(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):


### PR DESCRIPTION
Autogenerated from #1317.

:robot: _AI text below_ :robot:

Fixes a reviewed set of bugs in the experimental `hatch/` and `setuptools/` layers. Each finding was verified against the code before fixing.

## Hatch (`hatch/plugin.py`)

1. **Doubled `wheel.install_dir` prefix (high).** For non-editable wheels CMake already installs into `wheel_dirs[targetlib] / settings.wheel.install_dir`, so files already carry the prefix. The `force_include` mapping prefixed `install_dir` a second time, producing an unimportable layout (`hatchling_example/hatchling_example/_core{ext}` while `__init__.py` does `from ._core import add`). Dropped the extra prefix so it matches the editable branch. The `/`-prefixed absolute-install-dir branch is unaffected (it installs into a different wheel dir, so that loop body never runs). Updated `test_hatchling_wheel` to the single-prefix layout and made it install + import the built wheel.

2. **Unreachable sdist.cmake message.** `if not settings.wheel.cmake or settings.sdist.cmake:` raised "CMake is required for scikit-build" for anyone setting `sdist.cmake = true`, masking the dedicated "Not currently supported for SDist builds" check. Condition is now just `not settings.wheel.cmake`. Added a unit test for the message.

3. **Dead branching (simplification).** `_validate` guarantees `wheel.cmake` and rejects a purelib build, so `targetlib` is always `"platlib"` and `pure_python` always `False`. Removed the four-way branch.

## Setuptools (`setuptools/build_cmake.py`, `wrapper.py`)

4. **In-place list mutation.** `configure_args = self.cmake_args or []` aliased the command's list and then `.extend()`ed it, double-appending dist args on a second `run()`. Now copies via `list(...)`.

5. **Wrong directory in classic-layout no-manifest fallback.** In `use_wrapper_classic_layout_compat` mode CMake installs into `cmake_install_prefix = build_temp / "cmake-install" / install_subdir`, but the `installed_before`/`installed_after` diff scanned `install_dir`, so when no `install_manifest*.txt` exists the diff was empty and the compat copy silently copied nothing. Both `_collect_recursive_files` calls now scan `cmake_install_prefix`, consistent with `_read_cmake_install_manifests`. Verified against commit 5ccaecd: that commit roots manifest paths at `cmake_install_prefix`, so the fallback should too. (No dedicated fallback fixture exists since CMake normally writes a manifest; verified by reading the surrounding logic. The existing classic-layout wheel test still passes.)

6. **Dead attributes + ignored option.** `BuildCMake.cmake_install_dir`/`cmake_install_target` were declared/initialized but never read, and `cmake-install-target=` in `user_options` was accepted and silently ignored — inconsistent with the `setup()` keyword that deliberately errors. Removed the dead attributes and the user option (chose removal over erroring to keep the command surface minimal; the unsupported `setup()` keyword still errors via its validator).

7. **Wrong override state.** `_load_settings()` always used `state="sdist"`, so `if.state = "wheel"/"editable"` overrides never matched and `if.state = "sdist"` wrongly did, even though `run()` is always a wheel/editable build. Plumbed a `state` parameter; `run()` now passes `"editable"`/`"wheel"`. Added a regression test.

8. **`assert` for config rejection.** `_validate_settings` and `wrapper.setup` used bare `assert`s to reject unsupported configs (`wheel.py_api`, `editable.rebuild`, `cmake_with_sdist`, ...), which vanish under `python -O`. Replaced with `SetupError` (the project's `.._compat.setuptools.errors` shim). Added regression tests.

None skipped — all eight findings verified and fixed.

## Tests

- `tests/test_hatchling.py`: 8 passed (including build/install/import of the regular wheel).
- `tests/test_setuptools_pep517.py`: 17 passed.
- `tests/test_setuptools_abi3.py`, `tests/test_setuptools_pep518.py`: 4 passed.
- `prek -a --quiet`: ruff + mypy clean. (`check-sdist` flags pre-existing worktree artifacts `.claude/settings.local.json` and `uv.lock`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)