### PR TITLE
feat:de-experimentalize setuptools/hatchling plugins, document experimental features

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ features over classic Scikit-build:
 - Dedicated entrypoints for module and prefix directories
 - Several integrated dynamic metadata plugins (proposing standardized support
   soon)
-- Experimental editable mode support, with optional experimental auto rebuilds
-  on import and optional in-place mode
+- Editable mode support, with optional experimental auto rebuilds on import and
+  optional in-place mode
 - Supports WebAssembly (Emscripten/[Pyodide](https://pyodide.org)).
 - Supports [free-threaded Python 3.13+](https://py-free-threading.github.io).
 

--- a/README.md
+++ b/README.md
@@ -81,22 +81,21 @@ Some known missing features that will be developed soon:
   including setuptools)
 - Several editable mode caveats (mentioned in the docs).
 
-Other backends are also planned:
+Other backends are also available:
 
-- Setuptools integration highly experimental
-- Hatchling plugin highly experimental
+- Setuptools integration (use the `[setuptools]` extra)
+- Hatchling plugin (use the `[hatchling]` extra)
 
-The recommended interface is the native pyproject builder. There is also a WIP
-setuptools-based interface that is being developed to provide a transition path
-for classic scikit-build, and a WIP Hatchling plugin. Both might be moved to
-standalone packages in the future.
+The recommended interface is the native pyproject builder. There is also a
+setuptools-based interface that provides a transition path for classic
+scikit-build, and a Hatchling plugin.
 
 > [!WARNING]
 >
-> Only the pyproject-based builder should be used; the setuptools backend is
-> experimental and likely to move to a separate package before being declared
-> stable, and internal API is still being solidified. A future version of this
-> package will support creating new build extensions.
+> The setuptools and hatchling backends might move to standalone packages in the
+> future, so depend on them via the `scikit-build-core[setuptools]` and
+> `scikit-build-core[hatchling]` extras to stay protected if they do. The
+> internal API for writing new build extensions is still being solidified.
 
 ## Example
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -559,8 +559,8 @@ You can pass raw arguments directly to the build tool, as well:
 
 ## Editable installs
 
-Experimental support for editable installs is provided, with some caveats and
-configuration. Recommendations:
+Support for editable installs is provided, with some caveats and configuration.
+Recommendations:
 
 - Use `--no-build-isolation` when doing an editable install is recommended; you
   should preinstall your dependencies.
@@ -580,8 +580,7 @@ Known limitations:
 $ pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=build -ve.
 ```
 
-Due to the length of this line already being long, you do not need to set the
-`experimental` setting to use editable installs, but please consider them
+The automatic rebuild-on-import feature (`editable.rebuild`) is still
 experimental and subject to change.
 
 You can disable the verbose rebuild output with `editable.verbose=false` if you
@@ -605,11 +604,11 @@ the interpreter running the editable install.
 
 :::{note}
 
-A second experimental mode, `"inplace"`, is also available. This does an
-in-place CMake build, so all the caveats there apply too -- only one build per
-source directory, you can't change to an out-of-source builds without removing
-the build artifacts, your source directory will be littered with build
-artifacts, etc. Also, to make your binaries importable, you should set
+A second mode, `"inplace"`, is also available. This does an in-place CMake
+build, so all the caveats there apply too -- only one build per source
+directory, you can't change to an out-of-source builds without removing the
+build artifacts, your source directory will be littered with build artifacts,
+etc. Also, to make your binaries importable, you should set
 `LIBRARY_OUTPUT_DIRECTORY` (include a generator expression, like the empty one
 `$<0:>` for multi-config generator support, like MSVC, so you don't have to set
 all possible `*_<CONFIG>` variations) to make sure they are placed inside your
@@ -704,8 +703,9 @@ The following features currently require this flag:
   `/scripts`, and `/metadata`. See
   [`wheel.install-dir`](../reference/configs.md).
 
-[Editable installs](#editable-installs) are also considered experimental and
-subject to change, but are not gated behind this flag.
+The [rebuild-on-import feature](#editable-installs) for editable installs is
+also considered experimental and subject to change, but is not gated behind this
+flag.
 
 You can also fail the build with `fail = true`. This is useful with overrides if
 you want to make a specific configuration fail. If this is set, extra

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -696,8 +696,6 @@ The following features currently require this flag:
 - **Wheel variants**: [PEP 817][] variant support (`variant`, `variant-name`,
   `variant-label`, and `null-variant`). See
   [](../guide/faqs.md#building-wheel-variants-experimental).
-- **Hatchling plugin**: driving the build from hatchling instead of using
-  scikit-build-core as the backend directly. See [](../plugins/hatchling.md).
 - **Third-party dynamic-metadata plugins**: dynamic metadata providers not
   shipped with scikit-build-core (anything using `provider-path` or a provider
   outside the `scikit_build_core.*` namespace). See [](./dynamic.md).
@@ -706,9 +704,8 @@ The following features currently require this flag:
   `/scripts`, and `/metadata`. See
   [`wheel.install-dir`](../reference/configs.md).
 
-Some other features (such as [editable installs](#editable-installs) and the
-[setuptools integration](../plugins/setuptools.md)) are also considered
-experimental and subject to change, but are not gated behind this flag.
+[Editable installs](#editable-installs) are also considered experimental and
+subject to change, but are not gated behind this flag.
 
 You can also fail the build with `fail = true`. This is useful with overrides if
 you want to make a specific configuration fail. If this is set, extra

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -569,11 +569,9 @@ Recommendations:
   also enable automatic rebuilds.
 - You need to reinstall to pick up new files.
 
-Known limitations:
-
-- Resources (via `importlib.resources`) are not properly supported (yet).
-  Currently experimentally supported except on Python 3.9 (3.8, 3.10, 3.11,
-  3.12, and 3.13 work). `importlib_resources` may work on Python 3.9.
+Resources (via `importlib.resources`) are supported and tested on all supported
+Python versions. On Python 3.8, use the `importlib_resources` backport, since
+`importlib.resources.files` was added to the standard library in Python 3.9.
 
 ```console
 # Very experimental rebuild on initial import feature

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -601,6 +601,7 @@ it uses the classic `.pth` `import` line. This is handled automatically based on
 the interpreter running the editable install.
 
 [PEP 829]: https://peps.python.org/pep-0829/
+[PEP 817]: https://peps.python.org/pep-0817/
 
 :::{note}
 
@@ -689,6 +690,25 @@ only be used if you enable them:
 [tool.scikit-build]
 experimental = true
 ```
+
+The following features currently require this flag:
+
+- **Wheel variants**: [PEP 817][] variant support (`variant`, `variant-name`,
+  `variant-label`, and `null-variant`). See
+  [](../guide/faqs.md#building-wheel-variants-experimental).
+- **Hatchling plugin**: driving the build from hatchling instead of using
+  scikit-build-core as the backend directly. See [](../plugins/hatchling.md).
+- **Third-party dynamic-metadata plugins**: dynamic metadata providers not
+  shipped with scikit-build-core (anything using `provider-path` or a provider
+  outside the `scikit_build_core.*` namespace). See [](./dynamic.md).
+- **Absolute `wheel.install-dir`**: an absolute install dir is placed one level
+  above the platlib root, giving access to `/platlib`, `/data`, `/headers`,
+  `/scripts`, and `/metadata`. See
+  [`wheel.install-dir`](../reference/configs.md).
+
+Some other features (such as [editable installs](#editable-installs) and the
+[setuptools integration](../plugins/setuptools.md)) are also considered
+experimental and subject to change, but are not gated behind this flag.
 
 You can also fail the build with `fail = true`. This is useful with overrides if
 you want to make a specific configuration fail. If this is set, extra

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -1,7 +1,6 @@
 # Hatchling
 
-A [hatchling][] plugin is being developed for scikit-build-core. This is
-currently in a highly experimental state, but feedback is welcome.
+A [hatchling][] plugin is provided by scikit-build-core. Feedback is welcome.
 
 :::{warning}
 
@@ -23,13 +22,11 @@ get `cmake` and `ninja` auto-added if needed, and 1.24 if you want to write out
 custom scripts, metadata, or shared data.
 
 You need a `tool.hatch.build.targets.wheel.hooks.scikit-build` section to
-activate the plugin. Currently, you need at least the `experimental` option to
-use the plugin, which means you acknowledge that this might move in the next
-release of scikit-build-core. It was added in 0.9.
+activate the plugin. It was added in 0.9.
 
 ```toml
 [build-system]
-requires = ["hatchling", "scikit-build-core~=0.9.0"]
+requires = ["hatchling", "scikit-build-core[hatchling]"]
 build-backend = "hatchling.build"
 
 [project]
@@ -37,21 +34,7 @@ name = "hatchling_example"
 version = "0.1.0"
 
 [tool.hatch.build.targets.wheel.hooks.scikit-build]
-experimental = true
 ```
-
-:::{note}
-
-Note that this is equivalent:
-
-```toml
-[tool.hatch.build.targets.wheel.hooks.scikit-build]
-
-[tool.scikit-build]
-experimental = true
-```
-
-:::
 
 ## Options
 

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -74,10 +74,6 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
 
         settings_reader.validate_may_exit()
 
-        if not settings.experimental:
-            msg = "Hatch support is experimental, must enable the experimental flag"
-            raise ValueError(msg)
-
         if not settings.wheel.cmake:
             msg = "CMake is required for scikit-build"
             raise ValueError(msg)

--- a/tests/packages/hatchling/pyproject.toml
+++ b/tests/packages/hatchling/pyproject.toml
@@ -9,4 +9,3 @@ version = "0.1.0"
 [tool.hatch.build.targets.wheel.hooks.scikit-build]
 wheel.install-dir = "hatchling_example"
 cmake.source-dir = "cpp"
-experimental = true

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -27,7 +27,7 @@ def _validate_settings(pyproject: dict[str, object]) -> None:
 def test_hatchling_sdist_cmake_error_message() -> None:
     pyproject = {
         "project": {"name": "x", "version": "0.1.0"},
-        "tool": {"scikit-build": {"experimental": True, "sdist": {"cmake": True}}},
+        "tool": {"scikit-build": {"sdist": {"cmake": True}}},
     }
     with pytest.raises(ValueError, match="Not currently supported for SDist builds"):
         _validate_settings(pyproject)


### PR DESCRIPTION
Close #1149.

:robot: _AI text below_ :robot:

Towards #1149.

Three related changes from reviewing the state of experimental features for 1.0.

## 1. Document the experimental features

The experimental section of the configuration guide previously only explained the `experimental = true` flag mechanism without saying *which* features it unlocks. It now enumerates them, each linked to its detailed docs:

- **Wheel variants** (PEP 817: `variant`, `variant-name`, `variant-label`, `null-variant`)
- **Third-party dynamic-metadata plugins** (`provider-path` / non-`scikit_build_core.*` providers)
- **Absolute `wheel.install-dir`**

It also defines the previously-undefined `[PEP 817]` reference link (it was rendering as literal text in `faqs.md`).

## 2. De-experimentalize the setuptools and hatchling plugins

- **Remove the hatchling code gate**: the build hook no longer raises `Hatch support is experimental, must enable the experimental flag`, so the plugin works without `experimental = true`.
- Drop the "highly experimental" framing from the hatchling/setuptools docs and README.
- Keep the guidance to depend on these via the `scikit-build-core[hatchling]` / `scikit-build-core[setuptools]` extras, which protect against a future move to standalone packages.
- Remove the now-unnecessary `experimental = true` from the hatchling test package and a unit test (which now also confirms the plugin builds without the flag).

## 3. De-experimentalize editable installs

- Drop the "experimental" framing from the editable-install docs and README.
- The automatic **rebuild-on-import** feature (`editable.rebuild`) keeps its experimental caveat; inplace-mode caveats are unchanged.

## Verification

- `nox --non-interactive -s docs` builds cleanly (no new warnings).
- `tests/test_hatchling.py` passes (8 tests), including building the test package without the flag.
- `prek -a` passes.

## Notes

The tracker-issues half of #1149 (per-feature tracking issues) is a maintainer decision and not included here.