### PR TITLE
fix(docs): make sphinx-tippy tooltips follow the active theme

### DIFF
--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -15,13 +15,41 @@
 
 /*
  * Arrow fill (::before) follows the box; its outline (::after) the box border.
- * Only the side facing the box has a non-zero border width, so recoloring all
- * four sides is safe. The bare [data-placement] keeps specificity equal to
- * light-border's own per-placement rules so these (loaded later) win.
+ * The arrow is a CSS triangle: only the side facing the box may be colored, as
+ * the two perpendicular borders must stay transparent to form the point. That
+ * means one rule per placement (matching light-border's own per-placement
+ * selectors, so specificity ties and these later-loaded rules win).
  */
-.tippy-box[data-theme~="light-border"][data-placement] > .tippy-arrow::before {
-  border-color: var(--color-background-hover);
+.tippy-box[data-theme~="light-border"][data-placement^="top"]
+  > .tippy-arrow::before {
+  border-top-color: var(--color-background-hover);
 }
-.tippy-box[data-theme~="light-border"][data-placement] > .tippy-arrow::after {
-  border-color: var(--color-foreground-border);
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
+  > .tippy-arrow::before {
+  border-bottom-color: var(--color-background-hover);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="left"]
+  > .tippy-arrow::before {
+  border-left-color: var(--color-background-hover);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="right"]
+  > .tippy-arrow::before {
+  border-right-color: var(--color-background-hover);
+}
+
+.tippy-box[data-theme~="light-border"][data-placement^="top"]
+  > .tippy-arrow::after {
+  border-top-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
+  > .tippy-arrow::after {
+  border-bottom-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="left"]
+  > .tippy-arrow::after {
+  border-left-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="right"]
+  > .tippy-arrow::after {
+  border-right-color: var(--color-foreground-border);
 }

--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -1,0 +1,26 @@
+/*
+ * sphinx-tippy loads tippy.js with its default dark theme (#333 box), but the
+ * tip content is furo page HTML styled with furo's theme variables. The result
+ * is a dark box wrapping light-mode content. Drive the box from the same furo
+ * variables so it matches the page in both light and dark mode.
+ */
+.tippy-box {
+  background-color: var(--color-background-primary);
+  color: var(--color-foreground-primary);
+  border: 1px solid var(--color-background-border);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* The arrow color in tippy's default theme is set via per-placement borders. */
+.tippy-box[data-placement^="top"] > .tippy-arrow::before {
+  border-top-color: var(--color-background-primary);
+}
+.tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+  border-bottom-color: var(--color-background-primary);
+}
+.tippy-box[data-placement^="left"] > .tippy-arrow::before {
+  border-left-color: var(--color-background-primary);
+}
+.tippy-box[data-placement^="right"] > .tippy-arrow::before {
+  border-right-color: var(--color-background-primary);
+}

--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -1,28 +1,41 @@
 /*
- * sphinx-tippy loads tippy.js with its default dark theme (#333 box), but the
- * tip content is furo page HTML styled with furo's theme variables. The result
- * is a dark box wrapping light-mode content. Drive the box from the same furo
- * variables so it matches the page in both light and dark mode.
+ * sphinx-tippy renders tooltips with tippy.js, whose bundled themes hard-code
+ * light colors (#fff / #333). We use tippy's light-border theme (loaded in
+ * conf.py) for its outlined box and arrow, then recolor it from furo's theme
+ * variables so the tooltip matches the page in both light and dark mode.
  *
- * Box colors follow @lkubb's furo recipe:
+ * Colors follow @lkubb's furo recipe:
  * https://github.com/sphinx-extensions2/sphinx-tippy/issues/8#issuecomment-2311342324
  */
-.tippy-box {
+.tippy-box[data-theme~="light-border"] {
   background-color: var(--color-background-hover);
   color: var(--color-foreground-primary);
-  border: 1px solid var(--color-foreground-border);
+  border-color: var(--color-foreground-border);
 }
 
-/* The arrow color in tippy's default theme is set via per-placement borders. */
-.tippy-box[data-placement^="top"] > .tippy-arrow::before {
+/* Arrow fill (::before) follows the box; its outline (::after) the box border. */
+.tippy-box[data-theme~="light-border"][data-placement^="top"] > .tippy-arrow::before {
   border-top-color: var(--color-background-hover);
 }
-.tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"] > .tippy-arrow::before {
   border-bottom-color: var(--color-background-hover);
 }
-.tippy-box[data-placement^="left"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="left"] > .tippy-arrow::before {
   border-left-color: var(--color-background-hover);
 }
-.tippy-box[data-placement^="right"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="right"] > .tippy-arrow::before {
   border-right-color: var(--color-background-hover);
+}
+
+.tippy-box[data-theme~="light-border"][data-placement^="top"] > .tippy-arrow::after {
+  border-top-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"] > .tippy-arrow::after {
+  border-bottom-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="left"] > .tippy-arrow::after {
+  border-left-color: var(--color-foreground-border);
+}
+.tippy-box[data-theme~="light-border"][data-placement^="right"] > .tippy-arrow::after {
+  border-right-color: var(--color-foreground-border);
 }

--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -13,37 +13,15 @@
   border-color: var(--color-foreground-border);
 }
 
-/* Arrow fill (::before) follows the box; its outline (::after) the box border. */
-.tippy-box[data-theme~="light-border"][data-placement^="top"]
-  > .tippy-arrow::before {
-  border-top-color: var(--color-background-hover);
+/*
+ * Arrow fill (::before) follows the box; its outline (::after) the box border.
+ * Only the side facing the box has a non-zero border width, so recoloring all
+ * four sides is safe. The bare [data-placement] keeps specificity equal to
+ * light-border's own per-placement rules so these (loaded later) win.
+ */
+.tippy-box[data-theme~="light-border"][data-placement] > .tippy-arrow::before {
+  border-color: var(--color-background-hover);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
-  > .tippy-arrow::before {
-  border-bottom-color: var(--color-background-hover);
-}
-.tippy-box[data-theme~="light-border"][data-placement^="left"]
-  > .tippy-arrow::before {
-  border-left-color: var(--color-background-hover);
-}
-.tippy-box[data-theme~="light-border"][data-placement^="right"]
-  > .tippy-arrow::before {
-  border-right-color: var(--color-background-hover);
-}
-
-.tippy-box[data-theme~="light-border"][data-placement^="top"]
-  > .tippy-arrow::after {
-  border-top-color: var(--color-foreground-border);
-}
-.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
-  > .tippy-arrow::after {
-  border-bottom-color: var(--color-foreground-border);
-}
-.tippy-box[data-theme~="light-border"][data-placement^="left"]
-  > .tippy-arrow::after {
-  border-left-color: var(--color-foreground-border);
-}
-.tippy-box[data-theme~="light-border"][data-placement^="right"]
-  > .tippy-arrow::after {
-  border-right-color: var(--color-foreground-border);
+.tippy-box[data-theme~="light-border"][data-placement] > .tippy-arrow::after {
+  border-color: var(--color-foreground-border);
 }

--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -3,24 +3,26 @@
  * tip content is furo page HTML styled with furo's theme variables. The result
  * is a dark box wrapping light-mode content. Drive the box from the same furo
  * variables so it matches the page in both light and dark mode.
+ *
+ * Box colors follow @lkubb's furo recipe:
+ * https://github.com/sphinx-extensions2/sphinx-tippy/issues/8#issuecomment-2311342324
  */
 .tippy-box {
-  background-color: var(--color-background-primary);
+  background-color: var(--color-background-hover);
   color: var(--color-foreground-primary);
-  border: 1px solid var(--color-background-border);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--color-foreground-border);
 }
 
 /* The arrow color in tippy's default theme is set via per-placement borders. */
 .tippy-box[data-placement^="top"] > .tippy-arrow::before {
-  border-top-color: var(--color-background-primary);
+  border-top-color: var(--color-background-hover);
 }
 .tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
-  border-bottom-color: var(--color-background-primary);
+  border-bottom-color: var(--color-background-hover);
 }
 .tippy-box[data-placement^="left"] > .tippy-arrow::before {
-  border-left-color: var(--color-background-primary);
+  border-left-color: var(--color-background-hover);
 }
 .tippy-box[data-placement^="right"] > .tippy-arrow::before {
-  border-right-color: var(--color-background-primary);
+  border-right-color: var(--color-background-hover);
 }

--- a/docs/_static/tippy.css
+++ b/docs/_static/tippy.css
@@ -14,28 +14,36 @@
 }
 
 /* Arrow fill (::before) follows the box; its outline (::after) the box border. */
-.tippy-box[data-theme~="light-border"][data-placement^="top"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="top"]
+  > .tippy-arrow::before {
   border-top-color: var(--color-background-hover);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="bottom"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
+  > .tippy-arrow::before {
   border-bottom-color: var(--color-background-hover);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="left"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="left"]
+  > .tippy-arrow::before {
   border-left-color: var(--color-background-hover);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="right"] > .tippy-arrow::before {
+.tippy-box[data-theme~="light-border"][data-placement^="right"]
+  > .tippy-arrow::before {
   border-right-color: var(--color-background-hover);
 }
 
-.tippy-box[data-theme~="light-border"][data-placement^="top"] > .tippy-arrow::after {
+.tippy-box[data-theme~="light-border"][data-placement^="top"]
+  > .tippy-arrow::after {
   border-top-color: var(--color-foreground-border);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="bottom"] > .tippy-arrow::after {
+.tippy-box[data-theme~="light-border"][data-placement^="bottom"]
+  > .tippy-arrow::after {
   border-bottom-color: var(--color-foreground-border);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="left"] > .tippy-arrow::after {
+.tippy-box[data-theme~="light-border"][data-placement^="left"]
+  > .tippy-arrow::after {
   border-left-color: var(--color-foreground-border);
 }
-.tippy-box[data-theme~="light-border"][data-placement^="right"] > .tippy-arrow::after {
+.tippy-box[data-theme~="light-border"][data-placement^="right"]
+  > .tippy-arrow::after {
   border-right-color: var(--color-foreground-border);
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,8 @@ tippy_rtd_urls = [
     "https://packaging.readthedocs.io/en/stable",
     "https://setuptools.readthedocs.io/en/latest",
 ]
+# Recolored to furo's theme variables in _static/tippy.css.
+tippy_props = {"theme": "light-border"}
 
 nitpick_ignore = [
     ("py:class", "setuptools.dist.Distribution"),
@@ -150,7 +152,13 @@ html_theme_options = {
 html_copy_source = False
 html_show_sourcelink = False
 html_static_path = ["_static"]
-html_css_files = ["tippy.css"]
+# The light-border theme gives the tooltip arrow an outline; tippy.css recolors
+# it (and the box) from furo's theme variables. tippy.css must come last so its
+# overrides win. sphinx-tippy already loads tippy.js itself from this CDN.
+html_css_files = [
+    "https://unpkg.com/tippy.js@6/themes/light-border.css",
+    "tippy.css",
+]
 
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,8 @@ html_theme_options = {
 }
 html_copy_source = False
 html_show_sourcelink = False
+html_static_path = ["_static"]
+html_css_files = ["tippy.css"]
 
 
 # -- Extension configuration -------------------------------------------------


### PR DESCRIPTION
Gave Claude Desktop a screenshot, and it also runs a browser and visually inspects the results. (Normally don't like leaving the CLI, but this is a benefit for web stuff!)

:robot: _AI text below_ :robot:

## What

`sphinx-tippy` loads tippy.js with its bundled **default dark theme** (`.tippy-box` background `#333`), regardless of the active furo theme. In light mode this produced a dark tooltip box wrapping light-mode page content, leaving parts (especially inline code like `RPATH`, `PATH`, `os.add_dll_directory`) hard to read.

This adds a small stylesheet that drives the tooltip box and arrow colors from furo's own theme variables (`--color-background-primary`, `--color-foreground-primary`, `--color-background-border`), so the tooltip matches the page in both light and dark mode.

## Changes

- New `docs/_static/tippy.css` overriding `.tippy-box` and the per-placement `.tippy-arrow::before` border colors.
- `docs/conf.py`: register it via `html_static_path = ["_static"]` and `html_css_files = ["tippy.css"]` (neither existed before).

## Notes for reviewers

- No `!important` needed: tippy.js injects its bundled stylesheet *before* the first existing `<link>`, so our later-loaded sheet wins at equal specificity.
- Verified by building the docs and inspecting the rendered tooltip:
  - Light mode → `bg: rgb(255,255,255)`, `color: rgb(0,0,0)`
  - Dark mode → `bg: rgb(19,20,22)`, `color: rgb(207,208,208)`