### PR TITLE
ci: pin old-CMake Windows rows to windows-2022, add a VS 2026 row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,16 +100,23 @@ jobs:
           - python-version: "3.8"
             runs-on: windows-2022
             cmake-version: "3.24.x"
+          # CMake < 4.2 cannot detect Visual Studio 2026, so rows testing older
+          # CMake versions need the VS 2022 image: windows-latest and
+          # windows-2025 are both migrating to VS 2026 by default
+          # (https://github.com/actions/runner-images/issues/14017).
           - python-version: "3.12"
-            runs-on: windows-latest
+            runs-on: windows-2022
             cmake-version: "3.26.x"
             architecture: x86
           - python-version: "3.14"
-            runs-on: windows-latest
+            runs-on: windows-2022
             cmake-version: "4.0.x"
           - python-version: "3.13"
-            runs-on: windows-latest
+            runs-on: windows-2022
             cmake-version: "3.26.x"
+          - python-version: "3.14"
+            runs-on: windows-2025-vs2026
+            cmake-version: "4.2.x"
           - python-version: "3.8"
             runs-on: ubuntu-22.04
             cmake-version: "3.15.x"
@@ -177,7 +184,10 @@ jobs:
       matrix:
         python-version: ["3.8", "3.11"]
         # TODO: investigate failure with macos-latest (#1167)
-        runs-on: [ubuntu-latest, macos-15-intel, windows-latest]
+        # windows-2022: this job uses CMake 3.21, which cannot detect VS 2026;
+        # windows-latest/windows-2025 are migrating to VS 2026 by default
+        # (https://github.com/actions/runner-images/issues/14017).
+        runs-on: [ubuntu-latest, macos-15-intel, windows-2022]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
:robot: _AI text below_ :robot:

GitHub began rolling `windows-latest` from `windows-2025` to **`windows-2025-vs2026`** (first seen here on image version 20260608.135.2), whose only Visual Studio is VS 2026 — and per actions/runner-images#14017 the `windows-2025` label will also migrate to VS 2026 by default, so `windows-2022` is the durable label for VS 2022. CMake only gained the `Visual Studio 18 2026` generator in **CMake 4.2**, so matrix rows testing older CMake (3.21.x–4.0.x) find no usable Visual Studio on the new image, fall back to `NMake Makefiles`, and fail with `CMAKE_C_COMPILER not set, after EnableLanguage` (`nmake` isn't on PATH). This is what broke the Windows jobs on #1325 — main fails the same way if re-run on the new image.

Diagnosis details: the failures only hit flows that use the PATH CMake from `actions-setup-cmake`; flows resolving the pip `cmake` wheel (4.3.2, which knows VS 2026) passed, as did the pinned `windows-2022` rows and the toolchain-independent cygwin/msys/mingw64 jobs.

Changes:
- Pin the three `windows-latest` checks rows (CMake 3.26.x ×2, 4.0.x) and the `min` job (CMake 3.21 on Windows) to `windows-2022` — old CMake versions will never support VS 2026, so these rows structurally require the VS 2022 image.
- Add one new checks row: Python 3.14, CMake 4.2.x on `windows-2025-vs2026` for forward coverage of the new image.
- cygwin/msys/mingw64 stay on `windows-latest` (own toolchains, passing on the new image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)