### PR TITLE
feat: warn if plugin extra missing from build-system.requires

### DIFF
--- a/src/scikit_build_core/_check_extra.py
+++ b/src/scikit_build_core/_check_extra.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+from ._compat import tomllib
+from ._logging import rich_warning
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = ["warn_missing_extra"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _has_extra(reqlist: Iterable[str], extra: str) -> bool:
+    """Return True if scikit-build-core is required with the given extra."""
+    norm_extra = canonicalize_name(extra)
+    for req in reqlist:
+        try:
+            parsed = Requirement(req)
+        except InvalidRequirement:
+            continue
+        if canonicalize_name(parsed.name) != "scikit-build-core":
+            continue
+        if parsed.marker is not None and not parsed.marker.evaluate():
+            continue
+        if any(canonicalize_name(e) == norm_extra for e in parsed.extras):
+            return True
+    return False
+
+
+def warn_missing_extra(
+    extra: str, *, pyproject_path: Path | str = "pyproject.toml"
+) -> None:
+    """
+    Warn if ``scikit-build-core[{extra}]`` is missing from
+    ``build-system.requires``.
+
+    The setuptools and hatchling plugins may eventually move to separate
+    packages; depending on the extra keeps the plugin's requirements installed
+    if that happens.
+    """
+    path = Path(pyproject_path)
+    if not path.is_file():
+        return
+    with path.open("rb") as f:
+        pyproject = tomllib.load(f)
+    reqlist = pyproject.get("build-system", {}).get("requires", [])
+    if not _has_extra(reqlist, extra):
+        rich_warning(
+            f"{{bold}}scikit-build-core[{extra}]{{normal}} is not in "
+            "build-system.requires. Add it to keep working if the plugin moves "
+            "to a separate package in the future."
+        )

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -15,6 +15,7 @@ from typing import Any
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging.version import Version
 
+from .._check_extra import warn_missing_extra
 from .._logging import logger, rich_print
 from ..build._editable import (
     editable_inplace_files,
@@ -151,6 +152,8 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         editable = state == "editable"
 
         self._validate(settings_reader)
+
+        warn_missing_extra("hatchling")
 
         if state == "sdist":
             build_data["artifacts"].append("CMakeLists.txt")  # Needs full list, etc.

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 import setuptools
 from packaging.version import Version
 
+from .._check_extra import warn_missing_extra
 from .._compat import tomllib
 from .._compat.setuptools.errors import SetupError
 from .._logging import LEVEL_VALUE, raw_logger
@@ -515,6 +516,8 @@ class BuildCMake(setuptools.Command):
         assert self.build_lib is not None
         assert self.build_temp is not None
         assert self.plat_name is not None
+
+        warn_missing_extra("setuptools")
 
         self.editable_mode = self._get_editable_mode()
         # run() is always a wheel or editable build; pass the matching state so

--- a/tests/packages/abi3_setuptools_ext/pyproject.toml
+++ b/tests/packages/abi3_setuptools_ext/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["scikit-build-core", "setuptools"]
+requires = ["scikit-build-core[setuptools]"]
 build-backend = "scikit_build_core.setuptools.build_meta"

--- a/tests/packages/hatchling/pyproject.toml
+++ b/tests/packages/hatchling/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "scikit-build-core"]
+requires = ["scikit-build-core[hatchling]"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/packages/mixed_setuptools/pyproject.toml
+++ b/tests/packages/mixed_setuptools/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/packages/plugin_setuptools_install_dir/pyproject.toml
+++ b/tests/packages/plugin_setuptools_install_dir/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/packages/simple_setuptools_ext/pyproject.toml
+++ b/tests/packages/simple_setuptools_ext/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/packages/toml_setuptools_ext/pyproject.toml
+++ b/tests/packages/toml_setuptools_ext/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/packages/wrapper_setuptools_classic_layout/pyproject.toml
+++ b/tests/packages/wrapper_setuptools_classic_layout/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/packages/wrapper_setuptools_install_dir/pyproject.toml
+++ b/tests/packages/wrapper_setuptools_install_dir/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit_build_core",
-    "setuptools",
+    "scikit_build_core[setuptools]",
 ]
 build-backend = "scikit_build_core.setuptools.build_meta"
 

--- a/tests/test_check_extra.py
+++ b/tests/test_check_extra.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scikit_build_core._check_extra import _has_extra, warn_missing_extra
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import CaptureFixture
+
+
+@pytest.mark.parametrize(
+    ("reqlist", "extra", "expected"),
+    [
+        (["scikit-build-core[setuptools]"], "setuptools", True),
+        (["scikit_build_core[Setuptools]>=1"], "setuptools", True),
+        (['scikit-build-core[setuptools]; python_version>="3"'], "setuptools", True),
+        (["scikit-build-core[hatchling]"], "hatchling", True),
+        (["scikit-build-core", "setuptools"], "setuptools", False),
+        (["scikit-build-core[hatchling]"], "setuptools", False),
+        (['scikit-build-core[setuptools]; python_version<"3"'], "setuptools", False),
+        (["not a requirement!!", "scikit-build-core[setuptools]"], "setuptools", True),
+        ([], "setuptools", False),
+    ],
+)
+def test_has_extra(reqlist: list[str], extra: str, expected: bool) -> None:
+    assert _has_extra(reqlist, extra) is expected
+
+
+def _write_pyproject(tmp_path: Path, requires: str) -> Path:
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        textwrap.dedent(f"""\
+            [build-system]
+            requires = {requires}
+            build-backend = "setuptools.build_meta"
+            """)
+    )
+    return path
+
+
+def test_warn_missing_extra_warns(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    path = _write_pyproject(tmp_path, '["scikit-build-core", "setuptools"]')
+    warn_missing_extra("setuptools", pyproject_path=path)
+    err = capsys.readouterr().err
+    assert "scikit-build-core[setuptools]" in err
+    assert "build-system.requires" in err
+
+
+def test_warn_missing_extra_quiet(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    path = _write_pyproject(tmp_path, '["scikit-build-core[setuptools]"]')
+    warn_missing_extra("setuptools", pyproject_path=path)
+    assert capsys.readouterr().err == ""
+
+
+def test_warn_missing_extra_no_pyproject(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    warn_missing_extra("setuptools", pyproject_path=tmp_path / "pyproject.toml")
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The hatchling and setuptools plugins now warn when `scikit-build-core[hatchling]` / `scikit-build-core[setuptools]` is not present in `build-system.requires`. These plugins may eventually be split into separate packages; depending on the relevant extra ensures a project keeps building if that happens.

## Changes

- **New helper** `src/scikit_build_core/_check_extra.py`: `warn_missing_extra(extra)` reads `build-system.requires` from `pyproject.toml` and emits a `rich_warning` unless a `scikit-build-core` requirement carries the given extra. It normalizes names/extras and respects environment markers, and no-ops when `pyproject.toml` is absent (classic `setup.py`-only projects).
- **setuptools** (`setuptools/build_cmake.py`): calls `warn_missing_extra("setuptools")` at the top of `BuildCMake.run()`, covering the PEP 517 backend, entry-point, and wrapper paths.
- **hatchling** (`hatch/plugin.py`): calls `warn_missing_extra("hatchling")` in `_initialize`.
- **Sample packages**: the setuptools and hatchling fixtures in `tests/packages/` are updated to the `scikit-build-core[setuptools]` / `scikit-build-core[hatchling]` form (the extras pull in setuptools/hatchling, so the standalone entries are dropped).
- **Tests**: `tests/test_check_extra.py` covers `_has_extra` parsing and the warn/quiet/missing-file behaviors.

The warning is written to stderr via `rich_warning` (not `warnings.warn`), so it does not interact with pytest's `filterwarnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)