### PR TITLE
fix: strip flags from sysconfig CC/CXX to just the executable

### DIFF
--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 import sys
 import sysconfig
@@ -109,16 +110,19 @@ def set_environment_for_gen(
         env.setdefault("CMAKE_GENERATOR_PLATFORM", get_cmake_platform(env))
         return {}
 
-    # Set Python's recommended CC and CXX if not already set by the user
+    # Set Python's recommended CC and CXX if not already set by the user. Only
+    # the executable is kept; sysconfig may append flags (e.g. "c++ -pthread"),
+    # which would otherwise leak into tools like autotools sub-builds. CMake adds
+    # any flags it needs itself. See #1330.
     if "CC" not in env:
         cc = sysconfig.get_config_var("CC")
         if cc:
-            env["CC"] = cc
+            env["CC"] = shlex.split(cc)[0]
 
     if "CXX" not in env:
         cxx = sysconfig.get_config_var("CXX")
         if cxx:
-            env["CXX"] = cxx
+            env["CXX"] = shlex.split(cxx)[0]
 
     if "Ninja" in (generator or "Ninja"):
         ninja = best_program(get_ninja_programs(), version=ninja_settings.version)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -622,6 +622,32 @@ def test_set_environment_for_gen_ninja_variants(
     assert env["CMAKE_GENERATOR"] == generator
 
 
+def test_set_environment_for_gen_strips_cc_cxx_flags(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # sysconfig may report CC/CXX with trailing flags (e.g. "c++ -pthread").
+    # Only the executable should be exported, so flags don't leak into tools
+    # like autotools sub-builds. See #1330.
+    from scikit_build_core.builder import generator as gen_mod
+    from scikit_build_core.program_search import Program
+    from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+    fake_ninja = Program(Path("/usr/bin/ninja"), Version("1.11.0"))
+    monkeypatch.setattr(gen_mod, "get_ninja_programs", lambda: [fake_ninja])
+    config_vars = {"CC": "gcc -pthread", "CXX": "c++ -pthread"}
+    monkeypatch.setattr(gen_mod.sysconfig, "get_config_var", config_vars.get)
+
+    env: dict[str, str] = {}
+    gen_mod.set_environment_for_gen(
+        "Ninja",
+        CMake(Version("3.30"), Path("cmake")),
+        env,
+        NinjaSettings(),
+    )
+    assert env["CC"] == "gcc"
+    assert env["CXX"] == "c++"
+
+
 def test_set_environment_for_gen_ninja_multi_config_missing(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -635,7 +635,7 @@ def test_set_environment_for_gen_strips_cc_cxx_flags(
     fake_ninja = Program(Path("/usr/bin/ninja"), Version("1.11.0"))
     monkeypatch.setattr(gen_mod, "get_ninja_programs", lambda: [fake_ninja])
     config_vars = {"CC": "gcc -pthread", "CXX": "c++ -pthread"}
-    monkeypatch.setattr(gen_mod.sysconfig, "get_config_var", config_vars.get)
+    monkeypatch.setattr(sysconfig, "get_config_var", config_vars.get)
 
     env: dict[str, str] = {}
     gen_mod.set_environment_for_gen(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

When migrating from `scikit-build` to `scikit-build-core`, an autotools `ExternalProject` received `CXX=c++ -pthread` (or `CC=gcc -pthread`) where it was previously empty. This comes from `set_environment_for_gen` in `builder/generator.py`, which exports `sysconfig.get_config_var("CC"/"CXX")` verbatim. On some Python builds (e.g. the `uv`-provided CPython, and Debian/Ubuntu system Python) those config vars include trailing flags like `-pthread`.

CMake parses such strings fine and adds the flags it needs itself, but tools that consume `CXX` literally — like autotools sub-builds — break when the value is a compiler *plus flags*.

Closes #1330

## Fix

Keep only the executable using `shlex.split(value)[0]` when exporting `CC`/`CXX`. `CXXFLAGS`/`CFLAGS` are the right place for flags, so dropping them here matches expectations and CMake re-adds whatever it requires.

## Test

Added `test_set_environment_for_gen_strips_cc_cxx_flags` covering `"gcc -pthread"` → `"gcc"` and `"c++ -pthread"` → `"c++"`.