### PR TITLE
fix: honor CMAKE_OSX_DEPLOYMENT_TARGET in wheel platform tag (#977)

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -240,16 +240,15 @@ def _build_wheel_impl_impl(
         wheel_dir = build_tmp_folder / "wheel"
         wheel_variant = get_wheel_variant(settings, pyproject, metadata)
 
+        cmake_args = get_cmake_args_from_settings(settings, os.environ)
         tags = WheelTag.compute_best(
-            archs_to_tags(
-                get_archs(
-                    os.environ, get_cmake_args_from_settings(settings, os.environ)
-                )
-            ),
+            archs_to_tags(get_archs(os.environ, cmake_args)),
             settings.wheel.py_api,
             expand_macos=settings.wheel.expand_macos_universal_tags,
             root_is_purelib=targetlib == "purelib",
             build_tag=settings.wheel.build_tag,
+            cmake_defines=settings.cmake.define,
+            cmake_args=cmake_args,
         )
 
         # A build dir can be specified, otherwise use a temporary directory

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 import os
 import platform
-from typing import NamedTuple
+import re
+from typing import TYPE_CHECKING, NamedTuple
 
 from .._logging import logger
 
-__all__ = ["MacOSVer", "get_macosx_deployment_target", "normalize_macos_version"]
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "MacOSVer",
+    "get_cmake_osx_deployment_target",
+    "get_macosx_deployment_target",
+    "normalize_macos_version",
+]
 
 
 class MacOSVer(NamedTuple):
@@ -33,15 +42,56 @@ def normalize_macos_version(version: str, *, arm: bool) -> MacOSVer:
     return MacOSVer(major, minor)
 
 
-def get_macosx_deployment_target(*, arm: bool) -> MacOSVer:
+def get_cmake_osx_deployment_target(
+    cmake_defines: Mapping[str, str] | None = None,
+    cmake_args: Sequence[str] = (),
+) -> str | None:
     """
-    Get the MACOSX_DEPLOYMENT_TARGET environment variable. If not set, use the
-    current macOS version. If arm=True, then this will always return at least (11, 0).
-    Versions after 11 will be normalized to 0 for minor version.
+    Find an explicit ``CMAKE_OSX_DEPLOYMENT_TARGET`` known before the build
+    directory exists: a ``cmake.define`` entry or a ``-DCMAKE_OSX_DEPLOYMENT_TARGET=``
+    in ``cmake.args``. The args value wins over the define, mirroring CMake's own
+    command-line-over-cache precedence. Settings in ``CMakeLists.txt`` or a
+    toolchain file cannot be seen here and are not honored.
     """
-    target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
+    target: str | None = None
+    if cmake_defines is not None:
+        target = cmake_defines.get("CMAKE_OSX_DEPLOYMENT_TARGET", None)
+    for arg in cmake_args:
+        match = re.fullmatch(r"-D\s*CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg)
+        if match:
+            target = match.group(1)
+    return target
+
+
+def get_macosx_deployment_target(
+    *,
+    arm: bool,
+    cmake_defines: Mapping[str, str] | None = None,
+    cmake_args: Sequence[str] = (),
+) -> MacOSVer:
+    """
+    Get the deployment target used for the wheel platform tag. An explicit
+    ``CMAKE_OSX_DEPLOYMENT_TARGET`` from ``cmake.define`` or ``cmake.args`` wins;
+    otherwise the ``MACOSX_DEPLOYMENT_TARGET`` environment variable is used (this
+    is the fallback default CMake itself applies). If neither is set, the current
+    macOS version is used. If arm=True, then this will always return at least
+    (11, 0). Versions after 11 will be normalized to 0 for minor version.
+    """
     plat_ver_str, _, _ = platform.mac_ver()
     plat_target = normalize_macos_version(plat_ver_str, arm=arm)
+
+    cmake_target = get_cmake_osx_deployment_target(cmake_defines, cmake_args)
+    if cmake_target is not None:
+        try:
+            norm_cmake_target = normalize_macos_version(cmake_target, arm=arm)
+        except ValueError:
+            msg = "CMAKE_OSX_DEPLOYMENT_TARGET not readable ({}), trying MACOSX_DEPLOYMENT_TARGET / current version instead"
+            logger.warning(msg, cmake_target)
+        else:
+            logger.debug("CMAKE_OSX_DEPLOYMENT_TARGET is set to {}", cmake_target)
+            return norm_cmake_target
+
+    target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
     if target is None:
         logger.debug("MACOSX_DEPLOYMENT_TARGET not set, using {}", plat_target)
         return plat_target

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -13,7 +13,7 @@ from .._logging import logger
 from .macos import get_macosx_deployment_target
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from .._compat.typing import Self
 
@@ -70,6 +70,8 @@ class WheelTag:
         expand_macos: bool = False,
         root_is_purelib: bool = False,
         build_tag: str = "",
+        cmake_defines: Mapping[str, str] | None = None,
+        cmake_args: Sequence[str] = (),
     ) -> Self:
         if build_tag:
             if not build_tag[0].isdigit():
@@ -113,7 +115,12 @@ class WheelTag:
             plats = [
                 next(
                     packaging.tags.mac_platforms(
-                        get_macosx_deployment_target(arm=arm), arch
+                        get_macosx_deployment_target(
+                            arm=arm,
+                            cmake_defines=cmake_defines,
+                            cmake_args=cmake_args,
+                        ),
+                        arch,
                     )
                 )
                 for arch, arm in pairs

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -170,15 +170,14 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         self.__tmp_dir = Path(tempfile.mkdtemp()).resolve()
         wheel_dir = self.__tmp_dir / "wheel"
 
+        cmake_args = get_cmake_args_from_settings(settings, os.environ)
         tags = WheelTag.compute_best(
-            archs_to_tags(
-                get_archs(
-                    os.environ, get_cmake_args_from_settings(settings, os.environ)
-                )
-            ),
+            archs_to_tags(get_archs(os.environ, cmake_args)),
             settings.wheel.py_api,
             expand_macos=settings.wheel.expand_macos_universal_tags,
             build_tag=settings.wheel.build_tag,
+            cmake_defines=settings.cmake.define,
+            cmake_args=cmake_args,
         )
         # _validate guarantees wheel.cmake is true and rejects a falsy
         # wheel.platlib (purelib), so this is always a platlib build.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -90,6 +90,75 @@ def test_macos_version(monkeypatch, pycom, envvar, answer):
     assert str(get_macosx_deployment_target(arm=False)) == answer
 
 
+@pytest.mark.parametrize(
+    ("envvar", "defines", "args", "answer"),
+    [
+        pytest.param(
+            None,
+            {"CMAKE_OSX_DEPLOYMENT_TARGET": "11.0"},
+            (),
+            "11.0",
+            id="define_only",
+        ),
+        pytest.param(
+            None,
+            {},
+            ("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13",),
+            "10.13",
+            id="arg_only",
+        ),
+        pytest.param(
+            None,
+            {},
+            ("-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13",),
+            "10.13",
+            id="arg_typed",
+        ),
+        # cmake.define / cmake.args win over the env var fallback.
+        pytest.param(
+            "12.0",
+            {"CMAKE_OSX_DEPLOYMENT_TARGET": "11.0"},
+            (),
+            "11.0",
+            id="define_beats_envvar",
+        ),
+        # args win over the define, mirroring CMake's command-line precedence.
+        pytest.param(
+            None,
+            {"CMAKE_OSX_DEPLOYMENT_TARGET": "11.0"},
+            ("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13",),
+            "10.13",
+            id="arg_beats_define",
+        ),
+        # An unreadable cmake value falls back to the env var.
+        pytest.param(
+            "12.0",
+            {"CMAKE_OSX_DEPLOYMENT_TARGET": "random"},
+            (),
+            "12.0",
+            id="invalid_define_falls_back_to_envvar",
+        ),
+    ],
+)
+def test_macos_version_cmake_osx_deployment_target(
+    monkeypatch, envvar, defines, args, answer
+):
+    # Pin the platform version high so the answer must come from the explicit
+    # cmake setting (or env var fallback), not the current macOS version.
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("15.0.0", "", ""))
+    if envvar is None:
+        monkeypatch.delenv("MACOSX_DEPLOYMENT_TARGET", raising=False)
+    else:
+        monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", envvar)
+
+    result = get_macosx_deployment_target(
+        arm=False,
+        cmake_defines={k: CMakeSettingsDefine(v) for k, v in defines.items()},
+        cmake_args=args,
+    )
+    assert str(result) == answer
+
+
 def test_get_python_include_dir():
     assert get_python_include_dir().is_dir()
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

On macOS, the wheel platform tag was computed only from the `MACOSX_DEPLOYMENT_TARGET` environment variable (falling back to the running macOS version). When a user instead set the deployment target via `CMAKE_OSX_DEPLOYMENT_TARGET` (in `tool.scikit-build.cmake.define`, or as `-DCMAKE_OSX_DEPLOYMENT_TARGET=...` in `cmake.args`), the compiled `.so` correctly targeted that version but the wheel tag did not — producing a wheel whose tag and binary disagree (e.g. tag `macosx_26_0_arm64` for a `minos 11.0` binary).

## Fix

`get_macosx_deployment_target()` now also reads `CMAKE_OSX_DEPLOYMENT_TARGET` from the settings that are known *before* the build directory exists: `settings.cmake.define["CMAKE_OSX_DEPLOYMENT_TARGET"]` and a `-DCMAKE_OSX_DEPLOYMENT_TARGET=` entry in `settings.cmake.args` (typed `:STRING=` forms are handled too). These are threaded through `WheelTag.compute_best` from both the wheel build (`build/wheel.py`) and the hatch plugin.

### Precedence

`cmake.args` > `cmake.define` > `MACOSX_DEPLOYMENT_TARGET` env var > current macOS version.

The explicit cmake value wins over the env var because the env var is precisely the *fallback default* CMake itself applies for `CMAKE_OSX_DEPLOYMENT_TARGET`; `cmake.args` beats `cmake.define` mirroring CMake's command-line-over-cache precedence. An unreadable cmake value falls back to the env var / current version with a warning.

### Out of scope

Deployment targets set inside `CMakeLists.txt` or a toolchain file are *not* visible at tag-computation time (the tag must be known before configuring CMake, since `build/<wheel_tag>` can be a build directory) and are intentionally not honored here. This matches the discussion in the issue.

Fixes #977

## Testing

Added `test_macos_version_cmake_osx_deployment_target` in `tests/test_builder.py`, which calls `get_macosx_deployment_target` directly with injected defines/args (no macOS required, runs cross-platform). It covers define-only, arg-only, typed `:STRING=` args, define-beats-envvar, arg-beats-define, and invalid-value fallback. The test fails before the change and passes after. mypy and ruff pass on the touched files.