### PR TITLE
fix(settings): sources, overrides, and generated-docs bug fixes

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -223,7 +223,7 @@ print(mk_skbuild_docs())
 
 ```{eval-rst}
 .. confval:: cmake.define
-  :type: ``EnvVar``
+  :type: ``dict[str,CMakeSettingsDefine]``
 
   A table of defines to pass to CMake when configuring the project. Additive.
 ```

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -84,8 +84,9 @@ def get_display_type(field_type: type | str) -> str:
     if get_origin(field_type) is typing.Literal:
         return " | ".join(f'"{x}"' for x in get_args(field_type))
     if get_origin(field_type) is Annotated:
-        # For annotated assume we always want the second item
-        return get_display_type(get_args(field_type)[1])
+        # Display the real inner type, not the annotation metadata (e.g.
+        # ``Annotated[Dict[...], "EnvVar"]`` should show the dict, not "EnvVar").
+        return get_display_type(get_args(field_type)[0])
     if field_type is typing.Any:
         # Workaround for python<3.10 where typing.Any.__name__ does not evaluate
         return "Any"

--- a/src/scikit_build_core/settings/json_schema.py
+++ b/src/scikit_build_core/settings/json_schema.py
@@ -93,7 +93,12 @@ def to_json_schema(dclass: type[Any], *, normalize_keys: bool) -> dict[str, Any]
             field.default_factory is dataclasses.MISSING
             and field.default is dataclasses.MISSING
         ):
-            required.append(field.name)
+            # props keys are dash-normalized below when normalize_keys is set,
+            # so the required names must be normalized the same way to stay
+            # satisfiable.
+            required.append(
+                field.name.replace("_", "-") if normalize_keys else field.name
+            )
 
     if errs:
         msg = f"Failed Conversion to JSON Schema on {dclass.__name__}"

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -458,10 +458,11 @@ def process_overrides(
                         passed_all=passed_all,
                         passed_any=passed_any,
                     )
-                    inherit_override_tmp = inherit_override or "none"
-                    if isinstance(inherit_override_tmp, dict):
-                        assert not inherit_override_tmp
+                    # ``inherit`` is keyed per-table; a non-dict top-level key
+                    # has no nested inherit entry, so any inherit for it must be
+                    # a plain string (e.g. for a list-valued top-level field).
+                    inherit_for_key = inherit_override.get(key, "none")
                     tool_skb[key] = inherit_join(
-                        value, tool_skb.get(key), inherit_override_tmp
+                        value, tool_skb.get(key), inherit_for_key
                     )
     return global_matched, overridden_items

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -15,6 +15,7 @@ from .._compat import tomllib
 from .._logging import logger, rich_error, rich_print, rich_warning
 from .._variants import validate_variant_settings
 from ..errors import CMakeConfigError
+from ..utils.typing import get_target_raw_type
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .skbuild_model import CMakeSettings, NinjaSettings, ScikitBuildSettings
@@ -164,9 +165,9 @@ def _validate_overrides(
         # Check if we had a hard-coded value in the record
         conf_key = field.name.replace("_", "-")
         if field.metadata.get("override_only", False):
-            # "metadata" is the one dict-valued override-only field; has_item
-            # needs to know to use dict-presence semantics for it.
-            is_dict = field.name == "metadata"
+            # has_item needs dict-presence semantics for dict-valued fields,
+            # since some sources represent dict entries as nested keys.
+            is_dict = get_target_raw_type(field.type) is dict
             # override-only fields may be set dynamically via env vars or
             # config-settings; only static pyproject.toml values are forbidden.
             if any(
@@ -283,7 +284,11 @@ class SettingsReader:
 
         if extra_settings is not None:
             extra_skb = copy.deepcopy(dict(extra_settings))
-            process_overrides(extra_skb, state=state, env=env, retry=retry)
+            extra_matched, extra_overridden = process_overrides(
+                extra_skb, state=state, env=env, retry=retry
+            )
+            self.overrides |= extra_matched
+            self.overridden_items.update(extra_overridden)
             toml_srcs.insert(0, TOMLSource(settings=extra_skb))
 
         prefixed = {

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -190,6 +190,28 @@ def _dig_fields(opt: Any, /, *names: str) -> Any:
     return opt
 
 
+def _under_dict_field(opt: Any, names: Sequence[str], /) -> bool:
+    """
+    Return True if walking ``names`` from dataclass ``opt`` passes through a
+    dict-typed field before exhausting ``names``.
+
+    Such a path is free-form (e.g. ``metadata.version.*``), so deeper keys
+    cannot be validated against dataclass fields and must be accepted.
+    """
+    for name in names:
+        if not dataclasses.is_dataclass(opt):
+            return False
+        fields = dataclasses.fields(opt)
+        types = [x.type for x in fields if x.name == name]
+        if len(types) != 1:
+            return False
+        (opt,) = types
+        if get_target_raw_type(opt) is dict:
+            # Everything below a dict-typed field is free-form.
+            return True
+    return False
+
+
 def _nested_dataclass_to_names(
     target: type[Any] | Any, /, *inner: str
 ) -> Iterator[list[str]]:
@@ -535,7 +557,9 @@ class ConfSource(Source):
                 cls.convert(i.strip(), get_inner_type(target)) for i in item.split(";")
             ]
         if raw_target is dict:
-            assert not isinstance(item, (str, list, bool))
+            if isinstance(item, (str, list, bool)):
+                msg = f"Expected {target}, got {type(item).__name__}"
+                raise TypeError(msg)
             return {k: cls.convert(v, get_inner_type(target)) for k, v in item.items()}
         if is_union_type(raw_target):
             args = {get_target_raw_type(t): t for t in get_args(target)}
@@ -548,6 +572,20 @@ class ConfSource(Source):
                 }
             if list in args and isinstance(item, list):
                 return [cls.convert(i, get_inner_type(args[list])) for i in item]
+            # pip/uv/build deliver plain strings for ``-Cwheel.packages=...``;
+            # split them like a list (or as a dict if they contain ``=``),
+            # mirroring EnvSource and the plain-list branch above.
+            if isinstance(item, str):
+                if dict in args and "=" in item:
+                    items = (i.strip().split("=", 1) for i in item.split(";"))
+                    return {
+                        k: cls.convert(v, get_inner_type(args[dict])) for k, v in items
+                    }
+                if list in args:
+                    return [
+                        cls.convert(i.strip(), get_inner_type(args[list]))
+                        for i in item.split(";")
+                    ]
             msg = f"Can't convert into {target}"
             raise TypeError(msg)
         if isinstance(item, (list, dict)):
@@ -572,7 +610,13 @@ class ConfSource(Source):
             keys = keystr.replace("-", "_").split(".")[len(self.prefixes) :]
             try:
                 outer_option = _dig_fields(options, *keys[:-1])
-            except KeyError:
+            except (KeyError, TypeError):
+                # KeyError: an intermediate field does not exist.
+                # TypeError: an intermediate field is a dict (or other
+                # non-dataclass), so anything nested under it is free-form and
+                # cannot be a dataclass field.
+                if _under_dict_field(options, keys[:-1]):
+                    continue
                 yield ".".join(keystr.split(".")[:-1])
                 continue
             if dataclasses.is_dataclass(outer_option):
@@ -581,8 +625,12 @@ class ConfSource(Source):
                 except KeyError:
                     yield keystr
                     continue
+                continue
             if get_target_raw_type(outer_option) is dict:
                 continue
+            # Neither a dataclass field nor a dict: the final key cannot be a
+            # valid nested option (e.g. ``cmake.args.extra``).
+            yield keystr
 
     def all_option_names(self, target: type[Any]) -> Iterator[str]:
         for names in _nested_dataclass_to_names(target):
@@ -666,10 +714,11 @@ class TOMLSource(Source):
                 msg = f"Expected {target}, got {type(item).__name__}"
                 raise TypeError(msg)
             if annotations == ("EnvVar",):
+                resolved = ((k, _dict_with_envvar(v)) for k, v in item.items())
                 return {
-                    k: cls.convert(_dict_with_envvar(v), get_inner_type(target))
-                    for k, v in item.items()
-                    if _dict_with_envvar(v) is not None
+                    k: cls.convert(rv, get_inner_type(target))
+                    for k, rv in resolved
+                    if rv is not None
                 }
             return {k: cls.convert(v, get_inner_type(target)) for k, v in item.items()}
         if raw_target is Any:
@@ -685,6 +734,8 @@ class TOMLSource(Source):
                 if isinstance(item, list):
                     return [cls.convert(i, get_inner_type(args[list])) for i in item]
                 return item
+            msg = f"Expected {target}, got {type(item).__name__}"
+            raise TypeError(msg)
         if raw_target is Literal:
             if item not in get_args(process_union(target)):
                 msg = f"{item!r} not in {get_args(process_union(target))!r}"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -128,3 +128,19 @@ def test_valid_schemas(addition: dict[str, Any]) -> None:
 
     validator = api.Validator()
     validator(example)
+
+
+def test_required_names_normalized() -> None:
+    """Required field names must be dash-normalized like the prop keys when
+    normalize_keys is set, otherwise the schema would be unsatisfiable."""
+    from schema_models import HasUnderscoreRequired
+
+    from scikit_build_core.settings.json_schema import to_json_schema
+
+    schema = to_json_schema(HasUnderscoreRequired, normalize_keys=True)
+    assert schema["required"] == ["required-field"]
+    assert set(schema["required"]) <= set(schema["properties"])
+
+    schema = to_json_schema(HasUnderscoreRequired, normalize_keys=False)
+    assert schema["required"] == ["required_field"]
+    assert set(schema["required"]) <= set(schema["properties"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -148,6 +148,71 @@ def test_conf():
     assert settings.literal == "three"
 
 
+def test_conf_union_str_list():
+    # pip/uv/build pass a plain string for ``-Celeven=src/a``; it should be
+    # split like a list, matching EnvSource and the plain-list branch.
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(
+            settings={
+                "zero": "zero",
+                "one": "one",
+                "two": "2",
+                "three": ["three"],
+                "eleven": "src/a",
+            }
+        ),
+        TOMLSource(settings={}),
+    )
+    settings = sources.convert_target(SettingChecker)
+    assert settings.eleven == ["src/a"]
+
+
+def test_conf_union_str_list_multiple():
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(
+            settings={
+                "zero": "zero",
+                "one": "one",
+                "two": "2",
+                "three": ["three"],
+                "eleven": "src/a;src/b",
+            }
+        ),
+        TOMLSource(settings={}),
+    )
+    settings = sources.convert_target(SettingChecker)
+    assert settings.eleven == ["src/a", "src/b"]
+
+
+def test_conf_union_str_dict():
+    # A plain string with ``=`` should be parsed as a dict, matching EnvSource.
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(
+            settings={
+                "zero": "zero",
+                "one": "one",
+                "two": "2",
+                "three": ["three"],
+                "eleven": "a=one;b=two",
+            }
+        ),
+        TOMLSource(settings={}),
+    )
+    settings = sources.convert_target(SettingChecker)
+    assert settings.eleven == {"a": "one", "b": "two"}
+
+
+def test_conf_dict_wrong_type_raises():
+    # A scalar reaching the dict branch (e.g. ``-Cmetadata.version.provider=x``
+    # where the field is Dict[str, Dict[str, str]]) should raise a clear
+    # TypeError, not an AssertionError (which vanishes under python -O).
+    with pytest.raises(TypeError, match="Expected"):
+        ConfSource.convert("x", Dict[str, Dict[str, str]])
+
+
 def test_toml():
     toml_settings = {
         "zero": "zero",
@@ -475,6 +540,40 @@ def test_missing_opts_conf(prefixes):
     answer = ["missing", "two.missing", "other"]
     answer = [".".join([*prefixes, k]) for k in answer]
     assert list(sources.unrecognized_options(NestedSettingChecker)) == answer
+
+
+def test_unrecognized_conf_under_scalar():
+    # A key nested under a scalar field (``one.extra``) is bogus and must be
+    # reported, not silently accepted.
+    settings = {
+        "one": "one",
+        "one.extra": "x",
+        "two.literal": "two",
+    }
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(settings=settings),
+        TOMLSource(settings={}),
+    )
+    assert list(sources.unrecognized_options(NestedSettingChecker)) == ["one.extra"]
+
+
+def test_unrecognized_conf_under_dict_of_dict():
+    # Keys nested arbitrarily deep under a dict-typed field (``two.ten`` is
+    # Dict[str, Any]) are free-form and must be accepted (no TypeError, no
+    # spurious report).
+    settings = {
+        "one": "one",
+        "two.literal": "two",
+        "two.ten.foo": "x",
+        "two.ten.foo.bar": "y",
+    }
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(settings=settings),
+        TOMLSource(settings={}),
+    )
+    assert list(sources.unrecognized_options(NestedSettingChecker)) == []
 
 
 def test_ignore_conf():

--- a/tests/test_settings_docs.py
+++ b/tests/test_settings_docs.py
@@ -28,7 +28,7 @@ def test_skbuild_docs_sphinx() -> None:
     assert (
         textwrap.dedent("""\
     .. confval:: cmake.define
-      :type: ``EnvVar``
+      :type: ``dict[str,CMakeSettingsDefine]``
 
       A table of defines to pass to CMake when configuring the project. Additive.
     """)
@@ -49,7 +49,7 @@ def test_mk_docs() -> None:
     docs = set(mk_docs(ScikitBuildSettings))
 
     dcdoc = next(item for item in docs if item.name == "cmake.define")
-    assert dcdoc.type == "EnvVar"
+    assert dcdoc.type == "dict[str,CMakeSettingsDefine]"
     assert dcdoc.default == "{}"
     assert (
         dcdoc.docs

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -687,6 +687,69 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.define == {"a": "A", "b": "B", "c": "C"}
 
 
+def test_skbuild_overrides_inherit_with_scalar_key(tmp_path: Path):
+    """An override mixing inherit.<table>.<key> with a top-level scalar key
+    must not crash (previously asserted the whole inherit table was empty)."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build]
+            cmake.args = ["a", "b"]
+
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            inherit.cmake.args = "append"
+            build-dir = "mybuild"
+            cmake.args = ["c", "d"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, state="wheel")
+    settings = settings_reader.settings
+    assert settings.cmake.args == ["a", "b", "c", "d"]
+    assert settings.build_dir == "mybuild"
+
+
+def test_skbuild_overrides_in_extra_settings(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """An override-only field set via an [[overrides]] block in extra_settings
+    must validate just like the equivalent override in pyproject.toml (#1261)."""
+    caplog.set_level(logging.WARNING)
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build]
+            strict-config = true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    extra_settings = {
+        "overrides": [
+            {
+                "if": {"state": "wheel"},
+                "wheel": {"tags": ["cp312-abi3-win_amd64"]},
+            }
+        ]
+    }
+
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml,
+        state="wheel",
+        extra_settings=extra_settings,
+    )
+    settings_reader.validate_may_exit()
+    assert settings_reader.settings.wheel.tags == ["cp312-abi3-win_amd64"]
+    assert not [r for r in caplog.records if "hard-coded" in str(r.msg)]
+
+
 @pytest.mark.parametrize("from_sdist", [True, False])
 def test_skbuild_overrides_from_sdist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, from_sdist: bool

--- a/tests/utils/schema_models.py
+++ b/tests/utils/schema_models.py
@@ -1,0 +1,14 @@
+"""Helper dataclasses for JSON-schema tests.
+
+Deliberately *without* ``from __future__ import annotations`` so that field
+annotations resolve to real types (matching the settings model modules).
+"""
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class HasUnderscoreRequired:
+    """A dataclass with an underscore-named required field."""
+
+    required_field: str


### PR DESCRIPTION
Autogenerated from #1317.

:robot: _AI text below_ :robot:

Fixes a reviewed set of bugs and simplifications in the settings subsystem, each with regression tests. All findings were verified against the code before fixing; none were skipped.

## Bugs fixed

1. **`skbuild_overrides.py` — inherit + top-level scalar crash.** The non-dict override branch asserted the entire `inherit` table was empty whenever an override contained any top-level non-dict key. A schema-valid config like `inherit.cmake.args = "append"` combined with a top-level scalar (e.g. `build-dir = "mybuild"`) crashed with a bare `AssertionError`. Now uses the per-key inherit mode (`inherit_override.get(key, "none")`), which also supports a string inherit for list-valued top-level keys.

2. **`skbuild_read_settings.py` — extra_settings overrides discarded.** `process_overrides(extra_skb, ...)`'s return value was dropped, so `OverrideRecord`s and the matched-override set from `extra_settings` overrides never reached validation. An override-only field (e.g. `wheel.tags`) set via `[[overrides]]` in `extra_settings` failed with `SystemExit(7)`, unlike the identical pyproject.toml override. The records/matched set are now merged into `self.overridden_items`/`self.overrides`.

3. **`sources.py` — ConfSource union branch rejected plain strings.** `-Cwheel.packages=src/a` (what pip/uv/build deliver) raised `TypeError`, while the env var worked. The union branch now falls back to string splitting (list, or dict on `=`), matching `EnvSource` and the plain-list branch.

4. **`sources.py` — `unrecognized_options` gaps.** (a) Keys nested under a scalar field (`-Ccmake.args.extra=x`) silently passed even with strict-config; the loop now yields them. (b) Keys nested under a dict-of-dict field triggered a `TypeError` from `dataclasses.fields()` on a `Dict[...]` annotation; this path is now caught and treated as free-form via a new `_under_dict_field` helper.

5. **`sources.py` — reachable assert in dict branch.** `assert not isinstance(item, (str, list, bool))` was reachable from user input (`-Cmetadata.version.provider=x`) and vanished under `python -O`. Replaced with a clear `TypeError`.

6. **`documentation.py` — wrong displayed type for Annotated.** `get_display_type` returned the annotation metadata string, so `cmake.define` showed `:type: EnvVar`. Now recurses on the real inner type (`dict[str,CMakeSettingsDefine]`). Regenerated `docs/reference/configs.md` via `nox -t gen` (README and JSON schema were unaffected since the schema derives from the model types directly).

7. **`json_schema.py` — latent unsatisfiable schema.** Required field names were collected un-normalized while prop keys are dash-normalized when `normalize_keys=True`. A future required field with an underscore would emit an unsatisfiable schema. The appended name is now normalized the same way.

## Simplifications

8. **`skbuild_read_settings.py`** — removed the dead `is_dict = field.name == "metadata"` special case (metadata is not override-only); `is_dict` is now derived from the field type via `get_target_raw_type`.

9. **`sources.py`** — `_dict_with_envvar(v)` was evaluated twice per entry in the TOML EnvVar comprehension; it is now computed once.

Also (cosmetic): the `TOMLSource.convert` union branch now raises an explicit `TypeError` on type mismatch instead of falling through to a confusing `cannot create 'typing.Union' instances` error.

## Tests

Added regression tests in `tests/test_settings.py`, `tests/test_settings_overrides.py`, `tests/test_schema.py`, and updated `tests/test_settings_docs.py` for the corrected `cmake.define` type. Each new test was verified to fail against the unpatched source and pass with the fix.

```
tests/test_settings.py tests/test_settings_overrides.py tests/test_schema.py tests/test_settings_docs.py tests/test_json_schema.py
194 passed
```

`prek -a --quiet` passes (ruff, mypy, etc.); the only remaining hook noise is `check-sdist` flagging pre-existing worktree-local files (`.claude/settings.local.json`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
