### PR TITLE
fix: editable rebuild installs into the editable target, not the stale wheel dir (#1135)

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -443,6 +443,21 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
 
         try:
             lock.acquire()
+            # ``cmake --install --prefix`` is silently ignored for install rules
+            # with an absolute DESTINATION (e.g. ``${SKBUILD_PLATLIB_DIR}/...``).
+            # scikit-build-core bakes those SKBUILD_*_DIR cache variables at the
+            # temporary wheel-staging directory, which no longer exists, so a
+            # plain ``--prefix`` install would silently write nowhere useful.
+            # Re-point them at the editable target via an in-place reconfigure so
+            # the install lands in site-packages regardless of how the DESTINATION
+            # was written. The rewrite persists in the build directory's cache, so
+            # it only has to run once: skip it when the cache is already current.
+            # See https://github.com/scikit-build/scikit-build-core/issues/1135
+            if self._needs_reconfigure():
+                reconfigure = [
+                    f"-D{key}={value}" for key, value in self._reinstall_cache()
+                ]
+                run_checked(["cmake", *reconfigure, "."])
             run_checked(["cmake", "--build", ".", *self.build_options])
             run_checked(
                 [
@@ -456,6 +471,54 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             )
         finally:
             lock.release()
+
+    def _reinstall_cache(self) -> list[tuple[str, str]]:
+        """
+        Cache entries that re-point the install destinations at the editable target.
+
+        The original build baked ``SKBUILD_<scheme>_DIR`` (and
+        ``CMAKE_INSTALL_PREFIX``) at the temporary wheel-staging directory, which
+        no longer exists. For an editable install the platlib content lives next
+        to this redirect file (``self.dir``), so re-point the platlib-relative
+        destinations there. The other wheel schemes (data/headers/scripts) are
+        not reconstructable from here, so install rules targeting them are not
+        re-pointed.
+        """
+        platlib = self.dir
+        entries = [
+            ("SKBUILD_PLATLIB_DIR", platlib),
+            ("SKBUILD_PURELIB_DIR", platlib),
+            ("CMAKE_INSTALL_PREFIX", self.install_dir),
+        ]
+        return [(key, value.replace("\\", "/")) for key, value in entries]
+
+    def _needs_reconfigure(self) -> bool:
+        """
+        Whether the install destinations still need to be re-pointed.
+
+        The reconfigure rewrites the SKBUILD_*_DIR / CMAKE_INSTALL_PREFIX entries
+        in the persistent build directory's ``CMakeCache.txt``, and that rewrite
+        survives subsequent rebuilds. Reading the cache and skipping the
+        reconfigure when it already matches keeps steady-state rebuilds to just
+        ``cmake --build`` + ``cmake --install`` -- the reconfigure runs only on
+        the first rebuild after an install (or if the cache is missing).
+        """
+        if not self.path:
+            return True
+        try:
+            with open(os.path.join(self.path, "CMakeCache.txt"), encoding="utf-8") as f:
+                cache_text = f.read()
+        except OSError:
+            return True
+        # CMakeCache.txt lines are ``NAME:TYPE=VALUE``; CMake stores paths with
+        # forward slashes, matching the normalization in _reinstall_cache.
+        cached: dict[str, str] = {}
+        for line in cache_text.splitlines():
+            name_type, sep, value = line.partition("=")
+            if not sep or ":" not in name_type:
+                continue
+            cached[name_type.partition(":")[0]] = value.replace("\\", "/")
+        return any(cached.get(key) != value for key, value in self._reinstall_cache())
 
 
 def install(

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -196,8 +196,89 @@ def test_rebuild_success_runs_build_and_install(
     finder = _make_finder(tmp_path, verbose=False)
     finder.rebuild()
 
-    assert calls[0][:2] == ["cmake", "--build"]
-    assert calls[1][:2] == ["cmake", "--install"]
+    # A reconfigure precedes the build so the install destinations are re-pointed
+    # at the editable target (see test_rebuild_repoints_install_to_editable).
+    assert calls[0][0] == "cmake"
+    assert calls[0][-1] == "."
+    assert calls[1][:2] == ["cmake", "--build"]
+    assert calls[2][:2] == ["cmake", "--install"]
+
+
+def test_rebuild_repoints_install_to_editable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression for #1135.
+
+    ``cmake --install --prefix`` is ignored for install rules with an absolute
+    DESTINATION such as ``${SKBUILD_PLATLIB_DIR}/...``, which is baked at the
+    (now-deleted) temporary wheel directory. The rebuild must therefore re-point
+    SKBUILD_PLATLIB_DIR / CMAKE_INSTALL_PREFIX at the editable target before
+    installing, otherwise the rebuilt artifact never reaches site-packages.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,  # noqa: ARG001
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
+    )
+
+    finder = _make_finder(tmp_path, verbose=False)
+    finder.rebuild()
+
+    # The reconfigure is the first call and must re-point the platlib destination
+    # at the editable target and the install prefix at the install dir.
+    reconfigure = calls[0]
+    assert reconfigure[0] == "cmake"
+    expected_platlib = finder.dir.replace("\\", "/")
+    expected_prefix = finder.install_dir.replace("\\", "/")
+    assert f"-DSKBUILD_PLATLIB_DIR={expected_platlib}" in reconfigure
+    assert f"-DCMAKE_INSTALL_PREFIX={expected_prefix}" in reconfigure
+
+
+def test_rebuild_skips_reconfigure_when_cache_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The re-point reconfigure runs once, not on every rebuild (#1135).
+
+    The reconfigure rewrites the install destinations in the persistent build
+    directory's CMakeCache.txt and that survives, so a rebuild whose cache is
+    already current must skip straight to ``cmake --build`` + ``cmake --install``.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,  # noqa: ARG001
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
+    )
+
+    finder = _make_finder(tmp_path, verbose=False)
+    # Seed a cache that already holds the re-pointed destinations (with a comment
+    # and blank line to exercise the parser's skipping of non-entry lines).
+    cache_lines = ["# This is the CMakeCache file.", ""]
+    cache_lines += [f"{key}:PATH={value}" for key, value in finder._reinstall_cache()]
+    tmp_path.joinpath("CMakeCache.txt").write_text("\n".join(cache_lines) + "\n")
+
+    finder.rebuild()
+
+    # No reconfigure: build is first, install second, and nothing else ran.
+    assert [call[:2] for call in calls] == [
+        ["cmake", "--build"],
+        ["cmake", "--install"],
+    ]
 
 
 def test_rebuild_runs_once_per_process(tmp_path: Path):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

**Option A** for #1135. This is the in-place-reconfigure approach; #1375 is the alternative (**Option B**) that bakes a persistent install tree at first configure and needs no reconfigure at all. Opened both so the two can be compared.

## Problem

With `editable.rebuild = true`, importing the package rebuilds and re-installs via the redirect shim, which runs `cmake --install . --prefix <site-packages>`. But CMake **silently ignores `--prefix`** for install rules whose `DESTINATION` is absolute, e.g. `install(TARGETS ... DESTINATION ${SKBUILD_PLATLIB_DIR}/...)`.

scikit-build-core bakes `SKBUILD_PLATLIB_DIR` (and the other `SKBUILD_*_DIR` cache variables) into the CMake cache pointing at the *temporary* wheel-staging directory used during the initial build. That directory is deleted afterwards, so on rebuild the install writes back to the (now nonexistent / stale) temp path and the refreshed `.so` never reaches site-packages. The running process keeps using the old shared object, so source changes don't take effect.

## Fix (Option A: reconfigure once)

Before building during a rebuild, the redirect re-points the install destinations at the editable target via an in-place reconfigure:

- `SKBUILD_PLATLIB_DIR` / `SKBUILD_PURELIB_DIR` -> the directory next to the redirect file (the editable platlib root in site-packages)
- `CMAKE_INSTALL_PREFIX` -> the editable install dir

This makes the install land in site-packages regardless of whether the project wrote a relative `DESTINATION` (already worked via `--prefix`) or an absolute `${SKBUILD_PLATLIB_DIR}/...` one (previously broken). The existing `--install --prefix` call is kept, so the relative-destination path is unchanged.

The reconfigure rewrites those entries in the **persistent build directory's `CMakeCache.txt`**, and that rewrite survives subsequent rebuilds. So it only has to run **once**: `_needs_reconfigure()` reads the cache and skips the reconfigure when it is already current, keeping steady-state rebuilds to just `cmake --build` + `cmake --install`. The cost is paid exactly once, on the first rebuild after install.

## Comparison with #1375 (Option B)

| | #1342 (Option A) | #1375 (Option B) |
|---|---|---|
| Mechanism | reconfigure once, on first rebuild | bake persistent install tree at first configure |
| Reconfigure cost | one reconfigure after install | none |
| Artifacts in site-packages | yes (installed there) | no (loaded from build tree) |
| Schemes fixed | platlib/purelib | all (platlib/purelib/data/headers/scripts/metadata) |
| Diff size | small (shim only) | larger (wheel build + redirect) |

## Remaining limitation

Only the platlib/purelib schemes are re-pointed. The other wheel schemes (`data`, `headers`, `scripts`, `metadata`) are not reconstructable from the redirect shim, so install rules targeting `${SKBUILD_DATA_DIR}` / `${SKBUILD_HEADERS_DIR}` / `${SKBUILD_METADATA_DIR}` are still not refreshed on rebuild (this was already the case before this change). The common case -- compiled extension modules installed into platlib -- is fixed. (#1375 does not have this limitation.)

## Testing

- `test_rebuild_repoints_install_to_editable` asserts the first rebuild issues a reconfigure with `-DSKBUILD_PLATLIB_DIR=...` and `-DCMAKE_INSTALL_PREFIX=...` pointed at the editable target.
- `test_rebuild_skips_reconfigure_when_cache_current` asserts a rebuild whose cache is already current skips straight to `cmake --build` + `cmake --install` (no reconfigure). It fails before the once-guard and passes after.
- `test_rebuild_success_runs_build_and_install` updated for the reconfigure-then-build-then-install ordering.

Fixes #1135