### PR TITLE
refactor: rename editable files to _editable_skbc_<name>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,9 +182,9 @@ The project vendors a copy of `pyproject_metadata` (`_vendor/`) to parse the
 
 Two modes are supported:
 
-- **redirect** (default): A `.pth` file loads an `_editable_skbc_<pkg>.py` redirect
-  shim (from `resources/_editable_redirect.py`) that uses `sys.meta_path` to map
-  imports. Optionally triggers CMake rebuild on import if
+- **redirect** (default): A `.pth` file loads an `_editable_skbc_<pkg>.py`
+  redirect shim (from `resources/_editable_redirect.py`) that uses
+  `sys.meta_path` to map imports. Optionally triggers CMake rebuild on import if
   `editable.rebuild = true`.
 - **inplace**: A simple `.pth` file pointing at the source package directories.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ The project vendors a copy of `pyproject_metadata` (`_vendor/`) to parse the
 
 Two modes are supported:
 
-- **redirect** (default): A `.pth` file loads an `_<pkg>_editable.py` redirect
+- **redirect** (default): A `.pth` file loads an `_editable_skbc_<pkg>.py` redirect
   shim (from `resources/_editable_redirect.py`) that uses `sys.meta_path` to map
   imports. Optionally triggers CMake rebuild on import if
   `editable.rebuild = true`.

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -113,23 +113,27 @@ def editable_redirect_files(
         as_entrypoint=use_start,
     )
     package_paths = tuple(packages)
-    files = {f"_{name}_editable.py": editable_txt.encode()}
+    files = {f"_editable_skbc_{name}.py": editable_txt.encode()}
     if use_start:
         # PEP 829: the import callable lives in a UTF-8-sig encoded .start file,
         # and the .pth carries only sys.path entries (if any).
-        files[f"_{name}_editable.start"] = f"_{name}_editable:entrypoint".encode(
-            "utf-8-sig"
+        files[f"_editable_skbc_{name}.start"] = (
+            f"_editable_skbc_{name}:entrypoint".encode("utf-8-sig")
         )
         if package_paths:
-            files[f"_{name}_editable.pth"] = "\n".join([*package_paths, ""]).encode()
+            files[f"_editable_skbc_{name}.pth"] = "\n".join(
+                [*package_paths, ""]
+            ).encode()
     else:
-        pth_import_paths = "\n".join([f"import _{name}_editable", *package_paths, ""])
-        files[f"_{name}_editable.pth"] = pth_import_paths.encode()
+        pth_import_paths = "\n".join(
+            [f"import _editable_skbc_{name}", *package_paths, ""]
+        )
+        files[f"_editable_skbc_{name}.pth"] = pth_import_paths.encode()
     return files
 
 
 def editable_inplace_files(*, name: str, packages: Iterable[str]) -> dict[str, bytes]:
-    return {f"_{name}_editable.pth": "\n".join(packages).encode()}
+    return {f"_editable_skbc_{name}.pth": "\n".join(packages).encode()}
 
 
 def get_packages(

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -188,8 +188,10 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
         install_dir="",
     )
 
-    site_packages.joinpath("_pkg_editable.py").write_text(editable_txt)
-    site_packages.joinpath("_pkg_editable.pth").write_text("import _pkg_editable\n")
+    site_packages.joinpath("_editable_skbc_pkg.py").write_text(editable_txt)
+    site_packages.joinpath("_editable_skbc_pkg.pth").write_text(
+        "import _editable_skbc_pkg\n"
+    )
 
     # Test the editable install
     virtualenv.execute("import pkg.subpkg")
@@ -219,14 +221,14 @@ def test_editable_redirect_files_legacy_pth(tmp_path: Path):
         use_start=False,
     )
 
-    assert set(files) == {"_pkg_editable.py", "_pkg_editable.pth"}
-    assert "_pkg_editable.start" not in files
+    assert set(files) == {"_editable_skbc_pkg.py", "_editable_skbc_pkg.pth"}
+    assert "_editable_skbc_pkg.start" not in files
 
-    pth = files["_pkg_editable.pth"].decode()
-    assert pth.splitlines()[0] == "import _pkg_editable"
+    pth = files["_editable_skbc_pkg.pth"].decode()
+    assert pth.splitlines()[0] == "import _editable_skbc_pkg"
     assert str(tmp_path / "src") in pth
 
-    py = files["_pkg_editable.py"].decode()
+    py = files["_editable_skbc_pkg.py"].decode()
     assert "\ninstall(" in py
     assert "def entrypoint()" not in py
 
@@ -243,23 +245,23 @@ def test_editable_redirect_files_pep829_start(tmp_path: Path):
     )
 
     assert set(files) == {
-        "_pkg_editable.py",
-        "_pkg_editable.pth",
-        "_pkg_editable.start",
+        "_editable_skbc_pkg.py",
+        "_editable_skbc_pkg.pth",
+        "_editable_skbc_pkg.start",
     }
 
     # PEP 829 mandates UTF-8-sig (BOM) for .start files
-    start = files["_pkg_editable.start"]
-    assert start == "_pkg_editable:entrypoint".encode("utf-8-sig")
+    start = files["_editable_skbc_pkg.start"]
+    assert start == "_editable_skbc_pkg:entrypoint".encode("utf-8-sig")
     assert start.startswith(b"\xef\xbb\xbf")
 
     # The .pth keeps only the sys.path entries, no import line
-    pth = files["_pkg_editable.pth"].decode()
-    assert "import _pkg_editable" not in pth
+    pth = files["_editable_skbc_pkg.pth"].decode()
+    assert "import _editable_skbc_pkg" not in pth
     assert str(tmp_path / "src") in pth
 
     # The import is now a zero-argument entrypoint, not run at import time
-    py = files["_pkg_editable.py"].decode()
+    py = files["_editable_skbc_pkg.py"].decode()
     assert "def entrypoint() -> None:" in py
     assert "\ninstall(" not in py
 
@@ -276,4 +278,4 @@ def test_editable_redirect_files_pep829_no_paths(tmp_path: Path):
         use_start=True,
     )
 
-    assert set(files) == {"_pkg_editable.py", "_pkg_editable.start"}
+    assert set(files) == {"_editable_skbc_pkg.py", "_editable_skbc_pkg.start"}

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -131,14 +131,14 @@ def test_hatchling_editable_wheel(editable_mode: str, tmp_path: Path) -> None:
         # always emitted (in pep829 redirect mode it carries only the paths).
         pth_lines = [
             ln
-            for ln in f.read("_hatchling_example_editable.pth")
+            for ln in f.read("_editable_skbc_hatchling_example.pth")
             .decode("utf-8")
             .splitlines()
             if ln
         ]
         start_contents = (
-            f.read("_hatchling_example_editable.start")
-            if "_hatchling_example_editable.start" in file_names
+            f.read("_editable_skbc_hatchling_example.start")
+            if "_editable_skbc_hatchling_example.start" in file_names
             else None
         )
         wheel_metadata = f.read("hatchling_example-0.1.0.dist-info/WHEEL").decode(
@@ -149,22 +149,23 @@ def test_hatchling_editable_wheel(editable_mode: str, tmp_path: Path) -> None:
     pep829 = sys.version_info >= (3, 15)
 
     assert "hatchling_example-0.1.0.dist-info/METADATA" in file_names
-    assert "_hatchling_example_editable.pth" in file_names
+    assert "_editable_skbc_hatchling_example.pth" in file_names
     assert "Root-Is-Purelib: false" in wheel_metadata
     if editable_mode == "redirect":
-        assert "_hatchling_example_editable.py" in file_names
+        assert "_editable_skbc_hatchling_example.py" in file_names
         assert f"hatchling_example/_core{ext_suffix}" in file_names
         if pep829:
-            assert start_contents == "_hatchling_example_editable:entrypoint".encode(
-                "utf-8-sig"
+            assert (
+                start_contents
+                == "_editable_skbc_hatchling_example:entrypoint".encode("utf-8-sig")
             )
             # The .pth keeps only the path entries, no import line
             assert Path(pth_lines[0]).resolve().samefile(Path("src").resolve())
         else:
             assert start_contents is None
-            assert pth_lines[0] == "import _hatchling_example_editable"
+            assert pth_lines[0] == "import _editable_skbc_hatchling_example"
     else:
-        assert "_hatchling_example_editable.py" not in file_names
+        assert "_editable_skbc_hatchling_example.py" not in file_names
         assert start_contents is None
         assert f"hatchling_example/_core{ext_suffix}" not in file_names
         assert Path(pth_lines[0]).resolve().samefile(Path("src").resolve())

--- a/tests/test_pyproject_pep660.py
+++ b/tests/test_pyproject_pep660.py
@@ -41,13 +41,13 @@ def test_pep660_wheel(editable, tmp_path: Path):
     assert "simplest-0.0.1.dist-info" in file_names
     if editable.mode == "redirect":
         assert "simplest" in file_names
-        assert "_simplest_editable.py" in file_names
-        assert ("_simplest_editable.start" in file_names) == pep829
+        assert "_editable_skbc_simplest.py" in file_names
+        assert ("_editable_skbc_simplest.start" in file_names) == pep829
     else:
         assert "simplest" not in file_names
-        assert "_simplest_editable.py" not in file_names
-        assert "_simplest_editable.start" not in file_names
-    assert "_simplest_editable.pth" in file_names
+        assert "_editable_skbc_simplest.py" not in file_names
+        assert "_editable_skbc_simplest.start" not in file_names
+    assert "_editable_skbc_simplest.pth" in file_names
 
     assert "Metadata-Version: 2.2" in metadata
     assert "Name: simplest" in metadata


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Renames the editable redirect output files from `_<name>_editable.*` to `_editable_skbc_<name>.*`, per #1327.

## Why

The `editables` library (used by hatchling/flit) names its finder modules `_editable_impl_<name>`. Aligning to a similar shape:

- Makes our finder recognizable as an editable shim, paving the way for an upstream pytest fix that broadens the [`__editable__`-only assert-rewrite filter](https://github.com/pytest-dev/pytest/blob/0d8491a4ecf971800de0479ef55c7f5292c54937/src/_pytest/config/__init__.py#L992) to also skip `_editable_*` finders.
- The `_skbc_` infix avoids collisions when scikit-build-core is itself a plugin installed alongside another `editables`-based package.

## Changes

- `build/_editable.py`: `.py`, `.pth`, `.start` filenames, the `import _editable_skbc_<name>` line, and the `_editable_skbc_<name>:entrypoint` start target.
- Tests updated: `test_editable_unit.py`, `test_hatchling.py`, `test_pyproject_pep660.py`.
- `AGENTS.md` architecture note updated.

## Notes

- The companion pytest filter change is upstream and out of scope here.
- This is a behavior change for existing editable installs: the old `_<name>_editable.pth` is orphaned until the package is reinstalled.

Closes #1327