### PR TITLE
chore: remove 'orjson' from dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,6 @@ repos:
           - markdown-it-py
           - ninja
           - nox
-          - orjson
           - packaging>=24.2
           - pathspec>=1.1
           - pytest<9 # pytest 9 requires Python 3.10+


### PR DESCRIPTION
No longer needed by mypy (switched to sqlite), causes failures on free-threaded Python too.