### PR TITLE
fix: don't prune directories matched only by glob includes in default inclusion mode (#1248)

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -88,9 +88,12 @@ def each_unignored_file(
                     nested_excludes,
                     is_path=True,
                 ):
-                    # Check to see if any include rules start with this
-                    dstr = (dirpath / dname).as_posix().strip("/") + "/"
-                    if not any(p.lstrip("/").startswith(dstr) for p in include):
+                    # Only prune if no include pattern could match a file below
+                    # this directory. A literal include deeper than the dir, or
+                    # a glob include (e.g. ``pkg/**/*.py``) whose fixed prefix is
+                    # this dir or an ancestor of it, must keep the dir walkable.
+                    dstr = (dirpath / dname).as_posix().strip("/")
+                    if not any(_include_may_match_below(p, dstr) for p in include):
                         dirs.remove(dname)
 
         for fn in filenames:
@@ -106,6 +109,37 @@ def each_unignored_file(
                 is_path=False,
             ):
                 yield path
+
+
+def _include_may_match_below(pattern: str, dirpath: str) -> bool:
+    """
+    Decide whether an include ``pattern`` could match any file beneath the
+    directory ``dirpath`` (both POSIX, leading/trailing slashes stripped).
+
+    The fixed (glob-free) leading portion of the pattern is compared against the
+    directory. A glob like ``pkg/**/*.py`` has fixed prefix ``pkg`` and could
+    match below ``pkg/sub``; a literal include like ``pkg/sub/file.py`` is
+    deeper than ``pkg`` and must keep ``pkg`` walkable. Both cases reduce to the
+    directory and the fixed prefix sharing an ancestor relationship.
+    """
+    cleaned = pattern.lstrip("/")
+    prefix_parts: list[str] = []
+    for part in cleaned.split("/"):
+        # Stop at the first segment containing a glob metacharacter.
+        if any(ch in part for ch in "*?[") or part == "**":
+            break
+        if part:
+            prefix_parts.append(part)
+    prefix = "/".join(prefix_parts)
+    if not prefix:
+        # A leading glob (e.g. ``**/*.py``) can match anywhere below the dir.
+        return True
+    dir_with_sep = f"{dirpath}/"
+    prefix_with_sep = f"{prefix}/"
+    # dir is an ancestor of (or equal to) the fixed prefix, or vice versa.
+    return prefix_with_sep.startswith(dir_with_sep) or dir_with_sep.startswith(
+        prefix_with_sep
+    )
 
 
 def match_path(

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -226,6 +226,59 @@ def test_include_pattern_with_nested_path_and_broad_exclude(
     assert result == {nested_file}
 
 
+def test_glob_include_with_broad_exclude_keeps_subpackages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Regression for #1248: ``exclude=["**/*"]`` plus glob includes like
+    ``pkg/**/*.py`` must still descend into nested subdirectories. Previously
+    the default mode only kept a directory if an include's literal text started
+    with it, so glob-only subpackages were pruned and dropped.
+    """
+    monkeypatch.chdir(tmp_path)
+    files = set(
+        _mk_files(
+            tmp_path,
+            """
+        pkg/__init__.py
+        pkg/main.py
+        pkg/ase/__init__.py
+        pkg/ase/calc.py
+        pkg/common/__init__.py
+        pkg/common/grammar_types/__init__.py
+        pkg/common/grammar_types/base.py
+        pkg/data/values.csv
+        pkg/data/info.py
+        README.md
+    """,
+        )
+    )
+
+    py_files = {f for f in files if f.suffix == ".py"}
+
+    result = set(
+        each_unignored_file(
+            Path(),
+            include=["pkg/**/*.py"],
+            exclude=["**/*"],
+            mode="default",
+        )
+    )
+    assert result == py_files
+
+    # The same result must hold in classic mode (the pre-0.12 behavior).
+    classic = set(
+        each_unignored_file(
+            Path(),
+            include=["pkg/**/*.py"],
+            exclude=["**/*"],
+            mode="classic",
+        )
+    )
+    assert classic == py_files
+
+
 def test_exclude_patterns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
This could make the default setting quite a bit better.

:robot: _AI text below_ :robot:

## Problem

In the default (and `manual`) inclusion mode introduced in 0.12, an excluded subdirectory was pruned from the `os.walk` traversal unless an include pattern's **literal text** started with that directory path (`p.lstrip("/").startswith(dstr)`). Glob includes such as `src/pkg/**/*.py` do not literally start with `src/pkg/ase/`, so entire subtrees (e.g. `ase2sprkkr.ase`, `ase2sprkkr.common.grammar_types`) were pruned during the walk and their files silently dropped from the build. This also produced seemingly nondeterministic results: a sibling directory that happened to be reachable from another literal-path include was kept while one matched only by `**/*.py` was dropped.

Pinning to 0.11.5 or using `sdist.inclusion-mode = "classic"` avoided the regression.

## Fix

`src/scikit_build_core/build/_file_processor.py`: replace the literal-prefix check with `_include_may_match_below`, which derives the fixed (glob-free) leading portion of each include pattern and keeps a directory walkable when that prefix and the directory share an ancestor relationship (either direction). This restores the pre-0.12 (`classic`) result for glob includes while keeping the new manual/default semantics intact, and it does not over-walk excluded trees that have no possible include match.

## Testing

Added `test_glob_include_with_broad_exclude_keeps_subpackages` in `tests/test_file_processor.py`: with `exclude=["**/*"]` and `include=["pkg/**/*.py"]`, all nested matching `.py` files across subpackages are now included in `default` mode, matching `classic` mode. The test fails before the fix and passes after. The full `tests/test_file_processor.py` suite (36 tests) passes.

Fixes #1248