### PR TITLE
fix: import remapped namespace packages in editable installs (#1040)

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -219,6 +219,32 @@ class _ScikitBuildResourceLoaderWrapper:
         return _ScikitBuildEditableReader(self._skbuild_paths)
 
 
+class _ScikitBuildNamespaceLoader:
+    """
+    Loader for a synthesized namespace package (a tracked directory with no
+    importable __init__).
+
+    Returning None from create_module and doing nothing in exec_module mirrors
+    namespace-package semantics, while __path__ (set on the spec) carries every
+    tracked search location. A dedicated loader -- rather than a loader-less
+    namespace spec -- is required so importlib.resources can read data across
+    all locations: the stdlib NamespaceReader only accepts a real
+    _NamespacePath, which cannot be constructed from remapped directories.
+    """
+
+    def __init__(self, search_paths: list[str]) -> None:
+        self._skbuild_paths = search_paths
+
+    def create_module(self, spec: object) -> object:
+        return None
+
+    def exec_module(self, module: object) -> None:
+        return None
+
+    def get_resource_reader(self, module_name: str) -> _ScikitBuildEditableReader:
+        return _ScikitBuildEditableReader(self._skbuild_paths)
+
+
 def _patch_importlib_resources_for_python39() -> None:
     """
     Make importlib.resources.files() honor the editable resource reader on Python 3.9.
@@ -241,7 +267,9 @@ def _patch_importlib_resources_for_python39() -> None:
 
     def fallback_resources(spec: object) -> object:
         loader = getattr(spec, "loader", None)
-        if isinstance(loader, _ScikitBuildResourceLoaderWrapper):
+        if isinstance(
+            loader, (_ScikitBuildResourceLoaderWrapper, _ScikitBuildNamespaceLoader)
+        ):
             return loader.get_resource_reader(getattr(spec, "name", "")).files()
         return original_fallback_resources(spec)
 
@@ -331,6 +359,22 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         if fullname in self.known_source_files:
             origin = self.known_source_files[fullname]
             return self._make_spec(fullname, origin, submodule_search_locations)
+        # A tracked package directory without an importable __init__ is a
+        # namespace package. Its parent's __path__ need not physically contain
+        # it -- wheel.packages can remap it from an unrelated source location --
+        # so the standard PathFinder cannot resolve it. Synthesize a namespace
+        # spec from the tracked search locations, with a loader that exposes a
+        # resource reader spanning every location.
+        if submodule_search_locations is not None:
+            loader = _ScikitBuildNamespaceLoader(submodule_search_locations)
+            spec = importlib.util.spec_from_loader(
+                fullname,
+                loader,  # type: ignore[arg-type]
+                is_package=True,
+            )
+            if spec is not None:
+                spec.submodule_search_locations = submodule_search_locations
+            return spec
         return None
 
     def _make_spec(

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -359,12 +359,9 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         if fullname in self.known_source_files:
             origin = self.known_source_files[fullname]
             return self._make_spec(fullname, origin, submodule_search_locations)
+
         # A tracked package directory without an importable __init__ is a
-        # namespace package. Its parent's __path__ need not physically contain
-        # it -- wheel.packages can remap it from an unrelated source location --
-        # so the standard PathFinder cannot resolve it. Synthesize a namespace
-        # spec from the tracked search locations, with a loader that exposes a
-        # resource reader spanning every location.
+        # namespace package.
         if submodule_search_locations is not None:
             loader = _ScikitBuildNamespaceLoader(submodule_search_locations)
             spec = importlib.util.spec_from_loader(

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -21,10 +21,6 @@ import pytest
         pytest.param(
             False,
             id="datafolder",
-            marks=pytest.mark.xfail(
-                sys.version_info[:2] == (3, 9),
-                reason="Python 3.9 redirect does not support resource-only data folders yet",
-            ),
         ),
     ],
 )

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -297,11 +297,14 @@ def test_navigate_editable_remapped_namespace(
     assert out == "remapped"
 
     # importlib.resources must reach data in the remapped namespace directory.
-    data = virtualenv.execute(
-        "from importlib.resources import files;"
-        " print(files('pkg.namespace').joinpath('data.txt').read_text(encoding='utf-8'))"
-    )
-    assert data == "payload"
+    # importlib.resources.files() only exists from 3.9 (matches the resource
+    # checks in test_navigate_editable_pkg).
+    if sys.version_info >= (3, 9):
+        data = virtualenv.execute(
+            "from importlib.resources import files;"
+            " print(files('pkg.namespace').joinpath('data.txt').read_text(encoding='utf-8'))"
+        )
+        assert data == "payload"
 
 
 def test_editable_redirect_files_legacy_pth(tmp_path: Path):

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -297,14 +297,20 @@ def test_navigate_editable_remapped_namespace(
     assert out == "remapped"
 
     # importlib.resources must reach data in the remapped namespace directory.
-    # importlib.resources.files() only exists from 3.9 (matches the resource
-    # checks in test_navigate_editable_pkg).
+    # files() only exists from 3.9; on 3.8 the older read_text() API resolves
+    # the same way, via the loader's get_resource_reader().open_resource(). The
+    # subprocess venv shares this interpreter's version, so branch on it here.
     if sys.version_info >= (3, 9):
-        data = virtualenv.execute(
+        read_data = (
             "from importlib.resources import files;"
             " print(files('pkg.namespace').joinpath('data.txt').read_text(encoding='utf-8'))"
         )
-        assert data == "payload"
+    else:
+        read_data = (
+            "from importlib.resources import read_text;"
+            " print(read_text('pkg.namespace', 'data.txt'))"
+        )
+    assert virtualenv.execute(read_data) == "payload"
 
 
 def test_editable_redirect_files_legacy_pth(tmp_path: Path):

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -142,9 +142,6 @@ def editable_package(
     return EditablePackage(site_packages, pkg_dir, src_pkg_dir)
 
 
-@pytest.mark.xfail(
-    sys.version_info[:2] == (3, 9), reason="Python 3.9 not supported yet"
-)
 def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VEnv):
     site_packages, pkg_dir, src_pkg_dir = editable_package
 
@@ -235,6 +232,76 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
     if sys.version_info >= (3, 9):
         virtualenv.execute("import pkg.src_files")
         virtualenv.execute("import pkg.installed_files")
+
+
+def test_navigate_editable_remapped_namespace(
+    tmp_path: Path, virtualenv: VEnv, monkeypatch: pytest.MonkeyPatch
+):
+    # Regression test for #1040: a namespace subpackage (a directory with no
+    # __init__) remapped by wheel.packages from a source location *outside* the
+    # parent package's source tree must still be importable in an editable
+    # install. The parent's __path__ does not physically contain it, so the
+    # standard PathFinder cannot resolve it and the redirect finder has to
+    # synthesize the namespace spec from the tracked search locations. Unlike
+    # the resource-reading parts of test_navigate_editable_pkg, this works on
+    # every supported Python (including 3.9).
+    site_packages = virtualenv.purelib
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    monkeypatch.chdir(source_dir)
+
+    # Regular package at its own location ...
+    pkg_src = source_dir / "lang" / "pkg"
+    pkg_src.mkdir(parents=True)
+    pkg_src.joinpath("__init__.py").touch()
+
+    # ... and a namespace subpackage living somewhere unrelated, merged in as
+    # pkg.namespace by wheel.packages, holding both a module and a data file.
+    extras_src = source_dir / "extras"
+    extras_src.mkdir()
+    extras_src.joinpath("demo.py").write_text("value = 'remapped'\n")
+    extras_src.joinpath("data.txt").write_text("payload")
+
+    modules = {
+        "pkg": str(pkg_src / "__init__.py"),
+        "pkg.namespace.demo": str(extras_src / "demo.py"),
+    }
+    directories = {
+        "pkg": [str(pkg_src)],
+        "pkg.namespace": [str(extras_src)],
+    }
+    editable_txt = editable_redirect(
+        modules=modules,
+        installed={},
+        directories=directories,
+        packages=["pkg"],
+        reload_dir=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        install_dir="",
+    )
+
+    site_packages.joinpath("_editable_skbc_pkg.py").write_text(editable_txt)
+    site_packages.joinpath("_editable_skbc_pkg.pth").write_text(
+        "import _editable_skbc_pkg\n"
+    )
+
+    # Importing the bare namespace package and a module under it must both work.
+    virtualenv.execute("import pkg.namespace")
+    out = virtualenv.execute(
+        "import pkg.namespace.demo; print(pkg.namespace.demo.value)"
+    )
+    assert out == "remapped"
+
+    # importlib.resources must reach data in the remapped namespace directory.
+    data = virtualenv.execute(
+        "from importlib.resources import files;"
+        " print(files('pkg.namespace').joinpath('data.txt').read_text(encoding='utf-8'))"
+    )
+    assert data == "payload"
 
 
 def test_editable_redirect_files_legacy_pth(tmp_path: Path):

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -237,14 +237,7 @@ def test_navigate_editable_pkg(editable_package: EditablePackage, virtualenv: VE
 def test_navigate_editable_remapped_namespace(
     tmp_path: Path, virtualenv: VEnv, monkeypatch: pytest.MonkeyPatch
 ):
-    # Regression test for #1040: a namespace subpackage (a directory with no
-    # __init__) remapped by wheel.packages from a source location *outside* the
-    # parent package's source tree must still be importable in an editable
-    # install. The parent's __path__ does not physically contain it, so the
-    # standard PathFinder cannot resolve it and the redirect finder has to
-    # synthesize the namespace spec from the tracked search locations. Unlike
-    # the resource-reading parts of test_navigate_editable_pkg, this works on
-    # every supported Python (including 3.9).
+    # Regression test for #1040
     site_packages = virtualenv.purelib
 
     source_dir = tmp_path / "source"
@@ -297,9 +290,6 @@ def test_navigate_editable_remapped_namespace(
     assert out == "remapped"
 
     # importlib.resources must reach data in the remapped namespace directory.
-    # files() only exists from 3.9; on 3.8 the older read_text() API resolves
-    # the same way, via the loader's get_resource_reader().open_resource(). The
-    # subprocess venv shares this interpreter's version, so branch on it here.
     if sys.version_info >= (3, 9):
         read_data = (
             "from importlib.resources import files;"


### PR DESCRIPTION
I think this fixes most of the remaining issues with editable installs, including the 3.9 only issue.

:robot: _AI text below_ :robot:

Closes #1040 (the part still outstanding).

## Problem

When `wheel.packages` assembles a package from subpackages scattered across the source tree, a **namespace subpackage** — a directory with no importable `__init__` — remapped from a source location *outside* the parent package's source tree was not importable in editable installs (it works in a regular install).

Reproducer (the issue's structure, trimmed):

```toml
[tool.scikit-build.wheel.packages]
"oif" = "oif/lang_python/oif"
"oif/examples" = "examples"          # examples/ has no __init__.py
```

`import oif.examples.demo` fails with `ModuleNotFoundError: No module named 'oif.examples'`. The redirect finder's `find_spec` returned `None` for `oif.examples` (it isn't a known module file), and the standard `PathFinder` can't resolve it either, because `oif.__path__` points at `oif/lang_python/oif`, which doesn't physically contain an `examples` directory.

Regular subpackages (those with an `__init__`) already worked; only the namespace case was broken.

## Fix

- `find_spec` now synthesizes a namespace-package spec from the tracked search locations when a name is a package directory with no importable `__init__`.
- New `_ScikitBuildNamespaceLoader` backs those specs. A dedicated loader (rather than a loader-less namespace spec) is required so `importlib.resources` can read data across every search location: the stdlib `NamespaceReader` only accepts a real `_NamespacePath`, which can't be constructed from remapped directories.
- Extended `_patch_importlib_resources_for_python39` to recognize the new loader.

## Python 3.9

Verified on 3.9, 3.11, 3.12, 3.13. As a side effect, data-only directories now resolve through the namespace loader on 3.9, which fixes install-tree resource reading there — so the previously-`xfail`'d 3.9 case in `test_navigate_editable_pkg` now genuinely passes. Since `xfail_strict = true`, the stale marker is dropped (it would otherwise fail CI as XPASS).

## Tests

Added `test_navigate_editable_remapped_namespace`: remaps a namespace subpackage from outside the parent's source tree and asserts both module import and `importlib.resources` data reads work. Full editable suite passes (29 passed, 2 skipped).