### PR TITLE
fix: detect two-token `-G Ninja` and `-G` in CMAKE_ARGS for generator handling

### DIFF
--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -13,16 +13,35 @@ from ..program_search import best_program, get_make_programs, get_ninja_programs
 from .sysconfig import get_cmake_platform
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, MutableMapping
+    from collections.abc import Iterable, Mapping, MutableMapping
 
     from ..cmake import CMake
     from ..settings.skbuild_model import NinjaSettings
 
-__all__ = ["set_environment_for_gen"]
+__all__ = ["parse_generator", "set_environment_for_gen"]
 
 
 def __dir__() -> list[str]:
     return __all__
+
+
+def parse_generator(args: Iterable[str]) -> str | None:
+    """
+    Extract the generator from a sequence of CMake arguments, handling both the
+    joined ``-GNinja`` and the two-token ``-G Ninja`` forms. Returns the last
+    generator specified, or None if no ``-G`` is present.
+    """
+    result: str | None = None
+    expecting_value = False
+    for arg in args:
+        if expecting_value:
+            result = arg.strip()
+            expecting_value = False
+        elif arg == "-G":
+            expecting_value = True
+        elif arg.startswith("-G"):
+            result = arg[2:].strip()
+    return result
 
 
 def parse_help_default(txt: str) -> str | None:

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -4,6 +4,7 @@ import dataclasses
 import functools
 import importlib.util
 import os
+import shlex
 import sysconfig
 from typing import TYPE_CHECKING, Literal
 
@@ -22,6 +23,7 @@ from ..program_search import (
 from ..resources import resources
 from ..settings.skbuild_read_settings import SettingsReader
 from ._load_provider import load_provider
+from .generator import parse_generator
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
@@ -41,9 +43,10 @@ def _uses_ninja_generator(settings: ScikitBuildSettings) -> bool | None:
     Returns True if Ninja is set, False if something else is set, and None
     otherwise.
     """
-    gen_args = [arg[2:] for arg in settings.cmake.args if arg.startswith("-G")]
-    if gen_args:
-        return any("Ninja" in gen for gen in gen_args)
+    args = [*settings.cmake.args, *shlex.split(os.environ.get("CMAKE_ARGS", ""))]
+    generator = parse_generator(args)
+    if generator:
+        return "Ninja" in generator
 
     if "CMAKE_GENERATOR" in os.environ:
         return "Ninja" in os.environ["CMAKE_GENERATOR"]

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -18,6 +18,7 @@ from . import __version__
 from ._compat.builtins import ExceptionGroup
 from ._logging import logger
 from ._shutil import Run
+from .builder.generator import parse_generator
 from .errors import CMakeConfigError, CMakeNotFoundError, FailedLiveProcessError
 from .file_api.query import stateless_query
 from .file_api.reply import load_reply_dir
@@ -250,9 +251,9 @@ class CMaker:
         Try to get the generator that will be used to build the project. If it's
         not set, return None (default generator will be used).
         """
-        generators = [g for g in args if g.startswith("-G")]
-        if generators:
-            return generators[-1][2:].strip()
+        generator = parse_generator(args)
+        if generator:
+            return generator
         if defines and "CMAKE_GENERATOR" in defines:
             gen_value = defines["CMAKE_GENERATOR"]
             assert isinstance(gen_value, str)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -629,10 +629,19 @@ def test_get_soabi_abi3t(monkeypatch):
     )
 
 
-def test_generator_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["-GAnything"], id="joined"),
+        pytest.param(["-G", "Anything"], id="two-token"),
+    ],
+)
+def test_generator_args(
+    args: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.chdir(tmp_path)
     builder = Builder(
-        settings=ScikitBuildSettings(cmake=CMakeSettings(args=["-GAnything"])),
+        settings=ScikitBuildSettings(cmake=CMakeSettings(args=args)),
         config=CMaker(
             CMake(Version("4.0"), Path("no-cmake")), Path(), Path(), "Release"
         ),

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -209,3 +209,34 @@ def test_get_requires_state_override(
     assert "editable-only-dep" in get_requires_for_build_editable({})
     assert "editable-only-dep" not in get_requires_for_build_sdist({})
     assert "editable-only-dep" not in get_requires_for_build_wheel({})
+
+
+@pytest.mark.parametrize(
+    ("args", "cmake_args", "expected"),
+    [
+        pytest.param(["-GNinja"], None, True, id="settings-joined"),
+        pytest.param(["-G", "Ninja"], None, True, id="settings-two-token"),
+        pytest.param(["-GUnix Makefiles"], None, False, id="settings-non-ninja"),
+        pytest.param([], "-GNinja", True, id="env-joined"),
+        pytest.param([], "-G Ninja", True, id="env-two-token"),
+        pytest.param([], "-GUnix Makefiles", False, id="env-non-ninja"),
+        pytest.param([], None, None, id="unset"),
+    ],
+)
+def test_uses_ninja_generator(
+    args: list[str],
+    cmake_args: str | None,
+    expected: bool | None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from scikit_build_core.builder.get_requires import _uses_ninja_generator
+    from scikit_build_core.settings.skbuild_model import (
+        CMakeSettings,
+        ScikitBuildSettings,
+    )
+
+    monkeypatch.delenv("CMAKE_ARGS", raising=False)
+    if cmake_args is not None:
+        monkeypatch.setenv("CMAKE_ARGS", cmake_args)
+    settings = ScikitBuildSettings(cmake=CMakeSettings(args=args))
+    assert _uses_ninja_generator(settings) is expected


### PR DESCRIPTION
Let's make sure `cmake.args` works correctly before considering adding a new option.

:robot: _AI text below_ :robot:

Closes part of #1351 — makes `cmake.args` / `CMAKE_ARGS` a consistent per-project way to select the CMake generator (e.g. forcing Ninja on Windows).

### Problem

Two related gaps meant `-G` was not always honored:

1. **Two-token form ignored.** `CMaker.get_generator` matched only the joined `-GNinja` form (`generators[-1][2:].strip()`). A two-token `cmake.args = ["-G", "Ninja"]` matched the bare `-G` token, parsed to an empty string, and was silently dropped.
2. **`CMAKE_ARGS` not checked for build requirements.** `_uses_ninja_generator` (which decides whether to add the `ninja` PyPI requirement) only inspected `settings.cmake.args`, not the `CMAKE_ARGS` environment variable — so `-G` set there wouldn't pull in ninja.

### Fix

- Add a shared `parse_generator(args)` helper in `builder/generator.py` that handles both `-GNinja` and `-G Ninja` (two-token) forms and returns the last generator specified.
- Use it in `CMaker.get_generator`.
- Extend `_uses_ninja_generator` to also consider `shlex.split(CMAKE_ARGS)`, matching the precedence used at configure time (`cmake.args` / `CMAKE_ARGS` first, then `CMAKE_GENERATOR`).

### Tests

- `test_generator_args` is parametrized over joined and two-token forms.
- New `test_uses_ninja_generator` covers both forms in `cmake.args` and `CMAKE_ARGS`, plus non-ninja and unset cases.

The dedicated `cmake.generator` setting and the "VS generator silently ignores compiler overrides" warning from #1351 are left as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)