### PR TITLE
docs: remove documented unimplemented search settings

### DIFF
--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -52,58 +52,6 @@ With this any consuming project that depends on this would automatically work
 with `find_package(MyProject)` as long as it is in the `build-system.requires`
 list.
 
-````{tab} pyproject.toml
-
-```toml
-[tool.scikit-build.search]
-ignore_entry_point = ["MyProject"]
-[tool.scikit-build.search.roots]
-OtherProject = "/path/to/other_project"
-```
-
-````
-
-`````{tab} config-settings
-
-
-````{tab} pip
-
-```console
-$ pip install . -v --config-settings=search.ignore_entry_point="MyProject" --config-settings=search.roots.OtherProject="/path/to/other_project"
-```
-
-````
-
-````{tab} build
-
-```console
-$ pipx run build --wheel -Csearch.ignore_entry_point="MyProject" -Csearch.roots.OtherProject="/path/to/other_project"
-```
-
-````
-
-````{tab} cibuildwheel
-
-```toml
-[tool.cibuildwheel.config-settings]
-"search.ignore_entry_point" = ["MyProject"]
-"search.roots.OtherProject" = "/path/to/other_project"
-```
-
-````
-
-`````
-
-````{tab} Environment
-
-
-```yaml
-SKBUILD_SEARCH_IGNORE_ENTRY_POINT: "MyProject"
-SKBUILD_SEARCH_ROOTS_OtherProject: "/path/to/other_project"
-```
-
-````
-
 ## `CMAKE_PREFIX_PATH`
 
 Another common search path that scikit-build-core populates is the
@@ -124,57 +72,6 @@ dependent projects, which is similarly export as
 [project.entry-points."cmake.prefix"]
 MyProject = "myproject"
 ```
-
-````{tab} pyproject.toml
-
-```toml
-[tool.scikit-build.search]
-ignore_entry_point = ["MyProject"]
-prefixes = ["/path/to/prefixA", "/path/to/prefixB"]
-```
-
-````
-
-`````{tab} config-settings
-
-
-````{tab} pip
-
-```console
-$ pip install . -v --config-settings=search.ignore_entry_point="MyProject" --config-settings=search.prefixes="/path/to/prefixA;/path/to/prefixB"
-```
-
-````
-
-````{tab} build
-
-```console
-$ pipx run build --wheel -Csearch.ignore_entry_point="MyProject" -Csearch.prefixes="/path/to/prefixA;/path/to/prefixB"
-```
-
-````
-
-````{tab} cibuildwheel
-
-```toml
-[tool.cibuildwheel.config-settings]
-"search.ignore_entry_point" = ["MyProject"]
-"search.prefixes" = ["/path/to/prefixA", "/path/to/prefixB"]
-```
-
-````
-
-`````
-
-````{tab} Environment
-
-
-```yaml
-SKBUILD_SEARCH_IGNORE_ENTRY_POINT: "MyProject"
-SKBUILD_SEARCH_PREFIXES: "/path/to/prefixA;/path/to/prefixB"
-```
-
-````
 
 ## `CMAKE_MODULE_PATH`
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`docs/configuration/search_paths.md` documented three `tool.scikit-build.search` options that were **never implemented**:

- `search.prefixes`
- `search.roots`
- `search.ignore_entry_point`

The actual `SearchSettings` model only has `site-packages`, so copying these examples produced errors like:

```
ERROR: Unrecognized options in pyproject.toml:
  tool.scikit-build.search.prefixes -> Did you mean: ...
```

These crept in via #880 and were leftovers from an abandoned PR (confirmed by @LecrisUT in the issue thread).

## Change

Removed the phantom config-settings / environment-variable tab blocks from both the `<PackageName>_ROOT` and `CMAKE_PREFIX_PATH` sections. What remains is accurate:

- the entry-points `cmake.root`, `cmake.prefix`, `cmake.module`
- the one real setting, `search.site-packages`

Docs-only change. `nox --non-interactive -s docs` builds cleanly.

Closes #1151