### PR TITLE
fix: only warn about ninja in build-system.requires when it is actually injected (#953)

### DIFF
--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -25,6 +25,7 @@ from ..builder.builder import (
     get_archs,
     get_cmake_args_from_settings,
 )
+from ..builder.get_requires import _uses_ninja_generator
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMake, CMaker
 from ..errors import FailedLiveProcessError
@@ -131,9 +132,16 @@ def _build_wheel_impl(
             "cmake should not be in build-system.requires - scikit-build-core will inject it as needed"
         )
     if "ninja" in requirements:
-        logger.warning(
-            "ninja should not be in build-system.requires - scikit-build-core will inject it as needed"
-        )
+        # Only warn when scikit-build-core can fall back to make, meaning ninja
+        # is not strictly required. If the user forced a Ninja generator or
+        # disabled make-fallback, ninja may genuinely be needed in requires.
+        ninja_settings = settings_reader.settings.ninja
+        uses_ninja = _uses_ninja_generator(settings_reader.settings)
+        ninja_strictly_required = uses_ninja is True or not ninja_settings.make_fallback
+        if not ninja_strictly_required:
+            logger.warning(
+                "ninja should not be in build-system.requires - scikit-build-core will inject it as needed"
+            )
 
     try:
         return _build_wheel_impl_impl(

--- a/tests/test_ninja_requires_warning.py
+++ b/tests/test_ninja_requires_warning.py
@@ -1,0 +1,111 @@
+"""
+Regression tests for issue #953: the "ninja should not be in
+build-system.requires" warning must only fire when scikit-build-core would
+actually fall back to providing ninja itself.  When the user has pinned a
+Ninja generator or disabled make-fallback, ninja is genuinely required and
+the warning is misleading.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from scikit_build_core.build.wheel import _build_wheel_impl
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+PYPROJECT_TEMPLATE = """\
+[build-system]
+requires = ["scikit-build-core", {extra_requires}]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "dummy"
+version = "0.1.0"
+
+[tool.scikit-build]
+wheel.cmake = false
+{skbuild_extras}
+"""
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    extra_requires: str = "",
+    skbuild_extras: str = "",
+) -> None:
+    """Write a minimal pyproject.toml and call _build_wheel_impl for metadata only."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        PYPROJECT_TEMPLATE.format(
+            extra_requires=extra_requires,
+            skbuild_extras=skbuild_extras,
+        ),
+        encoding="utf-8",
+    )
+    mddir = tmp_path / "dist"
+    mddir.mkdir()
+    _build_wheel_impl(None, {}, str(mddir), editable=False)
+
+
+def _ninja_warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        str(r.message)
+        for r in caplog.records
+        if "ninja" in str(r.message) and "build-system.requires" in str(r.message)
+    ]
+
+
+def test_ninja_in_requires_warns_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Warning fires when ninja is in requires and make-fallback is on (default)."""
+    with caplog.at_level(logging.WARNING, logger="scikit_build_core"):
+        _run(tmp_path, monkeypatch, extra_requires='"ninja>=1.5"')
+
+    msgs = _ninja_warning_messages(caplog)
+    assert msgs, "Expected a ninja warning but got none"
+
+
+def test_ninja_in_requires_no_warn_when_make_fallback_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning when ninja.make-fallback is false — ninja is strictly required."""
+    with caplog.at_level(logging.WARNING, logger="scikit_build_core"):
+        _run(
+            tmp_path,
+            monkeypatch,
+            extra_requires='"ninja>=1.5"',
+            skbuild_extras="ninja.make-fallback = false",
+        )
+
+    msgs = _ninja_warning_messages(caplog)
+    assert not msgs, f"Unexpected ninja warning(s): {msgs}"
+
+
+def test_ninja_in_requires_no_warn_when_ninja_generator_forced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning when the user explicitly forces -GNinja (make fallback disabled)."""
+    monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
+    with caplog.at_level(logging.WARNING, logger="scikit_build_core"):
+        _run(
+            tmp_path,
+            monkeypatch,
+            extra_requires='"ninja>=1.5"',
+            skbuild_extras='cmake.args = ["-GNinja"]',
+        )
+
+    msgs = _ninja_warning_messages(caplog)
+    assert not msgs, f"Unexpected ninja warning(s): {msgs}"


### PR DESCRIPTION
This is not correct, the warning still applies. It should be added by us, not in the requires, since if it is present and it is in requires and has no wheel, this will break an otherwise working system.

:robot: _AI text below_ :robot:

## Summary

- The `"ninja should not be in build-system.requires"` warning was firing unconditionally whenever `ninja` appeared in `build-system.requires`, even when scikit-build-core could not reliably fall back to make and thus the user's explicit `ninja` requirement was genuinely necessary.
- Root cause: when the user forces a Ninja generator (`cmake.args = ["-GNinja"]`) or sets `ninja.make-fallback = false`, `allow_make_fallback` is `False` in `set_environment_for_gen`, meaning a missing system ninja raises `NinjaNotFoundError` instead of falling back — ninja is strictly required. The warning is misleading in this configuration.
- Fix: import `_uses_ninja_generator` from `builder/get_requires.py` and gate the ninja warning on `ninja_strictly_required = uses_ninja is True or not ninja_settings.make_fallback`. When ninja is genuinely required, no warning is emitted.

Fixes #953

## Testing

Three focused unit tests added in `tests/test_ninja_requires_warning.py`:

1. `test_ninja_in_requires_warns_by_default` — confirms the warning still fires in the baseline case (make-fallback enabled, no forced generator).
2. `test_ninja_in_requires_no_warn_when_make_fallback_disabled` — confirms no warning when `ninja.make-fallback = false`.
3. `test_ninja_in_requires_no_warn_when_ninja_generator_forced` — confirms no warning when `cmake.args = ["-GNinja"]`.

Tests use a minimal `wheel.cmake = false` pyproject (no cmake detection needed) and `caplog` to assert warning presence/absence. All pass after the fix; the latter two would have failed against the old code.