### PR TITLE
test: adapt to setuptools-scm 10 / vcs-versioning 2 warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,8 @@ filterwarnings = [
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning",  # From cattrs 24.1.2 and other?
     "ignore:The 'wheel.metadata' package has been made private:DeprecationWarning",
     "ignore:version of cmake-example already set:UserWarning",  # Caused by setuptoools-scm 9+ being installed
+    "default:tag.strict is not set:FutureWarning",  # setuptools-scm 10+ asks users to set tag.strict explicitly
+    "default:Configuration was created without VcsEnvironment:DeprecationWarning",  # Leaked by vcs-versioning 2.x internals, even from its public API
 ]
 log_level = "INFO"
 pythonpath = ["tests/utils"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

setuptools-scm 10.1 now builds on the new **vcs-versioning 2.x** backend, which introduced two warnings that our `filterwarnings = ["error", ...]` turned into a hard test failure (`test_plugin_metadata[dynamic_metadata]`, see [this CI run](https://github.com/scikit-build/scikit-build-core/actions/runs/27962795570/job/82748684424?pr=1349)):

1. `FutureWarning: tag.strict is not set` — emitted from `Configuration.from_file()` whenever a project's `[tool.setuptools_scm]` doesn't explicitly set `tag.strict`. This is upstream asking *users* to pin the tag-matching behavior; it is the user's config, not ours.
2. `DeprecationWarning: Configuration was created without VcsEnvironment` — leaked by vcs-versioning's internal pretend-version check (`_overrides.py` reads `config.env._env`). This fires **even through vcs-versioning's own public `infer_version_string` API**, so there is no change on our side that avoids it — it is an upstream leak.

Fixing only the first would just surface the second, so both are handled.

## Changes

- Add two scoped entries to `filterwarnings` in `pyproject.toml`, matching the existing convention there (using `default:` so they still surface once rather than being silenced entirely).

No library code change is needed — version detection still returns the correct value; only the warnings-as-errors were the problem. The filters are no-ops on older setuptools-scm, so there is no regression.

## Verification

- Reproduced the failure locally with `setuptools-scm>=10` + `vcs-versioning>=2`, then confirmed the fix.
- `tests/test_dynamic_metadata.py` and `tests/test_build_cli.py` → 23 passed.
- `prek -a --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)