### PR TITLE
fix: editable install adds symlinked module's real dir to __path__ (#647)

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -166,7 +166,13 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
         module = path_to_module(rel)
         # Prefer .py/.pyc over other extensions (e.g. .pxd, .pyx) for the same module
         if module not in result or rel.suffix in (".py", ".pyc"):
-            result[module] = str(Path(k).resolve())
+            # Make the source path absolute, but do NOT resolve symlinks: the
+            # redirect finder derives a package's submodule_search_locations from
+            # the dirname of this path. A symlinked-in module (e.g. a monorepo
+            # file linked into a package) must keep its in-package directory, or
+            # the symlink target's real directory would be wrongly added to the
+            # parent package's __path__, exposing unrelated files there (#647).
+            result[module] = str(Path(k).absolute())
     return result
 
 

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -166,12 +166,7 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
         module = path_to_module(rel)
         # Prefer .py/.pyc over other extensions (e.g. .pxd, .pyx) for the same module
         if module not in result or rel.suffix in (".py", ".pyc"):
-            # Make the source path absolute, but do NOT resolve symlinks: the
-            # redirect finder derives a package's submodule_search_locations from
-            # the dirname of this path. A symlinked-in module (e.g. a monorepo
-            # file linked into a package) must keep its in-package directory, or
-            # the symlink target's real directory would be wrongly added to the
-            # parent package's __path__, exposing unrelated files there (#647).
+            # Make the source path absolute, but do not resolve symlinks
             result[module] = str(Path(k).absolute())
     return result
 

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -275,3 +275,34 @@ def test_mapping_to_modules_prefers_py():
 
     # Bug 3: .py should win over .pxd (currently .pxd overwrites .py)
     assert result["pkg"].endswith("__init__.py")
+
+
+def test_mapping_to_modules_keeps_symlink_in_package_dir(tmp_path: Path):
+    """A symlinked-in module keeps its in-package directory, not the link target (#647)."""
+    from scikit_build_core.build._editable import mapping_to_modules
+
+    # A monorepo layout: shared/shared_mod.py is symlinked into src/pkg/.
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "shared_mod.py").write_text("value = 1\n")
+    # An unrelated sibling file that must NOT become importable as pkg.unrelated.
+    (shared / "unrelated.py").write_text("value = 2\n")
+
+    pkg_src = tmp_path / "src" / "pkg"
+    pkg_src.mkdir(parents=True)
+    (pkg_src / "__init__.py").touch()
+    symlink = pkg_src / "shared_mod.py"
+    symlink.symlink_to(shared / "shared_mod.py")
+
+    libdir = tmp_path / "site-packages"
+    mapping = {
+        str(pkg_src / "__init__.py"): str(libdir / "pkg/__init__.py"),
+        str(symlink): str(libdir / "pkg/shared_mod.py"),
+    }
+    result = mapping_to_modules(mapping, libdir)
+
+    # The recorded source path must stay inside the package (the symlink path),
+    # not point at the resolved target dir (shared/), which would otherwise leak
+    # into pkg.__path__ and make shared/unrelated.py importable as pkg.unrelated.
+    assert Path(result["pkg.shared_mod"]).parent == pkg_src
+    assert Path(result["pkg.shared_mod"]).parent != shared.resolve()


### PR DESCRIPTION
Subtle. Needs the overly long comments trimmed.

:robot: _AI text below_ :robot:

In editable (redirect) installs, a symlinked-in module had its source path recorded via `Path(k).resolve()` in `mapping_to_modules`. Resolving the symlink meant the link target's *real* directory was used to derive the parent package's `submodule_search_locations`. As a result, an unrelated, never-symlinked file in that real directory became wrongly importable as a submodule, and `pkg.__path__` contained a foreign directory.

This is common in monorepo layouts (see #362) where a package directory shares a name with a monorepo directory and files are symlinked in from outside the package.

The fix swaps `Path(k).resolve()` for `Path(k).absolute()`, which makes the source path absolute without following symlinks, so the in-package directory is preserved. The module is still importable by its in-package name; only the `__path__`/submodule search location changes. Legitimate nested packages are unaffected (their paths contain no symlinks to resolve).

Fixes #647

## Testing

Added a focused unit regression test `test_mapping_to_modules_keeps_symlink_in_package_dir` in `tests/test_editable_redirect.py`. It builds a monorepo layout with `shared/shared_mod.py` symlinked into `src/pkg/` and asserts the recorded source path's parent stays the in-package directory rather than the resolved `shared/` target. Confirmed it fails before the fix and passes after; neighboring editable tests (`tests/test_editable_redirect.py`, `tests/test_editable_unit.py`) still pass.