### PR TITLE
fix: detect symlink loops when walking the source tree for sdist (#1101)

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -31,6 +31,19 @@ def __dir__() -> list[str]:
     return __all__
 
 
+def _dir_key(dirstr: str) -> tuple[int, int] | None:
+    """
+    Identify a directory by its (device, inode) pair so that symlink loops can
+    be detected. Returns None if the directory can't be stat'd (it is then
+    treated as not-yet-seen and handled normally).
+    """
+    try:
+        st = Path(dirstr).stat()
+    except OSError:
+        return None
+    return (st.st_dev, st.st_ino)
+
+
 def each_unignored_file(
     starting_path: Path,
     include: Sequence[str] = (),
@@ -74,8 +87,31 @@ def each_unignored_file(
 
     include_spec = pathspec.GitIgnoreSpec.from_lines(include)
 
+    # Map each visited directory to the set of (device, inode) keys of itself
+    # and all of its ancestors along the walk path. A circular symlink
+    # (e.g. pkg/sub/pkg -> ../../pkg) re-enters a directory that is one of its
+    # own ancestors; pruning it stops os.walk from descending forever or
+    # emitting duplicated, ever-deeper copies of the same files (#1101). A
+    # symlink to an unrelated directory is not an ancestor of itself, so it is
+    # still followed.
+    ancestor_keys: dict[str, frozenset[tuple[int, int]]] = {}
+
     for dirstr, dirs, filenames in os.walk(str(starting_path), followlinks=True):
         dirpath = Path(dirstr)
+        key = _dir_key(dirstr)
+        # os.path.dirname keeps the exact string form os.walk uses for keys
+        # (e.g. "" for the root), unlike Path.parent which maps it to ".".
+        parent_keys = ancestor_keys.get(os.path.dirname(dirstr), frozenset())  # noqa: PTH120
+        if key is not None and key in parent_keys:
+            logger.debug(
+                "Not descending into {} because it is an ancestor of itself "
+                "(symlink loop).",
+                dirpath,
+            )
+            dirs.clear()
+            continue
+        if key is not None:
+            ancestor_keys[dirstr] = parent_keys | {key}
         if mode != "classic":
             for dname in list(dirs):
                 if not match_path(

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -136,6 +137,59 @@ def test_on_each_with_symlink(
             nested_dir.joinpath("more/ignored.txt"),
         }
     assert set(each_unignored_file(Path(), mode=mode)) == files
+
+
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy" and sys.platform.startswith("win"),
+    reason="PyPy on Windows does not support symlinks",
+)
+def test_circular_symlink_terminates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: Literal["default", "classic", "manual"],
+) -> None:
+    """
+    A circular directory symlink (pkg/sub/pkg -> ../../pkg) must not make the
+    walk loop forever or emit duplicated, ever-deeper copies of the same files
+    (#1101).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    pkg = Path("pkg")
+    sub = pkg / "sub"
+    sub.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("content")
+
+    loop = sub / "pkg"
+    try:
+        loop.symlink_to(Path("..") / ".." / "pkg")
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported on this platform")
+    if not loop.is_dir():
+        pytest.skip("Symlink support not available")
+
+    # Guard against an infinite loop (the pre-fix behavior on Linux) so the
+    # test fails fast instead of hanging the suite.
+    result: list[Path] = []
+    error: list[BaseException] = []
+
+    def _collect() -> None:
+        try:
+            result.extend(each_unignored_file(Path(), mode=mode))
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+
+    thread = threading.Thread(target=_collect, daemon=True)
+    thread.start()
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "each_unignored_file did not terminate (symlink loop)"
+    if error:
+        raise error[0]
+
+    # The real __init__.py must appear exactly once and there must be no
+    # ever-deeper duplicates re-entering through the symlink.
+    assert result.count(pkg / "__init__.py") == 1
+    assert not any("sub/pkg/sub/pkg" in p.as_posix() for p in result)
 
 
 def test_dot_git_is_a_file(


### PR DESCRIPTION
Need to trim the comments, but this looks like a nice solution to keep an infinite loop from happening.


:robot: _AI text below_ :robot:

## Problem

Since #362, `build_sdist` follows symlinks while walking the source tree. The `os.walk(..., followlinks=True)` in `each_unignored_file` has no symlink-loop detection, so a circular directory symlink such as:

```
my_package/
└─ some_subfolder/
   └─ my_package -> ../../my_package
```

makes the walk descend through the symlink endlessly. On Linux this is an **infinite loop** that hangs `build_sdist` with no warning; on macOS the kernel self-terminates the path around depth ~66, but the resulting sdist is **corrupt**, containing dozens of ever-deeper duplicated copies of the same files. `sdist.exclude` cannot help: the directory pruning never breaks the cycle.

## Fix

Track each visited directory by its `(st_dev, st_ino)` pair together with the keys of all of its ancestors on the current walk path. If a directory is an ancestor of itself (the defining property of a symlink loop), prune it (`dirs.clear()`) and skip re-entry. Symlinks pointing at unrelated directories are not ancestors of themselves, so they continue to be followed as before — the existing `test_on_each_with_symlink` behavior is preserved.

This is surgical and only addresses the **loop**; the sibling file-symlink discussion (#801) is out of scope here.

Fixes #1101

## Testing

Added `test_circular_symlink_terminates` in `tests/test_file_processor.py` (parametrized over all three inclusion modes). It builds a `pkg/sub/pkg -> ../../pkg` loop and asserts the walk terminates (guarded by a 30s thread-join timeout so it fails fast instead of hanging) and that the real `__init__.py` appears exactly once with no ever-deeper duplicates. The test fails (assertion error / hang) before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)