### PR TITLE
docs: use cython-cmake and f2py-cmake in getting started examples

### DIFF
--- a/.distro/plans/examples.fmf
+++ b/.distro/plans/examples.fmf
@@ -9,5 +9,6 @@ prepare+:
     how: artifact
     provide:
       - copr.repository:lecris/scikit-build-helpers
+    verify: false
 execute:
   how: tmt

--- a/.distro/plans/examples.fmf
+++ b/.distro/plans/examples.fmf
@@ -1,7 +1,7 @@
 summary: Documentation examples
 discover+:
   filter: "tag: examples"
-prepare:
+prepare+:
   # TODO: Remove when the package review is done
   # https://bugzilla.redhat.com/show_bug.cgi?id=2493460
   # https://bugzilla.redhat.com/show_bug.cgi?id=2493459

--- a/.distro/plans/examples.fmf
+++ b/.distro/plans/examples.fmf
@@ -1,5 +1,13 @@
 summary: Documentation examples
 discover+:
   filter: "tag: examples"
+prepare:
+  # TODO: Remove when the package review is done
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2493460
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2493459
+  - name: Add copr repo for f2py-cmake and cython-cmake
+    how: artifact
+    provide:
+      - copr.repository:lecris/scikit-build-helpers
 execute:
   how: tmt

--- a/.distro/plans/main.fmf
+++ b/.distro/plans/main.fmf
@@ -2,6 +2,11 @@ discover:
   how: fmf
   path: .
 
+prepare:
+  - how: install
+    package:
+      - python3-scikit-build-core
+
 adjust+:
   # Cannot use initiator: fedora-ci reliably yet
   when: initiator is not defined or initiator != packit

--- a/.distro/plans/smoke.fmf
+++ b/.distro/plans/smoke.fmf
@@ -5,5 +5,9 @@ summary: Basic smoke tests
 discover:
   how: fmf
   filter: "tag: smoke"
+prepare:
+  how: install
+  package:
+    - python3-scikit-build-core
 execute:
     how: tmt

--- a/docs/examples/getting_started/cython/CMakeLists.txt
+++ b/docs/examples/getting_started/cython/CMakeLists.txt
@@ -5,16 +5,11 @@ find_package(
   Python
   COMPONENTS Interpreter Development.Module
   REQUIRED)
+find_package(Cython MODULE REQUIRED VERSION 3.0)
+include(UseCython)
 
-add_custom_command(
-  OUTPUT example.c
-  COMMENT
-    "Making ${CMAKE_CURRENT_BINARY_DIR}/example.c from ${CMAKE_CURRENT_SOURCE_DIR}/example.pyx"
-  COMMAND Python::Interpreter -m cython
-          "${CMAKE_CURRENT_SOURCE_DIR}/example.pyx" --output-file example.c
-  DEPENDS example.pyx
-  VERBATIM)
+cython_transpile(example.pyx LANGUAGE C OUTPUT_VARIABLE example_c)
 
-python_add_library(example MODULE example.c WITH_SOABI)
+python_add_library(example MODULE "${example_c}" WITH_SOABI)
 
 install(TARGETS example DESTINATION .)

--- a/docs/examples/getting_started/cython/main.fmf
+++ b/docs/examples/getting_started/cython/main.fmf
@@ -1,3 +1,4 @@
 summary+: " (cython)"
 require+:
   - python3dist(cython)
+  - python3dist(cython-cmake)

--- a/docs/examples/getting_started/cython/pyproject.toml
+++ b/docs/examples/getting_started/cython/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "cython"]
+requires = ["scikit-build-core", "cython", "cython-cmake"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/docs/examples/getting_started/fortran/CMakeLists.txt
+++ b/docs/examples/getting_started/fortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.17...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/docs/examples/getting_started/fortran/CMakeLists.txt
+++ b/docs/examples/getting_started/fortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.2...4.3)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(
@@ -6,29 +6,8 @@ find_package(
   COMPONENTS Interpreter Development.Module NumPy
   REQUIRED)
 
-# F2PY headers
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c
-          "import numpy.f2py; print(numpy.f2py.get_include())"
-  OUTPUT_VARIABLE F2PY_INCLUDE_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+include(UseF2Py)
 
-add_library(fortranobject OBJECT "${F2PY_INCLUDE_DIR}/fortranobject.c")
-target_link_libraries(fortranobject PUBLIC Python::NumPy Python::Module)
-target_include_directories(fortranobject PUBLIC "${F2PY_INCLUDE_DIR}")
-set_property(TARGET fortranobject PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-add_custom_command(
-  OUTPUT examplemodule.c example-f2pywrappers.f
-  DEPENDS example.f
-  VERBATIM
-  COMMAND "${Python_EXECUTABLE}" -m numpy.f2py
-          "${CMAKE_CURRENT_SOURCE_DIR}/example.f" -m example --lower)
-
-python_add_library(
-  example MODULE "${CMAKE_CURRENT_BINARY_DIR}/examplemodule.c"
-  "${CMAKE_CURRENT_BINARY_DIR}/example-f2pywrappers.f"
-  "${CMAKE_CURRENT_SOURCE_DIR}/example.f" WITH_SOABI)
-target_link_libraries(example PRIVATE fortranobject)
+f2py_add_module(example example.f)
 
 install(TARGETS example DESTINATION .)

--- a/docs/examples/getting_started/fortran/main.fmf
+++ b/docs/examples/getting_started/fortran/main.fmf
@@ -3,3 +3,4 @@ require+:
   - gcc-gfortran
   - python3dist(numpy)
   - python3-numpy-f2py
+  - python3dist(f2py-cmake)

--- a/docs/examples/getting_started/fortran/pyproject.toml
+++ b/docs/examples/getting_started/fortran/pyproject.toml
@@ -1,12 +1,8 @@
 [build-system]
-requires = ["scikit-build-core", "numpy"]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "example"
 version = "0.0.1"
 dependencies = ["numpy"]
-
-[tool.scikit-build]
-ninja.version = ">=1.10"
-cmake.version = ">=3.17.2"

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -246,7 +246,6 @@ features. Also it's hard to compile Fortran on Windows as it's not supported by
 MSVC and macOS as it's not supported by Clang.
 ```
 
-
 ````
 
 Notice that you _do not_ include `cmake`, `ninja`, `setuptools`, or `wheel` in
@@ -338,8 +337,9 @@ The project line can optionally use `SKBUILD_PROJECT_NAME` and
 your `pyproject.toml`. You should specify exactly what language you use to keep
 CMake from searching for both `C` and `CXX` compilers (the default).
 
-You'll need to handle the generation of files by Cython directly at the moment.
-A helper (similar to scikit-build classic) might be added in the future.
+[cython-cmake][] provides the `cython_transpile` helper (via `include(UseCython)`)
+that turns your `.pyx` file into a C source you can pass to `python_add_library`.
+Add it to your build requirements as shown in the pyproject.toml above.
 
 ````
 
@@ -406,9 +406,10 @@ The project line can optionally use `SKBUILD_PROJECT_NAME` and
 your `pyproject.toml`. You should specify exactly what language you use to keep
 CMake from searching for both `C` and `CXX` compilers (the default).
 
-You'll need to handle the generation of files by NumPy directly at the moment.
-A helper (similar to scikit-build classic) might be added in the future. You'll
-need gfortran on macOS.
+[f2py-cmake][] provides the `f2py_add_module` helper (via `include(UseF2Py)`)
+that generates the f2py wrappers, builds the `fortranobject` support code, and
+links it all into an importable module in a single call. Add it to your build
+requirements as shown in the pyproject.toml above. You'll need gfortran on macOS.
 
 ````
 
@@ -439,6 +440,8 @@ That's it for a basic package!
 <!-- prettier-ignore-start -->
 [INTERSECT Training: Packaging]:     https://intersect-training.org/packaging
 [buildgen]:                          https://github.com/shakfu/buildgen
+[cython-cmake]:                      https://github.com/scikit-build/cython-cmake
+[f2py-cmake]:                        https://github.com/scikit-build/f2py-cmake
 [nanobind example]:                  https://github.com/wjakob/nanobind_example
 [packaging.python.org's tutorial]:   https://packaging.python.org/en/latest/tutorials/packaging-projects
 [pybind11/scikit_build_example]:     https://github.com/pybind/scikit_build_example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,10 @@ build.targets.sdist.exclude = [".git"]
 exclude-newer = "7 days"
 workspace.members = ["tmp/hello/hello"]
 
+[tool.uv.exclude-newer-package]
+f2py-cmake = false
+cython-cmake = false
+
 
 [tool.pytest.ini_options]
 minversion = "7.2"


### PR DESCRIPTION
@LecrisUT I guess this is stuck until Fedora has f2py-cmake 0.2 and cython-cmake 0.3?

:robot: _AI text below_ :robot:

## Summary

Switches the Cython and Fortran examples on the getting started page to use the dedicated helper packages instead of hand-rolled CMake recipes.

### Cython → [`cython-cmake`](https://github.com/scikit-build/cython-cmake)
- `CMakeLists.txt`: replaced the manual `add_custom_command` invoking `python -m cython` with `find_package(Cython MODULE REQUIRED VERSION 3.0)` + `include(UseCython)` + `cython_transpile(...)`.
- `pyproject.toml`: added `cython-cmake` to build requires.

### Fortran → [`f2py-cmake`](https://github.com/scikit-build/f2py-cmake)
- `CMakeLists.txt`: replaced the hand-rolled `fortranobject` object library, `execute_process` header lookup, and `numpy.f2py` custom command with `include(UseF2Py)` + `f2py_add_module(example example.f)`. Dropped the now-unneeded `cmake.version`/`ninja.version` pins.
- `pyproject.toml`: added `f2py-cmake` to build requires.

### Prose (`docs/guide/getting_started.md`)
- Rewrote the "you'll need to handle generation directly... a helper might be added in the future" notes in both tabs to point at the new helpers, with link references.
- Modernized the NumPy ABI warning that referenced the deprecated `oldest-supported-numpy`.

Module/function names (`example` / `square`) are unchanged so the existing example `test.py` still passes. APIs were verified against each project's README and test packages. Prettier passes on the touched files.