### PR TITLE
fix: dereference file symlinks when building sdist (#801)

### DIFF
--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -149,11 +149,23 @@ def build_sdist(
             )
         )
         for filepath in paths:
-            tar.add(
-                filepath,
-                arcname=srcdirname / filepath,
-                filter=normalize_tar_info if reproducible else lambda x: x,
-            )
+            arcname = srcdirname / filepath
+            filter_fn = normalize_tar_info if reproducible else lambda x: x
+            # Dereference file symlinks so the sdist contains real file content
+            # instead of a dangling symlink (directory symlinks are already
+            # followed by os.walk(followlinks=True) in the file collector).
+            if filepath.is_symlink() and filepath.resolve().is_file():
+                resolved = filepath.resolve()
+                tarinfo = tar.gettarinfo(str(resolved), arcname=str(arcname))
+                tarinfo = filter_fn(tarinfo)
+                with resolved.open("rb") as fobj:
+                    tar.addfile(tarinfo, fobj)
+            else:
+                tar.add(
+                    filepath,
+                    arcname=arcname,
+                    filter=filter_fn,
+                )
 
         add_bytes_to_tar(
             tar, pkg_info, f"{srcdirname}/PKG-INFO", normalize=reproducible

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -500,3 +500,57 @@ def test_pep639_license_files_optout(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     assert not any("dist-info/licenses/" in n for n in names)
     assert "License-File:" not in metadata
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows symlinks require elevated privileges",
+)
+def test_sdist_dereferences_file_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """File symlinks in the source tree must be stored as real files in the sdist
+    (regression test for #801)."""
+    src = tmp_path / "src"
+    src.mkdir()
+
+    # A real file one level above the package directory (simulates the original report)
+    real_file = tmp_path / "some-file.txt"
+    real_file.write_text("real content\n")
+
+    pyproject = src / "pyproject.toml"
+    pyproject.write_text(
+        inspect.cleandoc(
+            """
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "symlink_test"
+            version = "0.1.0"
+
+            [tool.scikit-build]
+            sdist.cmake = false
+            sdist.include = ["some-file.txt"]
+            """
+        )
+    )
+
+    # A file symlink pointing outside the package directory
+    link = src / "some-file.txt"
+    link.symlink_to("../some-file.txt")
+
+    monkeypatch.chdir(src)
+
+    dist = tmp_path / "dist"
+    out = build_sdist(str(dist))
+
+    sdist = dist / out
+    with tarfile.open(sdist) as tf:
+        member = tf.getmember("symlink_test-0.1.0/some-file.txt")
+        # Must be a regular file, not a symlink
+        assert member.isreg(), f"Expected regular file, got type {member.type!r}"
+        content = tf.extractfile(member)
+        assert content is not None
+        assert content.read() == b"real content\n"


### PR DESCRIPTION
I'm not sure we want to do this - and if we do, likely we want it as an option. Putting this here to see what it looks like. Edit: duplicate of #1265.
:robot: _AI text below_ :robot:

## Summary

- File symlinks in the source tree were stored as-is in the sdist tarball, producing dangling symlinks after extraction when the symlink target lived outside the sdist directory.
- The fix detects file symlinks in the tar-assembly loop (`build/sdist.py`) and adds the resolved file content as a regular file entry, instead of delegating to `tarfile.add()` which preserves symlinks by default.
- Directory symlinks continue to be followed transparently by `os.walk(followlinks=True)` in the file collector (the existing behaviour from the earlier fix for #359).

Fixes #801

## Testing

- Added `test_sdist_dereferences_file_symlinks` in `tests/test_pyproject_pep517.py`: creates a minimal package with a file symlink pointing outside the package directory, builds the sdist, then asserts the entry in the tarball is a regular file (`isreg()`) with the expected content — not a symlink.
- Test is skipped on Windows (symlinks require elevated privileges there).