### PR TITLE
feat: add unified `scikit-build` CLI with submodules as subcommands

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -78,6 +78,7 @@ export HATCH_METADATA_CLASSIFIERS_NO_VERIFY=1
 %files -n python3-scikit-build-core -f %{pyproject_files}
 %license LICENSE LICENSE-pyproject-metadata
 %doc README.md
+%{_bindir}/scikit-build
 
 
 %changelog

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -66,7 +66,7 @@ suppresses all output. You can
 printout of the current settings using:
 
 ```bash
-python -m scikit_build_core.builder
+scikit-build builder
 ```
 
 ## Repairing wheels

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,60 +4,81 @@ Scikit-build-core has a few integrated CLI tools. These are not guaranteed to be
 stable between releases yet, but can still be useful to investigate your
 environment.
 
-```{program-output} python -m scikit_build_core
+These are available through the `scikit-build` command (also runnable as
+`python -m scikit_build_core`), with the modules exposed as subcommands.
+
+```{program-output} scikit-build
 
 ```
 
 ## Build utilities
 
-```{program-output} python -m scikit_build_core.build --help
+```{program-output} scikit-build build --help
 
 ```
 
 ### Build requirements
 
-```{program-output} python -m scikit_build_core.build requires --help
+```{program-output} scikit-build build requires --help
 
 ```
 
 Example:
 
-```{command-output} python -m scikit_build_core.build requires
+```{command-output} scikit-build build requires
 :cwd: ../examples/getting_started/c
 
 ```
 
 ### Project table
 
-```{program-output} python -m scikit_build_core.build project-table --help
+```{program-output} scikit-build build project-table --help
 
 ```
 
 Example:
 
-```{command-output} python -m scikit_build_core.build project-table
+```{command-output} scikit-build build project-table
 :cwd: ../examples/getting_started/c
 
 ```
 
 ## Building environment info
 
-```{program-output} python -m scikit_build_core.builder.wheel_tag --help
+```{program-output} scikit-build builder --help
 
 ```
 
 Example:
 
-```{command-output} python -m scikit_build_core.builder.wheel_tag
+```{command-output} scikit-build builder
+
+```
+
+### Wheel tag
+
+```{program-output} scikit-build builder wheel-tag --help
+
+```
+
+Example:
+
+```{command-output} scikit-build builder wheel-tag
+
+```
+
+### Sysconfig
+
+```{program-output} scikit-build builder sysconfig --help
 
 ```
 
 ## File API tools
 
-```{program-output} python -m scikit_build_core.file_api.query --help
+```{program-output} scikit-build file-api query --help
 
 ```
 
-```{program-output} python -m scikit_build_core.file_api.reply --help
+```{program-output} scikit-build file-api reply --help
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ Documentation = "https://scikit-build-core.readthedocs.io"
 Homepage = "https://github.com/scikit-build/scikit-build-core"
 Issues = "https://github.com/scikit-build/scikit-build-core/issues"
 
+[project.scripts]
+scikit-build = "scikit_build_core.__main__:main"
+
 [project.entry-points]
 "distutils.commands".build_cmake = "scikit_build_core.setuptools.build_cmake:BuildCMake"
 "distutils.setup_keywords".cmake_source_dir = "scikit_build_core.setuptools.build_cmake:cmake_source_dir"

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import argparse
+from typing import TYPE_CHECKING
+
 from ._logging import rich_print
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __all__ = ["main"]
 
@@ -9,31 +15,61 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def main() -> None:
-    rich_print("{blue}A top level CLI is not currently provided for scikit-build-core.")
-    rich_print("{blue}However, the following modules have CLI utilities:")
+def main_info(_args: argparse.Namespace | None = None, /) -> None:
+    rich_print("{blue}The scikit-build-core CLI provides the following commands:")
+    rich_print("  scikit-build build requires        {green}Get the build requirements")
     rich_print(
-        "  python -m scikit_build_core.build requires       {green}Get the build requirements"
+        "  scikit-build build project-table   {green}Get the project table (with dynamic metadata)"
     )
+    rich_print("  scikit-build builder               {green}Info about the system")
     rich_print(
-        "  python -m scikit_build_core.build project-table  {green}Get the project table (with dynamic metadata)"
+        "  scikit-build builder wheel-tag     {green}Info about the computed wheel tag"
     )
-    rich_print(
-        "  python -m scikit_build_core.builder              {green}Info about the system"
-    )
-    rich_print(
-        "  python -m scikit_build_core.builder.wheel_tag    {green}Info about the computed wheel tag"
-    )
-    rich_print(
-        "  python -m scikit_build_core.builder.sysconfig    {green}Info from sysconfig"
-    )
-    rich_print(
-        "  python -m scikit_build_core.file_api.query       {green}Request CMake file API"
-    )
-    rich_print(
-        "  python -m scikit_build_core.file_api.reply       {green}Process CMake file API"
-    )
+    rich_print("  scikit-build builder sysconfig     {green}Info from sysconfig")
+    rich_print("  scikit-build file-api query        {green}Request CMake file API")
+    rich_print("  scikit-build file-api reply        {green}Process CMake file API")
     rich_print()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    from .build import __main__ as build_main
+    from .builder import __main__ as builder_main
+    from .file_api import __main__ as file_api_main
+
+    parser = argparse.ArgumentParser(
+        prog="scikit-build",
+        allow_abbrev=False,
+        description="scikit-build-core command line interface.",
+    )
+    parser.set_defaults(func=main_info)
+    subparsers = parser.add_subparsers(help="Commands")
+
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build backend utilities",
+        description="Build backend utilities.",
+        allow_abbrev=False,
+    )
+    build_main.populate_parser(build_parser)
+
+    builder_parser = subparsers.add_parser(
+        "builder",
+        help="Info about the system and build environment",
+        description="Info about the system and build environment.",
+        allow_abbrev=False,
+    )
+    builder_main.populate_parser(builder_parser)
+
+    file_api_parser = subparsers.add_parser(
+        "file-api",
+        help="CMake file API utilities",
+        description="CMake file API utilities.",
+        allow_abbrev=False,
+    )
+    file_api_main.populate_parser(file_api_parser)
+
+    args = parser.parse_args(argv)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -47,13 +47,8 @@ def get_requires(mode: Literal["sdist", "wheel", "editable"]) -> None:
     print(json.dumps(sorted(set(requires)), indent=2))
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        prog="python -m scikit_build_core.build",
-        allow_abbrev=False,
-        description="Build backend utilities.",
-    )
-
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``build`` subcommands to an existing parser."""
     subparsers = parser.add_subparsers(required=True, help="Commands")
     requires = subparsers.add_parser(
         "requires",
@@ -75,6 +70,14 @@ def main() -> None:
     )
     project_table.set_defaults(func=main_project_table)
 
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m scikit_build_core.build",
+        allow_abbrev=False,
+        description="Build backend utilities.",
+    )
+    populate_parser(parser)
     args = parser.parse_args()
     args.func(args)
 

--- a/src/scikit_build_core/builder/__main__.py
+++ b/src/scikit_build_core/builder/__main__.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .. import __version__
 from .._logging import rich_print
 from ..program_search import info_print as ip_program_search
+from . import sysconfig, wheel_tag
 from .get_requires import GetRequires
 from .sysconfig import info_print as ip_sysconfig
 from .wheel_tag import WheelTag
+
+if TYPE_CHECKING:
+    import argparse
 
 __all__ = ["main"]
 
@@ -17,7 +22,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def main() -> None:
+def main_info(_args: argparse.Namespace | None = None, /) -> None:
     rich_print(
         f"{{bold}}Scikit-build-core {__version__}{{normal}} on Python {sys.version}"
     )
@@ -26,7 +31,7 @@ def main() -> None:
 
     rich_print(f"{{bold.blue}}Default Wheel Tag:{{normal}} {WheelTag.compute_best([])}")
     rich_print(
-        "{blue} - Note: use {bold}python -m scikit_build_core.builder.wheel_tag -h{normal} for further options"
+        "{blue} - Note: use {bold}scikit-build builder wheel-tag -h{normal} for further options"
     )
 
     if Path("pyproject.toml").is_file():
@@ -40,6 +45,30 @@ def main() -> None:
         rich_print(f"{{bold.red}}Get Requires:{{normal}} {all_req!r}")
 
     ip_program_search(color="magenta")
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``builder`` subcommands to an existing parser."""
+    parser.set_defaults(func=main_info)
+    subparsers = parser.add_subparsers(help="Commands")
+    wheel_tag_parser = subparsers.add_parser(
+        "wheel-tag",
+        help="Get the computed wheel tag for the current environment",
+        description="Get the computed wheel tag for the current environment.",
+        allow_abbrev=False,
+    )
+    wheel_tag.populate_parser(wheel_tag_parser)
+    sysconfig_parser = subparsers.add_parser(
+        "sysconfig",
+        help="Print information about the Python environment",
+        description="Print information about the Python environment.",
+        allow_abbrev=False,
+    )
+    sysconfig.populate_parser(sysconfig_parser)
+
+
+def main() -> None:
+    main_info()
 
 
 if __name__ == "__main__":

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -12,6 +12,7 @@ import packaging.tags
 from .._logging import logger, rich_print
 
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Mapping
 
 __all__ = [
@@ -342,6 +343,15 @@ def info_print(
         get_abi_flags(),
         color=color,
     )
+
+
+def main_sysconfig(_args: argparse.Namespace, /) -> None:
+    info_print()
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Configure a parser to print sysconfig information."""
+    parser.set_defaults(func=main_sysconfig)
 
 
 if __name__ == "__main__":

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -246,7 +246,7 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     parser.set_defaults(func=main_wheel_tag)
 
 
-if __name__ == "__main__":
+def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -257,3 +257,7 @@ if __name__ == "__main__":
     populate_parser(parser)
     args = parser.parse_args()
     args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -13,6 +13,7 @@ from .._logging import logger
 from .macos import get_macosx_deployment_target
 
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Iterable, Mapping, Sequence
 
     from .._compat.typing import Self
@@ -219,14 +220,13 @@ class WheelTag:
         return frozenset(itertools.starmap(packaging.tags.Tag, vals))
 
 
-if __name__ == "__main__":
-    import argparse
+def main_wheel_tag(args: argparse.Namespace, /) -> None:
+    comp_tag = WheelTag.compute_best(args.archs, args.abi, root_is_purelib=args.purelib)
+    print(comp_tag)  # noqa: T201
 
-    parser = argparse.ArgumentParser(
-        prog="python -m scikit_build_core.builder.wheel_tag",
-        description="Get the computed wheel tag for the current environment.",
-        allow_abbrev=False,
-    )
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``wheel-tag`` arguments to an existing parser."""
     parser.add_argument(
         "--archs",
         nargs="*",
@@ -243,6 +243,17 @@ if __name__ == "__main__":
         action="store_true",
         help="Specify a non-platlib (pure) tag",
     )
+    parser.set_defaults(func=main_wheel_tag)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m scikit_build_core.builder.wheel_tag",
+        description="Get the computed wheel tag for the current environment.",
+        allow_abbrev=False,
+    )
+    populate_parser(parser)
     args = parser.parse_args()
-    comp_tag = WheelTag.compute_best(args.archs, args.abi, root_is_purelib=args.purelib)
-    print(comp_tag)  # noqa: T201
+    args.func(args)

--- a/src/scikit_build_core/file_api/__main__.py
+++ b/src/scikit_build_core/file_api/__main__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+
+from . import query, reply
+
+__all__ = ["main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``file-api`` subcommands to an existing parser."""
+    subparsers = parser.add_subparsers(required=True, help="Commands")
+    query_parser = subparsers.add_parser(
+        "query",
+        help="Write a stateless query to a build directory",
+        description="Write a stateless query to a build directory.",
+        allow_abbrev=False,
+    )
+    query.populate_parser(query_parser)
+    reply_parser = subparsers.add_parser(
+        "reply",
+        help="Read a query written out to a build directory",
+        description="Read a query written out to a build directory.",
+        allow_abbrev=False,
+    )
+    reply.populate_parser(reply_parser)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m scikit_build_core.file_api",
+        allow_abbrev=False,
+        description="CMake file API utilities.",
+    )
+    populate_parser(parser)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scikit_build_core/file_api/query.py
+++ b/src/scikit_build_core/file_api/query.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
 
 __all__ = ["stateless_query"]
 
@@ -22,6 +26,17 @@ def stateless_query(build_dir: Path) -> Path:
     return api_dir / "reply"
 
 
+def main_query(args: argparse.Namespace, /) -> None:
+    result = stateless_query(args.build_dir)
+    sys.stdout.write(f"{result}\n")
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``query`` argument to an existing parser."""
+    parser.add_argument("build_dir", type=Path, help="Path to the build directory")
+    parser.set_defaults(func=main_query)
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -30,8 +45,6 @@ if __name__ == "__main__":
         allow_abbrev=False,
         description="Write a stateless query to a build directory",
     )
-    parser.add_argument("build_dir", type=Path, help="Path to the build directory")
+    populate_parser(parser)
     args = parser.parse_args()
-
-    result = stateless_query(args.build_dir)
-    sys.stdout.write(f"{result}\n")
+    args.func(args)

--- a/src/scikit_build_core/file_api/query.py
+++ b/src/scikit_build_core/file_api/query.py
@@ -37,7 +37,7 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     parser.set_defaults(func=main_query)
 
 
-if __name__ == "__main__":
+def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -48,3 +48,7 @@ if __name__ == "__main__":
     populate_parser(parser)
     args = parser.parse_args()
     args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -153,7 +153,7 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     parser.set_defaults(func=main_reply)
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m scikit_build_core.file_api.reply",
         allow_abbrev=False,
@@ -162,3 +162,7 @@ if __name__ == "__main__":
     populate_parser(parser)
     args = parser.parse_args()
     args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -1,3 +1,4 @@
+import argparse
 import builtins
 import dataclasses
 import json
@@ -135,22 +136,29 @@ def load_reply_dir(path: Path) -> Index:
     return Converter(path).load()
 
 
-if __name__ == "__main__":
-    import argparse
-
+def main_reply(args: argparse.Namespace, /) -> None:
     rich_print: Callable[[object], None]
     try:
         from rich import print as rich_print
     except ModuleNotFoundError:
         rich_print = builtins.print
 
+    reply = Path(args.reply_dir)
+    rich_print(load_reply_dir(reply))
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``reply`` argument to an existing parser."""
+    parser.add_argument("reply_dir", type=Path, help="Path to the reply directory")
+    parser.set_defaults(func=main_reply)
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="python -m scikit_build_core.file_api.reply",
         allow_abbrev=False,
         description="Read a query written out to a build directory.",
     )
-    parser.add_argument("reply_dir", type=Path, help="Path to the reply directory")
+    populate_parser(parser)
     args = parser.parse_args()
-
-    reply = Path(args.reply_dir)
-    rich_print(load_reply_dir(reply))
+    args.func(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scikit_build_core.__main__ import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_cli_no_args(capsys: pytest.CaptureFixture[str]) -> None:
+    main([])
+    out, _ = capsys.readouterr()
+    assert "scikit-build build requires" in out
+    assert "scikit-build builder" in out
+    assert "scikit-build file-api" in out
+
+
+def test_cli_builder(capsys: pytest.CaptureFixture[str]) -> None:
+    main(["builder"])
+    out, _ = capsys.readouterr()
+    assert "Detected Python Library" in out
+
+
+def test_cli_builder_sysconfig(capsys: pytest.CaptureFixture[str]) -> None:
+    main(["builder", "sysconfig"])
+    out, _ = capsys.readouterr()
+    assert "Detected Python Library" in out
+
+
+def test_cli_builder_wheel_tag(capsys: pytest.CaptureFixture[str]) -> None:
+    main(["builder", "wheel-tag", "--purelib"])
+    out, _ = capsys.readouterr()
+    assert out.strip() == "py3-none-any"
+
+
+def test_cli_file_api_query(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    build_dir = tmp_path / "build"
+    main(["file-api", "query", str(build_dir)])
+    out, _ = capsys.readouterr()
+    query_dir = build_dir / ".cmake/api/v1/query"
+    assert query_dir.joinpath("codemodel-v2").is_file()
+    assert out.strip().endswith("reply")
+
+
+def test_cli_build_requires(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = (
+        "[build-system]\n"
+        'requires = ["scikit-build-core"]\n'
+        'build-backend = "scikit_build_core.build"\n'
+        "[project]\n"
+        'name = "test"\n'
+        'version = "0.1.0"\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject)
+    monkeypatch.chdir(tmp_path)
+    main(["build", "requires", "--mode=sdist"])
+    out, _ = capsys.readouterr()
+    assert "scikit-build-core" in out


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a `scikit-build` console script that wraps the existing `python -m scikit_build_core` utilities, exposing each submodule as a subcommand (with `-` instead of `_`).

```
scikit-build                       # top-level info (default, no subcommand)
├── build requires                 # python -m scikit_build_core.build requires
├── build project-table            # python -m scikit_build_core.build project-table
├── builder                        # python -m scikit_build_core.builder  (system info)
├── builder wheel-tag              # python -m scikit_build_core.builder.wheel_tag
├── builder sysconfig              # python -m scikit_build_core.builder.sysconfig
├── file-api query                 # python -m scikit_build_core.file_api.query
└── file-api reply                 # python -m scikit_build_core.file_api.reply
```

## Changes

- **`pyproject.toml`** — new `[project.scripts]` entry `scikit-build = "scikit_build_core.__main__:main"`.
- **`__main__.py`** — replaced the static "no top-level CLI" message with an argparse dispatcher. Both `scikit-build` and `python -m scikit_build_core` route through it; running with no subcommand prints the command list.
- Refactored each submodule to expose a reusable `populate_parser(parser)` helper (reusing the existing `func`/`Namespace` dispatch convention), so each module owns its CLI definition and the top level just composes them:
  - `build/__main__.py`, `builder/__main__.py`, `builder/wheel_tag.py`, `builder/sysconfig.py`, `file_api/query.py`, `file_api/reply.py`
  - **new** `file_api/__main__.py` groups `query` + `reply` (also enables `python -m scikit_build_core.file_api`).
- **`docs/reference/cli.md`** / **`docs/guide/faqs.md`** — updated to the `scikit-build …` forms (added wheel-tag/sysconfig sections).
- **`tests/test_cli.py`** — new tests covering each subcommand path.

## Backward compatibility

The standalone `python -m scikit_build_core.build` / `.builder` / `.builder.wheel_tag` / `.file_api.query` / `.file_api.reply` entrypoints all keep working unchanged, as does `builder/__main__.main()` used by existing tests.

## Notes

- The console script only takes effect after a (re)install.
- These CLI tools are still documented as not guaranteed stable between releases.

## Test plan

- [x] `prek -a` clean
- [x] `pytest tests/test_cli.py tests/test_build_cli.py tests/test_printouts.py tests/test_name_main.py tests/test_fileapi.py tests/test_builder.py`