### PR TITLE
fix(build): entry-point, wheel, and requires-state bugs

### DIFF
--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -4,9 +4,15 @@ This is the entry point for the build backend. Items in this module are designed
 
 from __future__ import annotations
 
+import contextlib
 import sys
+from typing import TYPE_CHECKING
 
 from .._compat import tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Literal
 
 __all__ = [
     "build_editable",
@@ -15,9 +21,23 @@ __all__ = [
     "get_requires_for_build_editable",
     "get_requires_for_build_sdist",
     "get_requires_for_build_wheel",
-    "prepare_metadata_for_build_editable",
-    "prepare_metadata_for_build_wheel",
 ]
+
+
+@contextlib.contextmanager
+def _exit_on_failed_live_process() -> Iterator[None]:
+    """Translate a FailedLiveProcessError into a clean ``SystemExit(1)``."""
+    from .._logging import rich_print
+    from ..errors import FailedLiveProcessError
+
+    try:
+        yield
+    except FailedLiveProcessError as err:
+        sys.stdout.flush()
+        rich_print("\n{bold}***", *err.args, color="red", file=sys.stderr)
+        if err.msg:
+            rich_print(err.msg)
+        raise SystemExit(1) from None
 
 
 def build_wheel(
@@ -25,23 +45,15 @@ def build_wheel(
     config_settings: dict[str, list[str] | str] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    from .._logging import rich_print
-    from ..errors import FailedLiveProcessError
     from .wheel import _build_wheel_impl
 
-    try:
+    with _exit_on_failed_live_process():
         return _build_wheel_impl(
             wheel_directory,
             config_settings,
             metadata_directory,
             editable=False,
         ).wheel_filename
-    except FailedLiveProcessError as err:
-        sys.stdout.flush()
-        rich_print("\n{bold}***", *err.args, color="red", file=sys.stderr)
-        if err.msg:
-            rich_print(err.msg)
-        raise SystemExit(1) from None
 
 
 def build_editable(
@@ -49,23 +61,15 @@ def build_editable(
     config_settings: dict[str, list[str] | str] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    from .._logging import rich_print
-    from ..errors import FailedLiveProcessError
     from .wheel import _build_wheel_impl
 
-    try:
+    with _exit_on_failed_live_process():
         return _build_wheel_impl(
             wheel_directory,
             config_settings,
             metadata_directory,
             editable=True,
         ).wheel_filename
-    except FailedLiveProcessError as err:
-        sys.stdout.flush()
-        rich_print("\n{bold}***", *err.args, color="red", file=sys.stderr)
-        if err.msg:
-            rich_print(err.msg)
-        raise SystemExit(1) from None
 
 
 def _has_safe_metadata() -> bool:
@@ -119,18 +123,10 @@ def build_sdist(
     sdist_directory: str,
     config_settings: dict[str, list[str] | str] | None = None,
 ) -> str:
-    from .._logging import rich_print
-    from ..errors import FailedLiveProcessError
     from .sdist import build_sdist as skbuild_build_sdist
 
-    try:
+    with _exit_on_failed_live_process():
         return skbuild_build_sdist(sdist_directory, config_settings)
-    except FailedLiveProcessError as err:
-        sys.stdout.flush()
-        rich_print("\n{bold}***", *err.args, color="red", file=sys.stderr)
-        if err.msg:
-            rich_print(err.msg)
-        raise SystemExit(1) from None
 
 
 def get_requires_for_build_sdist(
@@ -138,7 +134,7 @@ def get_requires_for_build_sdist(
 ) -> list[str]:
     from ..builder.get_requires import GetRequires
 
-    requires = GetRequires.from_config_settings(config_settings)
+    requires = GetRequires.from_config_settings(config_settings, state="sdist")
 
     # These are only injected if cmake is required for the SDist step
     cmake_requires = (
@@ -152,12 +148,13 @@ def get_requires_for_build_sdist(
     ]
 
 
-def get_requires_for_build_wheel(
-    config_settings: dict[str, str | list[str]] | None = None,
+def _get_requires_for_build_wheel(
+    config_settings: dict[str, str | list[str]] | None,
+    state: Literal["wheel", "editable"],
 ) -> list[str]:
     from ..builder.get_requires import GetRequires
 
-    requires = GetRequires.from_config_settings(config_settings)
+    requires = GetRequires.from_config_settings(config_settings, state=state)
 
     # These are only injected if cmake is required for the wheel step
     cmake_requires = (
@@ -169,22 +166,15 @@ def get_requires_for_build_wheel(
         *requires.variants(),
         *requires.dynamic_metadata(),
     ]
+
+
+def get_requires_for_build_wheel(
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> list[str]:
+    return _get_requires_for_build_wheel(config_settings, state="wheel")
 
 
 def get_requires_for_build_editable(
     config_settings: dict[str, str | list[str]] | None = None,
 ) -> list[str]:
-    from ..builder.get_requires import GetRequires
-
-    requires = GetRequires.from_config_settings(config_settings)
-
-    # These are only injected if cmake is required for the wheel step
-    cmake_requires = (
-        [*requires.cmake(), *requires.ninja()] if requires.settings.wheel.cmake else []
-    )
-
-    return [
-        *cmake_requires,
-        *requires.variants(),
-        *requires.dynamic_metadata(),
-    ]
+    return _get_requires_for_build_wheel(config_settings, state="editable")

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -77,7 +77,7 @@ def each_unignored_file(
     for dirstr, dirs, filenames in os.walk(str(starting_path), followlinks=True):
         dirpath = Path(dirstr)
         if mode != "classic":
-            for dname in dirs:
+            for dname in list(dirs):
                 if not match_path(
                     dirpath,
                     dirpath / dname,

--- a/src/scikit_build_core/build/_scripts.py
+++ b/src/scikit_build_core/build/_scripts.py
@@ -19,6 +19,8 @@ SHEBANG_PATTERN = re.compile(r"^#!.*(?:python|pythonw|pypy)[0-9.]*([ \t].*)?$")
 
 def process_script_dir(script_dir: Path) -> None:
     for item in script_dir.iterdir():
+        if not item.is_file():
+            continue
         content = []
         with contextlib.suppress(UnicodeDecodeError), item.open(encoding="utf-8") as f:
             file_iter = iter(f)

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -125,7 +125,7 @@ def build_sdist(
     for gen in settings.generate:
         if gen.location == "source":
             contents = generate_file_contents(gen, metadata)
-            gen.path.write_text(contents)
+            gen.path.write_text(contents, encoding="utf-8")
             settings.sdist.include.append(str(gen.path))
 
     sdist_dir.mkdir(parents=True, exist_ok=True)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import os
 import platform
 import shutil
@@ -273,6 +274,23 @@ def _build_wheel_impl_impl(
         for d in wheel_dirs.values():
             d.mkdir(parents=True)
 
+        # The metadata-only and full-wheel paths build identical WheelWriters
+        # except for the output folder; share a single constructor.
+        make_wheel = functools.partial(
+            WheelWriter,
+            metadata,
+            tags=override_wheel_tags or tags.as_tags_set(),
+            wheel_metadata=WheelMetadata(
+                root_is_purelib=targetlib == "purelib",
+                build_tag=settings.wheel.build_tag,
+            ),
+            metadata_dir=wheel_dirs["metadata"],
+            variant_label=wheel_variant.label if wheel_variant else "",
+            variant_dist_info_contents=(
+                wheel_variant.dist_info_contents if wheel_variant else None
+            ),
+        )
+
         if ".." in settings.wheel.install_dir:
             msg = "wheel.install_dir must not contain '..'"
             raise AssertionError(msg)
@@ -288,7 +306,7 @@ def _build_wheel_impl_impl(
             install_dir = wheel_dirs[targetlib] / settings.wheel.install_dir
 
         # Include the metadata license.file entry if provided
-        if metadata.license_files:
+        if metadata.license_files is not None:
             license_paths = metadata.license_files
         else:
             if settings.wheel.license_files is None:
@@ -327,27 +345,14 @@ def _build_wheel_impl_impl(
         for gen in settings.generate:
             if gen.location == "source":
                 contents = generate_file_contents(gen, metadata)
-                gen.path.write_text(contents)
+                gen.path.write_text(contents, encoding="utf-8")
                 settings.sdist.include.append(str(gen.path))
 
         if wheel_directory is None and not exit_after_config:
             if metadata_directory is None:
                 msg = "metadata_directory must be specified if wheel_directory is None"
                 raise AssertionError(msg)
-            wheel = WheelWriter(
-                metadata,
-                Path(metadata_directory),
-                override_wheel_tags or tags.as_tags_set(),
-                WheelMetadata(
-                    root_is_purelib=targetlib == "purelib",
-                    build_tag=settings.wheel.build_tag,
-                ),
-                wheel_dirs["metadata"],
-                variant_label=wheel_variant.label if wheel_variant else "",
-                variant_dist_info_contents=(
-                    wheel_variant.dist_info_contents if wheel_variant else None
-                ),
-            )
+            wheel = make_wheel(folder=Path(metadata_directory))
             dist_info_contents = wheel.dist_info_contents()
             dist_info = Path(metadata_directory) / f"{wheel.name_ver}.dist-info"
             dist_info.mkdir(parents=True)
@@ -459,20 +464,7 @@ def _build_wheel_impl_impl(
 
             process_script_dir(wheel_dirs["scripts"])
 
-        with WheelWriter(
-            metadata,
-            Path(wheel_directory),
-            override_wheel_tags or tags.as_tags_set(),
-            WheelMetadata(
-                root_is_purelib=targetlib == "purelib",
-                build_tag=settings.wheel.build_tag,
-            ),
-            wheel_dirs["metadata"],
-            variant_label=wheel_variant.label if wheel_variant else "",
-            variant_dist_info_contents=(
-                wheel_variant.dist_info_contents if wheel_variant else None
-            ),
-        ) as wheel:
+        with make_wheel(folder=Path(wheel_directory)) as wheel:
             wheel.build(wheel_dirs, exclude=settings.wheel.exclude)
 
             str_pkgs = (

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -64,8 +64,11 @@ def is_known_platform(platforms: frozenset[str]) -> bool:
 
 def _load_scikit_build_settings(
     config_settings: Mapping[str, list[str] | str] | None = None,
+    state: Literal["sdist", "wheel", "editable"] = "sdist",
 ) -> ScikitBuildSettings:
-    return SettingsReader.from_file("pyproject.toml", config_settings).settings
+    return SettingsReader.from_file(
+        "pyproject.toml", config_settings, state=state
+    ).settings
 
 
 @dataclasses.dataclass(frozen=True)
@@ -76,9 +79,11 @@ class GetRequires:
 
     @classmethod
     def from_config_settings(
-        cls, config_settings: Mapping[str, list[str] | str] | None
+        cls,
+        config_settings: Mapping[str, list[str] | str] | None,
+        state: Literal["sdist", "wheel", "editable"] = "sdist",
     ) -> Self:
-        return cls(_load_scikit_build_settings(config_settings))
+        return cls(_load_scikit_build_settings(config_settings, state))
 
     def cmake(self) -> Generator[str, None, None]:
         if self.settings.fail or os.environ.get("CMAKE_EXECUTABLE", ""):

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -547,6 +548,58 @@ def test_empty_directory(
 
     result = list(each_unignored_file(Path(), exclude=["*.py"], mode=mode))
     assert result == []
+
+
+def test_consecutive_excluded_dirs_not_descended(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Two consecutive excluded sibling directories must both be pruned from the
+    os.walk traversal (mutating the dirs list while iterating it used to skip
+    the second one, descending into the excluded tree).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    Path("keep.txt").write_text("content")
+    for name in ("excluded_a", "excluded_b"):
+        deep = Path(name) / "deep"
+        deep.mkdir(parents=True)
+        (deep / "inner.txt").write_text("content")
+
+    # Track which directories the main (followlinks) traversal descends into.
+    # The unrelated nested-.gitignore discovery walk is not followlinks, so it
+    # is ignored here.
+    descended: list[str] = []
+    real_walk = os.walk
+
+    def tracking_walk(
+        top: str, *args: object, **kwargs: object
+    ) -> Generator[tuple[str, list[str], list[str]], None, None]:
+        track = bool(kwargs.get("followlinks"))
+        for dirstr, dirs, filenames in real_walk(top, *args, **kwargs):  # type: ignore[arg-type]
+            if track:
+                descended.append(dirstr)
+            yield dirstr, dirs, filenames
+
+    monkeypatch.setattr(os, "walk", tracking_walk)
+
+    result = set(
+        each_unignored_file(
+            Path(),
+            exclude=["excluded_a", "excluded_b"],
+            mode="default",
+        )
+    )
+
+    assert result == {Path("keep.txt")}
+
+    # Neither excluded directory should have been descended into. With the
+    # mutate-while-iterating bug, the second sibling (excluded_b) was skipped
+    # by the removal loop and therefore still walked.
+    descended_paths = {Path(d) for d in descended}
+    assert Path("excluded_a") not in descended_paths
+    assert Path("excluded_b") not in descended_paths
 
 
 def test_nonexistent_patterns(

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -172,3 +172,40 @@ def test_get_requires_for_build_editable_pure(fp: FakeProcess):
         stdout='{"version":{"string":"3.14.0"}}',
     )
     assert set(get_requires_for_build_editable({"wheel.cmake": "False"})) == set()
+
+
+def test_get_requires_state_override(
+    fp: FakeProcess, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """
+    Overrides gated on ``if.state`` must be resolved against the actual hook's
+    state, so a ``state = "wheel"`` override only affects the wheel hook.
+    """
+    monkeypatch.chdir(tmp_path)
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+        [tool.scikit-build]
+        wheel.cmake = false
+        sdist.cmake = false
+
+        [[tool.scikit-build.overrides]]
+        if.state = "wheel"
+        build.requires = ["wheel-only-dep"]
+
+        [[tool.scikit-build.overrides]]
+        if.state = "editable"
+        build.requires = ["editable-only-dep"]
+        """
+    )
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.14.0"}}',
+    )
+
+    assert "wheel-only-dep" in get_requires_for_build_wheel({})
+    assert "wheel-only-dep" not in get_requires_for_build_sdist({})
+    assert "wheel-only-dep" not in get_requires_for_build_editable({})
+
+    assert "editable-only-dep" in get_requires_for_build_editable({})
+    assert "editable-only-dep" not in get_requires_for_build_sdist({})
+    assert "editable-only-dep" not in get_requires_for_build_wheel({})

--- a/tests/test_process_scripts.py
+++ b/tests/test_process_scripts.py
@@ -56,3 +56,29 @@ def test_script_dir(tmp_path: Path) -> None:
         script_7.read_text(encoding="utf-8")
         == "#!/usr/bin/env other\n\nprint('hello world')"
     )
+
+
+def test_script_dir_with_subdirectory(tmp_path: Path) -> None:
+    """
+    A subdirectory installed into the scripts dir must be skipped, not opened
+    (which would raise IsADirectoryError / PermissionError on Windows).
+    """
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+
+    script_1 = script_dir / "script1"
+    script_1.write_text("#!/usr/bin/env python3\n\nprint('hello world')")
+
+    nested = script_dir / "nested"
+    nested.mkdir()
+    nested_script = nested / "script2"
+    nested_script.write_text("#!/usr/bin/env python3\n\nprint('nested')")
+
+    # Must not raise on the subdirectory.
+    process_script_dir(script_dir)
+
+    assert script_1.read_text(encoding="utf-8") == "#!python\n\nprint('hello world')"
+    # Nested files are not rewritten by this function (packaging handles them).
+    assert nested_script.read_text(encoding="utf-8") == (
+        "#!/usr/bin/env python3\n\nprint('nested')"
+    )

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -458,3 +458,45 @@ def test_pep639_license_files_wheel(tmp_path: Path):
 
     assert "LICENSE1.txt" in metadata
     assert "nested/more/LICENSE2.txt" in metadata
+
+
+def test_pep639_license_files_optout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """
+    An explicit ``license-files = []`` opts out of shipping license files, even
+    if a default-glob-matching file (LICENSE) is present in the source tree.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    src.joinpath("pyproject.toml").write_text(
+        inspect.cleandoc(
+            """
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "license_optout"
+            version = "0.1.0"
+            license = "MIT"
+            license-files = []
+
+            [tool.scikit-build]
+            wheel.cmake = false
+            """
+        )
+    )
+    # A file that would otherwise be picked up by the default license globs.
+    src.joinpath("LICENSE").write_text("Not actually shipped\n")
+    monkeypatch.chdir(src)
+
+    dist = tmp_path / "dist"
+    build_wheel(str(dist), {})
+    (wheel,) = dist.glob("license_optout-0.1.0-*.whl")
+
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+        with zf.open("license_optout-0.1.0.dist-info/METADATA") as f:
+            metadata = f.read().decode("utf-8")
+
+    assert not any("dist-info/licenses/" in n for n in names)
+    assert "License-File:" not in metadata


### PR DESCRIPTION
Autogenerated from #1317.

:robot: _AI text below_ :robot:

Fixes a reviewed batch of bugs in `src/scikit_build_core/build/` plus the
`get_requires` state plumbing, with regression tests. Each finding was verified
against the source before fixing.

## Bug fixes

1. **`build/__init__.py` `__all__` duplication / undefined names** — The
   top-level `__all__` unconditionally listed `prepare_metadata_for_build_wheel`
   and `prepare_metadata_for_build_editable`, which are only defined (and
   appended to `__all__`) inside `if _has_safe_metadata():`. This produced
   duplicates when metadata was safe and advertised undefined names (breaking
   `import *`) otherwise. Removed them from the top-level list.

2. **`wheel.py` ignored explicit `license-files = []`** — `if metadata.license_files:`
   used truthiness, so opting out of PEP 639 license files fell into the default
   license-glob branch and shipped files METADATA did not list. Now uses
   `is not None` (matching the validation check above). Regression test:
   `test_pep639_license_files_optout`.

3. **Generated `location = "source"` files written without UTF-8** — both
   `wheel.py` and `sdist.py` wrote source-location generated files without
   `encoding="utf-8"` (unlike the build/install path), breaking non-ASCII output
   on non-UTF-8 locales (Windows). Added `encoding="utf-8"` at both sites.

4. **`_scripts.py` crashed on subdirectories in the scripts dir** —
   `process_script_dir` opened every `iterdir()` entry, suppressing only
   `UnicodeDecodeError`; a subdirectory raised `IsADirectoryError`
   (`PermissionError` on Windows). Now skips non-files. Regression test:
   `test_script_dir_with_subdirectory`.

5. **`_file_processor.py` mutated `dirs` while iterating it** — excluded
   directory names were removed from `dirs` during `for dname in dirs:`,
   skipping the next sibling so consecutive excluded dirs were not all pruned,
   letting `os.walk(followlinks=True)` descend into excluded trees. Now iterates
   `list(dirs)`. Regression test: `test_consecutive_excluded_dirs_not_descended`.

6. **`get_requires_for_build_*` resolved overrides with the wrong state** —
   `GetRequires.from_config_settings` always used the default `state="sdist"`, so
   `if.state = "wheel"`/`"editable"` overrides were ignored when computing build
   requirements for the wheel/editable hooks. Plumbed a `state` argument through
   and pass `"sdist"`/`"wheel"`/`"editable"` from the respective hooks.
   Regression test: `test_get_requires_state_override`.

## Simplifications

7. **`build/__init__.py`** — extracted the thrice-copied
   `FailedLiveProcessError` → flush → `rich_print` → `SystemExit(1)` block into
   an `_exit_on_failed_live_process` context manager, and factored the
   byte-identical wheel/editable requirement bodies into a shared
   `_get_requires_for_build_wheel` helper differing only by state.

8. **`wheel.py`** — factored the two identical `WheelWriter(...)` constructions
   (metadata-only and full-wheel paths, differing only in `folder`) into one
   `functools.partial`.

## Skipped

- **Optional `_file_processor.py` `nested_excludes` caching** — `each_unignored_file`
  runs a full `os.walk(".")` to discover nested `.gitignore`s on every call, and
  `packages_to_file_mapping` calls it once per package. Caching it cleanly would
  require module-level memoization keyed on cwd (the walk always starts at `.`
  regardless of `starting_path`), which is fragile across the test suite's
  `chdir`-based fixtures. Skipped to avoid contorting the API, as the task noted
  this was optional and "only if clean."

## Tests

Targeted suites pass:

```
tests/test_pyproject_pep517.py tests/test_file_processor.py
tests/test_get_requires.py tests/test_process_scripts.py
tests/test_prepare_metadata.py tests/test_settings_overrides.py
→ 152 passed, 1 skipped
```

`prek -a --quiet` passes ruff + mypy on the changes. The only `prek` failure is
`check-sdist`, which flags untracked worktree artifacts (`uv.lock`,
`.claude/settings.local.json`) present in this agent worktree and unrelated to
these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)