### PR TITLE
fix: don't treat versioned sonames as importable modules in editable installs (#1144)

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from ..resources import resources
 from ._pathutil import (
+    is_module,
     is_valid_module,
     module_loader_rank,
     path_to_module,
@@ -20,6 +21,7 @@ if typing.TYPE_CHECKING:
     from ..settings.skbuild_model import ScikitBuildSettings
 
 __all__ = [
+    "collect_search_locations",
     "editable_inplace_files",
     "editable_redirect",
     "editable_redirect_files",
@@ -37,6 +39,8 @@ def editable_redirect(
     *,
     modules: dict[str, str],
     installed: dict[str, str],
+    directories: dict[str, list[str]],
+    packages: Sequence[str],
     reload_dir: Path | None,
     rebuild: bool,
     verbose: bool,
@@ -59,6 +63,8 @@ def editable_redirect(
     arguments = (
         modules,
         installed,
+        directories,
+        list(packages),
         os.fspath(reload_dir) if reload_dir else None,
         rebuild,
         verbose,
@@ -99,12 +105,15 @@ def editable_redirect_files(
         use_start = sys.version_info >= (3, 15)
     modules = mapping_to_modules(mapping, libdir)
     installed = libdir_to_installed(libdir)
+    directories, known_packages = collect_search_locations(mapping, libdir)
     if settings.editable.rebuild and settings.wheel.install_dir.startswith("/"):
         msg = "Editable installs cannot rebuild an absolute wheel.install-dir. Use an override to change if needed."
         raise AssertionError(msg)
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,
+        directories=directories,
+        packages=known_packages,
         reload_dir=reload_dir,
         rebuild=settings.editable.rebuild,
         verbose=settings.editable.verbose,
@@ -161,13 +170,17 @@ def get_packages(
 
 def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     """
-    Convert a mapping of files to modules to a mapping of modules to installed files.
+    Map importable module names to their (absolute) source files.
+
+    Only importable files are included; data/resource files are tracked
+    separately by :func:`collect_search_locations` so that ``find_spec`` never
+    resolves a name to a non-importable file.
     """
     result: dict[str, str] = {}
     selected: dict[str, Path] = {}
     for k, v in mapping.items():
         rel = Path(v).relative_to(libdir)
-        if not is_valid_module(rel):
+        if not is_valid_module(rel) or not is_module(rel):
             continue
         module = path_to_module(rel)
         if module in result and not _prefer_module(rel, selected[module]):
@@ -180,13 +193,16 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
 
 def libdir_to_installed(libdir: Path) -> dict[str, str]:
     """
-    Convert a mapping of files to modules to a mapping of modules to installed files.
+    Map importable module names to their installed files (relative to ``libdir``).
+
+    Only importable files are included; data/resource files are tracked
+    separately by :func:`collect_search_locations`.
     """
     result: dict[str, str] = {}
     selected: dict[str, Path] = {}
     for v in scantree(libdir):
         pth = v.relative_to(libdir)
-        if not is_valid_module(pth):
+        if not is_valid_module(pth) or not is_module(pth):
             continue
         module = path_to_module(pth)
         if module in result and not _prefer_module(pth, selected[module]):
@@ -194,6 +210,65 @@ def libdir_to_installed(libdir: Path) -> dict[str, str]:
         result[module] = str(pth)
         selected[module] = pth
     return result
+
+
+def collect_search_locations(
+    mapping: dict[str, str], libdir: Path
+) -> tuple[dict[str, list[str]], list[str]]:
+    """
+    Build the package search-location map and the list of regular packages.
+
+    Every tracked file -- importable modules *and* data/resource files -- adds
+    its directory to its package's ``__path__``, so ``importlib.resources`` can
+    reach data even in a directory that holds no importable module (e.g. CMake
+    installs only data into a package dir). This is kept separate from the
+    module-resolution maps so a non-importable file is never returned as a
+    module's origin.
+
+    Source-tree directories are absolute; install-tree directories are relative
+    to ``libdir`` (the redirect joins them with the install location at runtime).
+    Returns ``(directories, packages)`` where ``packages`` are the modules whose
+    directory holds an ``__init__`` (including ``.pxd``/``.pyx`` ones).
+    """
+    directories: dict[str, set[str]] = {}
+    packages: set[str] = set()
+
+    def add(module: str, directory: str, *, is_init: bool) -> None:
+        if is_init:
+            packages.add(module)
+            parent = module
+        else:
+            parent = module.rpartition(".")[0]
+        if parent:
+            directories.setdefault(parent, set()).add(directory)
+
+    # Source tree: register the (absolute) source file's parent directory.
+    for source, target in mapping.items():
+        rel = Path(target).relative_to(libdir)
+        if not is_valid_module(rel):
+            continue
+        source_path = Path(source).absolute()
+        add(
+            path_to_module(rel),
+            str(source_path.parent),
+            is_init=_is_init(source_path.name),
+        )
+
+    # Install tree: register the directory relative to libdir.
+    for v in scantree(libdir):
+        rel = v.relative_to(libdir)
+        if not is_valid_module(rel):
+            continue
+        add(path_to_module(rel), str(rel.parent), is_init=_is_init(rel.name))
+
+    return (
+        {pkg: sorted(dirs) for pkg, dirs in directories.items()},
+        sorted(packages),
+    )
+
+
+def _is_init(name: str) -> bool:
+    return name.partition(".")[0] == "__init__"
 
 
 def _prefer_module(candidate: Path, current: Path) -> bool:

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ..resources import resources
 from ._pathutil import (
     is_module,
-    is_valid_module,
+    is_trackable,
     module_loader_rank,
     path_to_module,
     scantree,
@@ -180,7 +180,7 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     selected: dict[str, Path] = {}
     for k, v in mapping.items():
         rel = Path(v).relative_to(libdir)
-        if not is_valid_module(rel) or not is_module(rel):
+        if not is_trackable(rel) or not is_module(rel):
             continue
         module = path_to_module(rel)
         if module in result and not _prefer_module(rel, selected[module]):
@@ -202,7 +202,7 @@ def libdir_to_installed(libdir: Path) -> dict[str, str]:
     selected: dict[str, Path] = {}
     for v in scantree(libdir):
         pth = v.relative_to(libdir)
-        if not is_valid_module(pth) or not is_module(pth):
+        if not is_trackable(pth) or not is_module(pth):
             continue
         module = path_to_module(pth)
         if module in result and not _prefer_module(pth, selected[module]):
@@ -228,10 +228,22 @@ def collect_search_locations(
     ``libdir``. Returns ``(directories, packages)`` where ``packages`` are the
     modules whose directory holds an ``__init__`` (including ``.pxd``/``.pyx``).
     """
+    # Collect (module, directory, is_init) entries. Source tree: the absolute
+    # source file's parent. Install tree: the directory relative to libdir.
+    entries: list[tuple[str, str, bool]] = []
+    for source, target in mapping.items():
+        rel = Path(target).relative_to(libdir)
+        if is_trackable(rel):
+            src = Path(source).absolute()
+            entries.append((path_to_module(rel), str(src.parent), _is_init(src.name)))
+    for v in scantree(libdir):
+        rel = v.relative_to(libdir)
+        if is_trackable(rel):
+            entries.append((path_to_module(rel), str(rel.parent), _is_init(rel.name)))
+
     directories: dict[str, set[str]] = {}
     packages: set[str] = set()
-
-    def add(module: str, directory: str, *, is_init: bool) -> None:
+    for module, directory, is_init in entries:
         if is_init:
             packages.add(module)
             parent = module
@@ -239,25 +251,6 @@ def collect_search_locations(
             parent = module.rpartition(".")[0]
         if parent:
             directories.setdefault(parent, set()).add(directory)
-
-    # Source tree: register the (absolute) source file's parent directory.
-    for source, target in mapping.items():
-        rel = Path(target).relative_to(libdir)
-        if not is_valid_module(rel):
-            continue
-        source_path = Path(source).absolute()
-        add(
-            path_to_module(rel),
-            str(source_path.parent),
-            is_init=_is_init(source_path.name),
-        )
-
-    # Install tree: register the directory relative to libdir.
-    for v in scantree(libdir):
-        rel = v.relative_to(libdir)
-        if not is_valid_module(rel):
-            continue
-        add(path_to_module(rel), str(rel.parent), is_init=_is_init(rel.name))
 
     return (
         {pkg: sorted(dirs) for pkg, dirs in directories.items()},

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ..resources import resources
 from ._pathutil import (
     is_valid_module,
+    module_loader_rank,
     path_to_module,
     scantree,
 )
@@ -163,15 +164,17 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     Convert a mapping of files to modules to a mapping of modules to installed files.
     """
     result: dict[str, str] = {}
+    selected: dict[str, Path] = {}
     for k, v in mapping.items():
         rel = Path(v).relative_to(libdir)
         if not is_valid_module(rel):
             continue
         module = path_to_module(rel)
-        # Prefer .py/.pyc over other extensions (e.g. .pxd, .pyx) for the same module
-        if module not in result or rel.suffix in (".py", ".pyc"):
-            # Make the source path absolute, but do not resolve symlinks
-            result[module] = str(Path(k).absolute())
+        if module in result and not _prefer_module(rel, selected[module]):
+            continue
+        # Make the source path absolute, but do not resolve symlinks
+        result[module] = str(Path(k).absolute())
+        selected[module] = rel
     return result
 
 
@@ -179,8 +182,28 @@ def libdir_to_installed(libdir: Path) -> dict[str, str]:
     """
     Convert a mapping of files to modules to a mapping of modules to installed files.
     """
-    return {
-        path_to_module(pth): str(pth)
-        for v in scantree(libdir)
-        if is_valid_module(pth := v.relative_to(libdir))
-    }
+    result: dict[str, str] = {}
+    selected: dict[str, Path] = {}
+    for v in scantree(libdir):
+        pth = v.relative_to(libdir)
+        if not is_valid_module(pth):
+            continue
+        module = path_to_module(pth)
+        if module in result and not _prefer_module(pth, selected[module]):
+            continue
+        result[module] = str(pth)
+        selected[module] = pth
+    return result
+
+
+def _prefer_module(candidate: Path, current: Path) -> bool:
+    """
+    Whether ``candidate`` should replace ``current`` for the same module name.
+
+    Files are ranked by Python's import loader precedence (extension module >
+    source > bytecode > non-importable), so editable installs resolve a module
+    to the same file a real wheel would import. This keeps a versioned shared
+    library (``_tango.so.10``) from shadowing the real ``_tango.so`` (issue
+    #1144) and an extension module from being shadowed by a ``.py`` next to it.
+    """
+    return module_loader_rank(candidate) < module_loader_rank(current)

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -221,14 +221,12 @@ def collect_search_locations(
     Every tracked file -- importable modules *and* data/resource files -- adds
     its directory to its package's ``__path__``, so ``importlib.resources`` can
     reach data even in a directory that holds no importable module (e.g. CMake
-    installs only data into a package dir). This is kept separate from the
-    module-resolution maps so a non-importable file is never returned as a
-    module's origin.
+    installs only data into a package dir). Keeping this separate from the
+    module-resolution maps means a non-importable file is never a module's origin.
 
-    Source-tree directories are absolute; install-tree directories are relative
-    to ``libdir`` (the redirect joins them with the install location at runtime).
-    Returns ``(directories, packages)`` where ``packages`` are the modules whose
-    directory holds an ``__init__`` (including ``.pxd``/``.pyx`` ones).
+    Source-tree directories are absolute, install-tree ones relative to
+    ``libdir``. Returns ``(directories, packages)`` where ``packages`` are the
+    modules whose directory holds an ``__init__`` (including ``.pxd``/``.pyx``).
     """
     directories: dict[str, set[str]] = {}
     packages: set[str] = set()
@@ -273,12 +271,7 @@ def _is_init(name: str) -> bool:
 
 def _prefer_module(candidate: Path, current: Path) -> bool:
     """
-    Whether ``candidate`` should replace ``current`` for the same module name.
-
-    Files are ranked by Python's import loader precedence (extension module >
-    source > bytecode > non-importable), so editable installs resolve a module
-    to the same file a real wheel would import. This keeps a versioned shared
-    library (``_tango.so.10``) from shadowing the real ``_tango.so`` (issue
-    #1144) and an extension module from being shadowed by a ``.py`` next to it.
+    Whether ``candidate`` outranks ``current`` for the same module name, by
+    import loader precedence (see :func:`module_loader_rank`).
     """
     return module_loader_rank(candidate) < module_loader_rank(current)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -21,13 +21,10 @@ __all__ = [
     "scantree",
 ]
 
-# Importable file extensions for the running interpreter, in the exact order
-# Python's FileFinder tries them: extension modules (most specific tag first,
-# e.g. .cpython-313-x86_64-linux-gnu.so before .abi3.so before .so), then source
-# (.py), then bytecode (.pyc) -- see
-# importlib.machinery._get_supported_file_loaders. EXTENSION_SUFFIXES is
-# platform- and interpreter-specific (.pyd on Windows), which matches an editable
-# install resolving on the same interpreter it was built for.
+# Importable suffixes for this interpreter, in the order Python's FileFinder
+# tries them: extension modules (most specific tag first), then source (.py),
+# then bytecode (.pyc). EXTENSION_SUFFIXES is platform-specific (.pyd on
+# Windows), matching the interpreter the editable install resolves on.
 _MODULE_SUFFIXES = (
     *importlib.machinery.EXTENSION_SUFFIXES,
     *importlib.machinery.SOURCE_SUFFIXES,
@@ -109,17 +106,15 @@ def is_valid_module(path: Path) -> bool:
 
 def module_loader_rank(path: Path) -> int:
     """
-    Where ``path`` sits in Python's import loader precedence.
+    Index of ``path``'s suffix in Python's import loader precedence.
 
     A file maps to the module name before its first ``.``; the rest is its
-    suffix. The rank is that suffix's index in the ordered list of suffixes the
-    interpreter's FileFinder tries (extension tags first, then ``.py``, then
-    ``.pyc``), so when several files share a module name the one chosen matches
-    what a real wheel import would load -- including between extension tags
-    (``mod.cpython-313-...so`` beats ``mod.abi3.so`` beats ``mod.so``).
-    Non-importable files -- data/resource files, and versioned shared libraries
-    such as ``_tango.so.10`` whose ``.so.10`` is not a real suffix -- rank last
-    (issue #1144).
+    suffix. Ranking by that suffix's position in the FileFinder order (extension
+    tags first, then ``.py``, then ``.pyc``) makes a shared module name resolve
+    to the same file a real wheel import would load -- ``mod.cpython-313-...so``
+    beats ``mod.abi3.so`` beats ``mod.so`` beats ``mod.py``. Non-importable files
+    -- data and versioned shared libraries like ``_tango.so.10`` -- rank last
+    (#1144).
     """
     _, dot, rest = path.name.partition(".")
     suffix = dot + rest
@@ -131,13 +126,10 @@ def module_loader_rank(path: Path) -> int:
 
 def is_module(path: Path) -> bool:
     """
-    True if ``path`` is an importable module file for this interpreter.
+    True if ``path``'s suffix is one this interpreter imports (``.py``, ``.pyc``,
+    or an extension suffix like ``.so``/``.pyd``/``.abi3.so``).
 
-    The file's suffix (everything after the first ``.`` in its name) must be one
-    the interpreter imports: ``.py``, ``.pyc``, or an extension suffix such as
-    ``.so``/``.pyd``/``.abi3.so``. Versioned shared libraries such as
-    ``_tango.so.10`` are *not* importable -- they alias the real ``_tango.so`` --
-    so they return ``False`` and never shadow it when a module name is resolved
-    (issue #1144).
+    Versioned shared libraries like ``_tango.so.10`` alias the real ``_tango.so``
+    and are not importable, so they never shadow it (#1144).
     """
     return module_loader_rank(path) < len(_MODULE_SUFFIXES)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.machinery
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -11,7 +12,26 @@ from ._file_processor import each_unignored_file
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
 
-__all__ = ["is_valid_module", "packages_to_file_mapping", "path_to_module", "scantree"]
+__all__ = [
+    "is_module",
+    "is_valid_module",
+    "module_loader_rank",
+    "packages_to_file_mapping",
+    "path_to_module",
+    "scantree",
+]
+
+# Importable file extensions for the running interpreter, grouped in Python's
+# loader precedence order: extension modules first, then source, then bytecode
+# (see importlib.machinery._get_supported_file_loaders). EXTENSION_SUFFIXES is
+# platform-specific (.cpython-313-x86_64-linux-gnu.so, .abi3.so, .so on Linux;
+# .pyd on Windows), which matches the editable install resolving on the same
+# platform it was built for.
+_MODULE_SUFFIX_GROUPS = (
+    tuple(importlib.machinery.EXTENSION_SUFFIXES),
+    tuple(importlib.machinery.SOURCE_SUFFIXES),
+    tuple(importlib.machinery.BYTECODE_SUFFIXES),
+)
 
 
 def __dir__() -> list[str]:
@@ -71,8 +91,46 @@ def packages_to_file_mapping(
 
 
 def is_valid_module(path: Path) -> bool:
+    """
+    True if ``path`` should be tracked in an editable install.
+
+    This is intentionally broad: it accepts data/resource files (``.txt``,
+    ``.pyx``, ``.pxd``, ...) as well as importable modules, so that the editable
+    redirect registers their directories and ``importlib.resources`` can find
+    them. Use :func:`is_module` to tell whether a tracked file is importable.
+    """
     parts = path.parts
     return (
         all(p.isidentifier() for p in parts[:-1])
-        and parts[-1].split(".", 1)[0].isidentifier()
+        and parts[-1].partition(".")[0].isidentifier()
     )
+
+
+def module_loader_rank(path: Path) -> int:
+    """
+    Where ``path`` sits in Python's import loader precedence.
+
+    Returns 0 for extension modules (``.so``, ``.pyd``, ``.abi3.so``, ...), 1
+    for source (``.py``), 2 for bytecode (``.pyc``), matching the order Python's
+    FileFinder tries them. Non-importable files (data/resource files, and
+    versioned shared libraries such as ``_tango.so.10`` that alias the real
+    ``_tango.so``) rank last, after every importable file (issue #1144).
+    """
+    name = path.name
+    for rank, suffixes in enumerate(_MODULE_SUFFIX_GROUPS):
+        if name.endswith(suffixes):
+            return rank
+    return len(_MODULE_SUFFIX_GROUPS)
+
+
+def is_module(path: Path) -> bool:
+    """
+    True if ``path`` is an importable module file (``.py``, ``.pyc``, ``.so``,
+    ``.pyd``, ``.abi3.so``, ...).
+
+    Versioned shared libraries such as ``_tango.so.10`` or
+    ``_tango.so.10.1.0.0`` are *not* importable -- they alias the real
+    ``_tango.so`` -- so they return ``False`` and never shadow it when a module
+    name is resolved (issue #1144).
+    """
+    return module_loader_rank(path) < len(_MODULE_SUFFIX_GROUPS)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -21,16 +21,17 @@ __all__ = [
     "scantree",
 ]
 
-# Importable file extensions for the running interpreter, grouped in Python's
-# loader precedence order: extension modules first, then source, then bytecode
-# (see importlib.machinery._get_supported_file_loaders). EXTENSION_SUFFIXES is
-# platform-specific (.cpython-313-x86_64-linux-gnu.so, .abi3.so, .so on Linux;
-# .pyd on Windows), which matches the editable install resolving on the same
-# platform it was built for.
-_MODULE_SUFFIX_GROUPS = (
-    tuple(importlib.machinery.EXTENSION_SUFFIXES),
-    tuple(importlib.machinery.SOURCE_SUFFIXES),
-    tuple(importlib.machinery.BYTECODE_SUFFIXES),
+# Importable file extensions for the running interpreter, in the exact order
+# Python's FileFinder tries them: extension modules (most specific tag first,
+# e.g. .cpython-313-x86_64-linux-gnu.so before .abi3.so before .so), then source
+# (.py), then bytecode (.pyc) -- see
+# importlib.machinery._get_supported_file_loaders. EXTENSION_SUFFIXES is
+# platform- and interpreter-specific (.pyd on Windows), which matches an editable
+# install resolving on the same interpreter it was built for.
+_MODULE_SUFFIXES = (
+    *importlib.machinery.EXTENSION_SUFFIXES,
+    *importlib.machinery.SOURCE_SUFFIXES,
+    *importlib.machinery.BYTECODE_SUFFIXES,
 )
 
 
@@ -110,27 +111,33 @@ def module_loader_rank(path: Path) -> int:
     """
     Where ``path`` sits in Python's import loader precedence.
 
-    Returns 0 for extension modules (``.so``, ``.pyd``, ``.abi3.so``, ...), 1
-    for source (``.py``), 2 for bytecode (``.pyc``), matching the order Python's
-    FileFinder tries them. Non-importable files (data/resource files, and
-    versioned shared libraries such as ``_tango.so.10`` that alias the real
-    ``_tango.so``) rank last, after every importable file (issue #1144).
+    A file maps to the module name before its first ``.``; the rest is its
+    suffix. The rank is that suffix's index in the ordered list of suffixes the
+    interpreter's FileFinder tries (extension tags first, then ``.py``, then
+    ``.pyc``), so when several files share a module name the one chosen matches
+    what a real wheel import would load -- including between extension tags
+    (``mod.cpython-313-...so`` beats ``mod.abi3.so`` beats ``mod.so``).
+    Non-importable files -- data/resource files, and versioned shared libraries
+    such as ``_tango.so.10`` whose ``.so.10`` is not a real suffix -- rank last
+    (issue #1144).
     """
-    name = path.name
-    for rank, suffixes in enumerate(_MODULE_SUFFIX_GROUPS):
-        if name.endswith(suffixes):
-            return rank
-    return len(_MODULE_SUFFIX_GROUPS)
+    _, dot, rest = path.name.partition(".")
+    suffix = dot + rest
+    try:
+        return _MODULE_SUFFIXES.index(suffix)
+    except ValueError:
+        return len(_MODULE_SUFFIXES)
 
 
 def is_module(path: Path) -> bool:
     """
-    True if ``path`` is an importable module file (``.py``, ``.pyc``, ``.so``,
-    ``.pyd``, ``.abi3.so``, ...).
+    True if ``path`` is an importable module file for this interpreter.
 
-    Versioned shared libraries such as ``_tango.so.10`` or
-    ``_tango.so.10.1.0.0`` are *not* importable -- they alias the real
-    ``_tango.so`` -- so they return ``False`` and never shadow it when a module
-    name is resolved (issue #1144).
+    The file's suffix (everything after the first ``.`` in its name) must be one
+    the interpreter imports: ``.py``, ``.pyc``, or an extension suffix such as
+    ``.so``/``.pyd``/``.abi3.so``. Versioned shared libraries such as
+    ``_tango.so.10`` are *not* importable -- they alias the real ``_tango.so`` --
+    so they return ``False`` and never shadow it when a module name is resolved
+    (issue #1144).
     """
-    return module_loader_rank(path) < len(_MODULE_SUFFIX_GROUPS)
+    return module_loader_rank(path) < len(_MODULE_SUFFIXES)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -14,17 +14,14 @@ if TYPE_CHECKING:
 
 __all__ = [
     "is_module",
-    "is_valid_module",
+    "is_trackable",
     "module_loader_rank",
     "packages_to_file_mapping",
     "path_to_module",
     "scantree",
 ]
 
-# Importable suffixes for this interpreter, in the order Python's FileFinder
-# tries them: extension modules (most specific tag first), then source (.py),
-# then bytecode (.pyc). EXTENSION_SUFFIXES is platform-specific (.pyd on
-# Windows), matching the interpreter the editable install resolves on.
+# Importable suffixes for this interpreter, in order.
 _MODULE_SUFFIXES = (
     *importlib.machinery.EXTENSION_SUFFIXES,
     *importlib.machinery.SOURCE_SUFFIXES,
@@ -47,7 +44,7 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 def path_to_module(path: Path) -> str:
     name, _, _ = path.name.partition(".")
-    assert name, f"Empty name should be filtered by is_valid_module first, got {path}"
+    assert name, f"Empty name should be filtered by is_trackable first, got {path}"
     path = path.with_name(name)
     if path.name == "__init__":
         path = path.parent
@@ -88,7 +85,7 @@ def packages_to_file_mapping(
     return mapping
 
 
-def is_valid_module(path: Path) -> bool:
+def is_trackable(path: Path) -> bool:
     """
     True if ``path`` should be tracked in an editable install.
 

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -254,6 +254,8 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self,
         known_source_files: dict[str, str],
         known_wheel_files: dict[str, str],
+        known_directories: dict[str, list[str]],
+        known_packages: list[str],
         path: str | None,
         rebuild: bool,
         verbose: bool,
@@ -272,33 +274,20 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.dir = dir
         self.install_dir = os.path.join(DIR, install_dir)
 
-        # Construct the __path__ of all resource files
-        # I.e. the paths of all package-like objects
+        # Construct the __path__ of all package-like objects. known_directories
+        # maps each package to the directories that make up its __path__,
+        # covering importable modules and data/resource files alike (so
+        # importlib.resources can navigate directories that hold only data).
+        # Install-tree paths are relative and joined with this file's directory;
+        # source-tree paths are already absolute.
         submodule_search_locations: dict[str, set[str]] = {}
-        pkgs: list[str] = []
-        # Loop over both python native source files and cmake installed ones
-        for tree in (known_source_files, known_wheel_files):
-            for module, file in tree.items():
-                # Strip the last element of the module
-                parent = ".".join(module.split(".")[:-1])
-                # Check if it is a package
-                if os.path.basename(file).partition(".")[0] == "__init__":
-                    parent = module
-                    pkgs.append(parent)
-                # Skip if it's a root module (there are no search paths for these)
-                if not parent:
-                    continue
-                # Initialize the tree element if needed
-                submodule_search_locations.setdefault(parent, set())
-                # Add the parent path to the dictionary values
-                parent_path = os.path.dirname(file)
-                if not parent_path:
-                    # root modules are skipped so all files should be in a parent package
-                    msg = f"Unexpected path to source file: {file} [{module}]"
-                    raise ImportError(msg)
+        for parent, parent_paths in known_directories.items():
+            locations = submodule_search_locations.setdefault(parent, set())
+            for parent_path in parent_paths:
                 if not os.path.isabs(parent_path):
-                    parent_path = os.path.join(self.dir, parent_path)
-                submodule_search_locations[parent].add(parent_path)
+                    parent_path = os.path.join(self.dir, parent_path)  # noqa: PLW2901
+                locations.add(parent_path)
+        pkgs = list(known_packages)
         # Second pass: propagate build-tree paths from parent packages to
         # sub-packages.  This covers the case where a Python package (with
         # __init__.py) lives in a directory that also contains CMake-generated
@@ -424,7 +413,9 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
 def install(
     known_source_files: dict[str, str],
     known_wheel_files: dict[str, str],
-    path: str | None,
+    known_directories: dict[str, list[str]] | None = None,
+    known_packages: list[str] | None = None,
+    path: str | None = None,
     rebuild: bool = False,
     verbose: bool = False,
     build_options: list[str] | None = None,
@@ -437,12 +428,17 @@ def install(
 
     :param known_source_files: A mapping of module names to source files
     :param known_wheel_files: A mapping of module names to wheel files
+    :param known_directories: A mapping of package names to the directories that
+                              make up their __path__ (covers data-only dirs)
+    :param known_packages: The packages that have an __init__ (regular packages)
     :param path: The path to the build directory, or None
     :param verbose: Whether to print the cmake commands (also controlled by the
                     SKBUILD_EDITABLE_VERBOSE environment variable)
     :param install_dir: The wheel install directory override, if one was
                         specified
     """
+    known_directories = known_directories or {}
+    known_packages = known_packages or []
     # PEP 829 .start entry points may be invoked more than once (e.g. CPython
     # 3.15.0b1 processes a venv's site-packages twice during startup), unlike a
     # .pth `import` line whose side effects run once via the module cache.
@@ -463,6 +459,8 @@ def install(
         ScikitBuildRedirectingFinder(
             known_source_files,
             known_wheel_files,
+            known_directories,
+            known_packages,
             path,
             rebuild,
             verbose,

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -12,39 +12,28 @@ from scikit_build_core.resources._editable_redirect import (
 )
 
 
-def process_dict(d: dict[str, str]) -> dict[str, str]:
-    return {k: str(Path(v)) for k, v in d.items()}
-
-
 def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
     return {k: {str(Path(x)) for x in v} for k, v in d.items()}
 
 
 def test_editable_redirect():
-    known_source_files = process_dict(
+    # known_directories drives __path__: install-tree dirs are relative (joined
+    # with `dir` at runtime), source-tree dirs are absolute. Data-only dirs
+    # (pkg.resources, pkg.iresources) are present here without any module entry.
+    known_directories = process_dict_set(
         {
-            "pkg": "/source/pkg/__init__.py",
-            "pkg.module": "/source/pkg/module.py",
-            "pkg.subpkg": "/source/pkg/subpkg/__init__.py",
-            "pkg.subpkg.module": "/source/pkg/subpkg/module.py",
-            "pkg.resources.file": "/source/pkg/resources/file.txt",
-            "pkg.namespace.module": "/source/pkg/namespace/module.py",
+            "pkg": {"pkg", "/source/pkg"},
+            "pkg.iresources": {"pkg/iresources"},
+            "pkg.namespace": {"pkg/namespace", "/source/pkg/namespace"},
+            "pkg.resources": {"/source/pkg/resources"},
+            "pkg.subpkg": {"pkg/subpkg", "/source/pkg/subpkg"},
         }
     )
-    known_wheel_files = process_dict(
-        {
-            "pkg.subpkg.source": "pkg/subpkg/source.py",
-            "pkg.src_files": "pkg/src_files.py",
-            "pkg.namespace.source": "pkg/namespace/source.py",
-            "pkg.iresources.file": "pkg/iresources/file.txt",
-            "pkg.installed_files": "pkg/installed_files.py",
-            "pkg.source": "pkg/source.py",
-        }
-    )
-
     finder = ScikitBuildRedirectingFinder(
-        known_source_files=known_source_files,
-        known_wheel_files=known_wheel_files,
+        known_source_files={},
+        known_wheel_files={},
+        known_directories={k: sorted(v) for k, v in known_directories.items()},
+        known_packages=["pkg", "pkg.subpkg"],
         path=None,
         rebuild=False,
         verbose=False,
@@ -75,58 +64,6 @@ def test_editable_redirect():
         }
     )
     assert finder.pkgs == frozenset(["pkg", "pkg.subpkg"])
-
-
-def test_editable_redirect_pxd():
-    """Test that .pxd/.pyx __init__ files are recognized as packages.
-
-    If packages have both __init__.py and __init__.pxd, the file scanner may pick up the
-    .pxd as the representative file for the package init and produce the wrong __path__.
-    """
-    known_source_files = process_dict(
-        {
-            "pkg": "/source/pkg/__init__.py",
-            "pkg.module": "/source/pkg/module.py",
-            # Cython subpackage whose init was picked up as .pxd (not .py)
-            "pkg.cython_subpkg": "/source/pkg/cython_subpkg/__init__.pxd",
-            "pkg.cython_subpkg.impl": "/source/pkg/cython_subpkg/impl.pyx",
-            # Pyx subpackage
-            "pkg.pyx_subpkg": "/source/pkg/pyx_subpkg/__init__.pyx",
-            "pkg.pyx_subpkg.module": "/source/pkg/pyx_subpkg/module.py",
-        }
-    )
-    known_wheel_files = process_dict(
-        {"pkg.cython_subpkg.compiled": "pkg/cython_subpkg/compiled.abi3.so"}
-    )
-
-    finder = ScikitBuildRedirectingFinder(
-        known_source_files=known_source_files,
-        known_wheel_files=known_wheel_files,
-        path=None,
-        rebuild=False,
-        verbose=False,
-        build_options=[],
-        install_options=[],
-        dir=str(Path("/sitepackages")),
-        install_dir="",
-    )
-
-    # .pxd/.pyx init files should be recognized as packages
-    assert "pkg.cython_subpkg" in finder.pkgs
-    assert "pkg.pyx_subpkg" in finder.pkgs
-
-    # Cython subpackages must have their OWN search locations
-    assert "pkg.cython_subpkg" in finder.submodule_search_locations
-    assert "pkg.pyx_subpkg" in finder.submodule_search_locations
-
-    # parent pkg.__path__ must NOT be polluted with child package dirs
-    pkg_paths = finder.submodule_search_locations.get("pkg", set())
-    assert not any("cython_subpkg" in p for p in pkg_paths), (
-        f"pkg.__path__ is polluted with cython_subpkg: {pkg_paths}"
-    )
-    assert not any("pyx_subpkg" in p for p in pkg_paths), (
-        f"pkg.__path__ is polluted with pyx_subpkg: {pkg_paths}"
-    )
 
 
 @pytest.fixture
@@ -193,6 +130,8 @@ def _make_finder(tmp_path: Path, *, verbose: bool) -> ScikitBuildRedirectingFind
     return ScikitBuildRedirectingFinder(
         known_source_files={},
         known_wheel_files={},
+        known_directories={},
+        known_packages=[],
         path=str(tmp_path),
         rebuild=True,
         verbose=verbose,

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -18,7 +18,7 @@ from scikit_build_core.build._editable import (
 )
 from scikit_build_core.build._pathutil import (
     is_module,
-    is_valid_module,
+    is_trackable,
     module_loader_rank,
     packages_to_file_mapping,
 )
@@ -352,27 +352,27 @@ def test_editable_redirect_files_absolute_install_dir_with_rebuild(tmp_path: Pat
         )
 
 
-def test_is_valid_module():
+def test_is_trackable():
     # Importable modules and data/resource files are both tracked, so the
     # redirect registers their directories for importlib.resources.
-    assert is_valid_module(Path("one.py"))
-    assert is_valid_module(Path("one/two.py"))
-    assert is_valid_module(Path("one/two.pyc"))
-    assert is_valid_module(Path("tango/_tango.so"))
-    assert is_valid_module(Path("tango/_tango.abi3.so"))
-    assert is_valid_module(Path("pkg/resources/file.txt"))
-    assert is_valid_module(Path("pkg/module.pyx"))
-    assert is_valid_module(Path("pkg/module.pxd"))
+    assert is_trackable(Path("one.py"))
+    assert is_trackable(Path("one/two.py"))
+    assert is_trackable(Path("one/two.pyc"))
+    assert is_trackable(Path("tango/_tango.so"))
+    assert is_trackable(Path("tango/_tango.abi3.so"))
+    assert is_trackable(Path("pkg/resources/file.txt"))
+    assert is_trackable(Path("pkg/module.pyx"))
+    assert is_trackable(Path("pkg/module.pxd"))
     # Versioned sonames are tracked too (so tango/ still gets registered), but
     # is_module rejects them so they never resolve as the module (issue #1144).
-    assert is_valid_module(Path("tango/_tango.so.10"))
-    assert is_valid_module(Path("tango/_tango.so.10.1.0.0"))
+    assert is_trackable(Path("tango/_tango.so.10"))
+    assert is_trackable(Path("tango/_tango.so.10.1.0.0"))
 
     # Invalid identifiers are rejected
-    assert not is_valid_module(Path("1one/two.py"))
-    assert not is_valid_module(Path("one/2two.py"))
-    assert not is_valid_module(Path("one/.py"))
-    assert not is_valid_module(Path(".py"))
+    assert not is_trackable(Path("1one/two.py"))
+    assert not is_trackable(Path("one/2two.py"))
+    assert not is_trackable(Path("one/.py"))
+    assert not is_trackable(Path(".py"))
 
 
 def test_is_module():

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -412,6 +412,37 @@ def test_module_loader_rank_matches_import_precedence():
     assert ext_rank < py_rank < pyc_rank < data_rank
 
 
+@pytest.mark.skipif(
+    len(importlib.machinery.EXTENSION_SUFFIXES) < 2,
+    reason="needs at least two extension suffixes to order",
+)
+def test_module_loader_rank_orders_extension_suffixes():
+    # FileFinder tries EXTENSION_SUFFIXES in order, so a more specific tag (e.g.
+    # .cpython-313-...so) outranks the bare suffix (.so) for the same module.
+    suffixes = importlib.machinery.EXTENSION_SUFFIXES
+    assert module_loader_rank(Path(f"mod{suffixes[0]}")) < module_loader_rank(
+        Path(f"mod{suffixes[-1]}")
+    )
+
+
+@pytest.mark.skipif(
+    len(importlib.machinery.EXTENSION_SUFFIXES) < 2,
+    reason="needs at least two extension suffixes to order",
+)
+def test_libdir_to_installed_prefers_specific_extension_tag(tmp_path: Path):
+    # Two extension files for the same module: pick the one a wheel import would
+    # load first (the most specific tag), not whichever was scanned first.
+    suffixes = importlib.machinery.EXTENSION_SUFFIXES
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / f"mod{suffixes[0]}").touch()
+    (pkg_dir / f"mod{suffixes[-1]}").touch()
+
+    installed = libdir_to_installed(tmp_path)
+
+    assert installed["pkg.mod"] == str(Path("pkg") / f"mod{suffixes[0]}")
+
+
 def test_libdir_to_installed_prefers_extension_over_source(tmp_path: Path):
     # A wheel import loads the extension module before mod.py; editable agrees.
     pkg_dir = tmp_path / "pkg"

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 import pytest
 
 from scikit_build_core.build._editable import (
+    collect_search_locations,
     editable_redirect,
     editable_redirect_files,
     libdir_to_installed,
@@ -168,30 +169,44 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
     }
     modules = mapping_to_modules(mapping, libdir=site_packages)
 
+    # Importable modules only: the data file (pkg/resources/file.txt) is not here.
     assert modules == {
         "pkg": str(src_pkg_dir / "__init__.py"),
         "pkg.module": str(src_pkg_dir / "module.py"),
         "pkg.namespace.module": str(src_pkg_dir / "namespace/module.py"),
         "pkg.subpkg": str(src_pkg_dir / "subpkg/__init__.py"),
         "pkg.subpkg.module": str(src_pkg_dir / "subpkg/module.py"),
-        "pkg.resources.file": str(src_pkg_dir / "resources/file.txt"),
     }
 
     installed = libdir_to_installed(site_packages)
     installed = {k: v for k, v in installed.items() if k.startswith("pkg")}
 
+    # Importable modules only: the data file (pkg/iresources/file.txt) is not here.
     assert installed == {
         "pkg.subpkg.source": str(Path("pkg/subpkg/source.py")),
         "pkg.namespace.source": str(Path("pkg/namespace/source.py")),
         "pkg.source": str(Path("pkg/source.py")),
         "pkg.installed_files": str(Path("pkg/installed_files.py")),
-        "pkg.iresources.file": str(Path("pkg/iresources/file.txt")),
         "pkg.src_files": str(Path("pkg/src_files.py")),
     }
+
+    directories, package_names = collect_search_locations(mapping, libdir=site_packages)
+    directories = {k: v for k, v in directories.items() if k.startswith("pkg")}
+    package_names = [p for p in package_names if p.startswith("pkg")]
+
+    # Data directories are tracked (as directories only, with no importable
+    # module) so importlib.resources can reach them: pkg.resources lives in the
+    # source tree, pkg.iresources in the install tree.
+    assert str(src_pkg_dir / "resources") in directories["pkg.resources"]
+    assert "pkg.iresources" in directories
+    assert str(src_pkg_dir) in directories["pkg"]
+    assert package_names == ["pkg", "pkg.subpkg"]
 
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,
+        directories=directories,
+        packages=package_names,
         reload_dir=None,
         rebuild=False,
         verbose=False,
@@ -426,3 +441,55 @@ def test_libdir_to_installed_prefers_plain_so_over_versioned(tmp_path: Path):
     assert "tango._tango" in installed
     # Must pick the plain .so, not a versioned soname
     assert installed["tango._tango"] == str(Path("tango/_tango.so"))
+
+
+def test_collect_search_locations_data_only_install_dir(tmp_path: Path):
+    # The source tree has the importable package; the install (CMake) tree adds
+    # only a data file into the same package dir. The install dir must still be
+    # registered on pkg.__path__ so importlib.resources can find the data --
+    # this is the one case where a non-importable file is load-bearing.
+    libdir = tmp_path / "site"
+    (libdir / "pkg").mkdir(parents=True)
+    (libdir / "pkg" / "data.txt").write_text("hi")
+    src = tmp_path / "src"
+    mapping = {str(src / "pkg" / "__init__.py"): str(libdir / "pkg" / "__init__.py")}
+
+    directories, packages = collect_search_locations(mapping, libdir)
+
+    assert packages == ["pkg"]
+    # pkg.__path__ has both the source dir (absolute) and the install dir
+    # (relative), the latter reachable only because the data file registered it.
+    assert str(src / "pkg") in directories["pkg"]
+    assert str(Path("pkg")) in directories["pkg"]
+    # The data file itself is not an importable module.
+    assert "pkg.data" not in libdir_to_installed(libdir)
+
+
+def test_collect_search_locations_pxd_packages(tmp_path: Path):
+    # .pxd/.pyx __init__ files define packages even though they are not
+    # importable; they must be marked as packages and given their own directory
+    # without polluting the parent package's __path__.
+    libdir = tmp_path / "site"
+    libdir.mkdir()
+    src = tmp_path / "src"
+    mapping = {
+        str(src / "pkg" / "__init__.py"): str(libdir / "pkg" / "__init__.py"),
+        str(src / "pkg" / "cython_subpkg" / "__init__.pxd"): str(
+            libdir / "pkg" / "cython_subpkg" / "__init__.pxd"
+        ),
+        str(src / "pkg" / "cython_subpkg" / "impl.pyx"): str(
+            libdir / "pkg" / "cython_subpkg" / "impl.pyx"
+        ),
+        str(src / "pkg" / "pyx_subpkg" / "__init__.pyx"): str(
+            libdir / "pkg" / "pyx_subpkg" / "__init__.pyx"
+        ),
+    }
+
+    directories, packages = collect_search_locations(mapping, libdir)
+
+    assert "pkg.cython_subpkg" in packages
+    assert "pkg.pyx_subpkg" in packages
+    assert directories["pkg.cython_subpkg"] == [str(src / "pkg" / "cython_subpkg")]
+    assert directories["pkg.pyx_subpkg"] == [str(src / "pkg" / "pyx_subpkg")]
+    # The parent pkg.__path__ must not be polluted with child package dirs.
+    assert all("subpkg" not in p for p in directories["pkg"])

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.machinery
 import sys
 import textwrap
 import typing
@@ -14,11 +15,22 @@ from scikit_build_core.build._editable import (
     libdir_to_installed,
     mapping_to_modules,
 )
-from scikit_build_core.build._pathutil import packages_to_file_mapping
+from scikit_build_core.build._pathutil import (
+    is_module,
+    is_valid_module,
+    module_loader_rank,
+    packages_to_file_mapping,
+)
 from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
 
 if typing.TYPE_CHECKING:
     from conftest import VEnv
+
+# The bare extension-module suffix for this interpreter (.so on Unix, .pyd on
+# Windows), and whether .so is importable here (it is not on Windows, where
+# versioned-soname collisions cannot occur).
+EXT_SUFFIX = importlib.machinery.EXTENSION_SUFFIXES[-1]
+SO_IMPORTABLE = ".so" in importlib.machinery.EXTENSION_SUFFIXES
 
 
 class EditablePackage(NamedTuple):
@@ -323,3 +335,94 @@ def test_editable_redirect_files_absolute_install_dir_with_rebuild(tmp_path: Pat
             settings=settings,
             use_start=False,
         )
+
+
+def test_is_valid_module():
+    # Importable modules and data/resource files are both tracked, so the
+    # redirect registers their directories for importlib.resources.
+    assert is_valid_module(Path("one.py"))
+    assert is_valid_module(Path("one/two.py"))
+    assert is_valid_module(Path("one/two.pyc"))
+    assert is_valid_module(Path("tango/_tango.so"))
+    assert is_valid_module(Path("tango/_tango.abi3.so"))
+    assert is_valid_module(Path("pkg/resources/file.txt"))
+    assert is_valid_module(Path("pkg/module.pyx"))
+    assert is_valid_module(Path("pkg/module.pxd"))
+    # Versioned sonames are tracked too (so tango/ still gets registered), but
+    # is_module rejects them so they never resolve as the module (issue #1144).
+    assert is_valid_module(Path("tango/_tango.so.10"))
+    assert is_valid_module(Path("tango/_tango.so.10.1.0.0"))
+
+    # Invalid identifiers are rejected
+    assert not is_valid_module(Path("1one/two.py"))
+    assert not is_valid_module(Path("one/2two.py"))
+    assert not is_valid_module(Path("one/.py"))
+    assert not is_valid_module(Path(".py"))
+
+
+def test_is_module():
+    # Importable module files (EXT_SUFFIX is .so on Unix, .pyd on Windows)
+    assert is_module(Path("one.py"))
+    assert is_module(Path("one/two.pyc"))
+    assert is_module(Path(f"mod{EXT_SUFFIX}"))
+
+    # Data/resource and Cython source files are not importable modules
+    assert not is_module(Path("pkg/resources/file.txt"))
+    assert not is_module(Path("pkg/module.pyx"))
+    assert not is_module(Path("pkg/module.pxd"))
+
+
+@pytest.mark.skipif(
+    not SO_IMPORTABLE, reason="versioned .so sonames only occur where .so is importable"
+)
+def test_is_module_rejects_versioned_sonames():
+    assert is_module(Path("tango/_tango.so"))
+    assert is_module(Path("tango/_tango.abi3.so"))
+
+    # Versioned sonames are not importable (PEP 3149); they alias the real
+    # _tango.so and must not resolve as the module (issue #1144).
+    assert not is_module(Path("tango/_tango.so.10"))
+    assert not is_module(Path("tango/_tango.so.10.1.0.0"))
+
+
+def test_module_loader_rank_matches_import_precedence():
+    # Extension modules load before source, source before bytecode; everything
+    # else (data, versioned sonames) ranks last. This mirrors Python's own
+    # FileFinder order so editable installs resolve the same file as a wheel.
+    ext_rank = module_loader_rank(Path(f"mod{EXT_SUFFIX}"))
+    py_rank = module_loader_rank(Path("mod.py"))
+    pyc_rank = module_loader_rank(Path("mod.pyc"))
+    data_rank = module_loader_rank(Path("file.txt"))
+
+    assert ext_rank < py_rank < pyc_rank < data_rank
+
+
+def test_libdir_to_installed_prefers_extension_over_source(tmp_path: Path):
+    # A wheel import loads the extension module before mod.py; editable agrees.
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / f"mod{EXT_SUFFIX}").touch()
+    (pkg_dir / "mod.py").touch()
+
+    installed = libdir_to_installed(tmp_path)
+
+    assert installed["pkg.mod"] == str(Path("pkg") / f"mod{EXT_SUFFIX}")
+
+
+@pytest.mark.skipif(
+    not SO_IMPORTABLE, reason="versioned .so sonames only occur where .so is importable"
+)
+def test_libdir_to_installed_prefers_plain_so_over_versioned(tmp_path: Path):
+    # Simulate a site-packages/tango/ directory that has all three soname variants,
+    # as seen in the pytango issue (#1144). Only _tango.so should be selected.
+    pkg_dir = tmp_path / "tango"
+    pkg_dir.mkdir()
+    (pkg_dir / "_tango.so").touch()
+    (pkg_dir / "_tango.so.10").touch()
+    (pkg_dir / "_tango.so.10.1.0.0").touch()
+
+    installed = libdir_to_installed(tmp_path)
+
+    assert "tango._tango" in installed
+    # Must pick the plain .so, not a versioned soname
+    assert installed["tango._tango"] == str(Path("tango/_tango.so"))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

In editable installs, the redirect maps (`known_source_files` / `known_wheel_files`) serve **two** roles:

1. **Module resolution** — `find_spec` looks a module name up in the maps to find the file to load.
2. **Resource directories** — every tracked file contributes its parent directory to `submodule_search_locations`, so `importlib.resources` can find data files.

`is_valid_module` was overloaded for both roles. Because `path_to_module` keys on the stem before the first `.`, the SONAME variants Linux CMake builds commonly produce side-by-side — `_tango.so`, `_tango.so.10`, `_tango.so.10.1.0.0` — all mapped to the same key `tango._tango`, and `libdir_to_installed` had no collision handling, so a non-importable versioned soname could win non-deterministically. The result was `ModuleNotFoundError: No module named 'tango._tango'` (issue #1144).

## Fix

Split the two roles instead of overloading one predicate:

- **`is_valid_module`** stays broad: it tracks data/resource files (`.txt`, `.pyx`, `.pxd`, ...) **and** versioned sonames, so their directories are still registered and `importlib.resources` keeps working.
- **`module_loader_rank`** (new) ranks a file by Python's own import-loader precedence, using `importlib.machinery` suffixes: extension module (`.so`/`.pyd`/`.abi3.so`/...) → source (`.py`) → bytecode (`.pyc`) → non-importable (data files and versioned sonames, which rank last). This mirrors the order CPython's `FileFinder` tries loaders.
- **`_prefer_module`** is a collision tiebreaker, applied in **both** `mapping_to_modules` and `libdir_to_installed`: for a given module name it keeps the highest-precedence file. So editable installs resolve the **same file a real wheel would import** — the plain `.so` beats versioned sonames (issue #1144), and an extension module beats a `.py` sitting beside it (rather than the reverse).

Earlier iterations used a simpler boolean "is this importable?" check that preferred `.py`/`.pyc`; that diverged from CPython's loader order when an extension module and a source file shared a name (raised in review). Ranking by loader precedence makes editable and wheel imports agree.

`module_loader_rank` relies on `importlib.machinery.EXTENSION_SUFFIXES`, which already contains the native extension on each platform (`.so` on Unix, `.pyd` on Windows) — matching the fact that an editable install resolves on the platform it was built for.

Fixes #1144

## Testing

Unit tests in `tests/test_editable_unit.py` (no virtualenv required):

- `test_is_valid_module` — modules, data files, and versioned sonames are all tracked; non-identifier paths are rejected.
- `test_is_module` / `test_is_module_rejects_versioned_sonames` — only real module extensions are importable; sonames, data files, and Cython sources are not. (The soname test is skipped where `.so` is not importable, i.e. Windows, since versioned sonames are a Unix concept.)
- `test_module_loader_rank_matches_import_precedence` — extension < source < bytecode < non-importable.
- `test_libdir_to_installed_prefers_extension_over_source` — a dir with both `mod.<ext>` and `mod.py` resolves `pkg.mod` to the extension module, matching wheel import order.
- `test_libdir_to_installed_prefers_plain_so_over_versioned` — a `tango/` dir with all three soname variants resolves `tango._tango` to `tango/_tango.so`.

The existing `test_navigate_editable_pkg` (with virtualenv) continues to pass, confirming data/resource files remain resolvable via `importlib.resources`.


---

## Follow-up: separate directory tracking from module resolution

The redirect maps were doing double duty — resolving importable modules **and**, as a side effect, registering each file's directory so `importlib.resources` can navigate it. To get the directory side, non-importable data files were stored as fake module entries (`pkg.resources.file → file.txt`); `find_spec` could then hand one of those back as a module's origin (e.g. `import pkg.foo` returning `foo.txt`).

These are now split:

- `mapping_to_modules` / `libdir_to_installed` return **importable files only** (used by `find_spec`).
- A new `collect_search_locations` walks every tracked file — modules and data alike — to build the package→`__path__` map (`known_directories`) and the set of regular packages (`known_packages`, including `.pxd`/`.pyx` `__init__` packages). These are passed to the finder, which no longer derives `__path__` from the file maps.

Net effect: a non-importable file is never resolved as a module, while data-only directories (e.g. a package dir where CMake installs only data, with no module of its own in that tree) still join their package's `__path__` so `importlib.resources` can reach them — verified by `test_navigate_editable_pkg` and a new `test_collect_search_locations_data_only_install_dir`.

This changes the internal `install(...)` signature in the generated `_editable_skbc_*.py` shim (adds `known_directories` / `known_packages`); the shim and its `install(...)` call are emitted together, so there is no version skew.
