### PR TITLE
ci: exclude pytest 9.1.0 (params-fixture override regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ test-core = [
     "hatch-vcs >=0.4",
     "pip>=23; python_version<'3.13'",
     "pip>=24.1; python_version>='3.13'",
-    "pytest >=7.2",
+    "pytest >=7.2,!=9.1.0",  # 9.1.0 regression overriding params-fixtures: pytest-dev/pytest#13974
     "pytest-subprocess >=1.5",
     'setuptools >=43; python_version<"3.9"',
     'setuptools >=45; python_version=="3.9"',


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

pytest 9.1.0 shipped a regression ([pytest-dev/pytest#13974](https://github.com/pytest-dev/pytest/issues/13974), fixed upstream in [#13976](https://github.com/pytest-dev/pytest/pull/13976), landing in 9.1.1) where overriding a `params=`-fixture via `@pytest.mark.parametrize(..., indirect=True)` raises `duplicate parametrization` at collection time.

Because our config sets `filterwarnings = ["error"]` and these surface as collection errors, the suite hard-fails on the three tests that override the `editable` fixture (defined with `params=[None, "redirect", "inplace"]` in `tests/conftest.py`):

- `test_editable.py::test_cython_pxd`
- `test_editable_generated.py::test_generated_files`
- `test_pyproject_pep660.py::test_pep660_wheel`

## Fix

Pin `pytest >=7.2,!=9.1.0` in the `test-core` dependency group. The exclusion is narrow: 9.1.1+ (with the upstream fix) is allowed once released. No test code changes needed.

Verified collection is clean (622 tests, no errors) with the pin applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)