### PR TITLE
docs: fix incorrect config keys and stale claims in docs

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -1,6 +1,6 @@
 # Dynamic metadata
 
-Scikit-build-core supports dynamic metadata with three built-in plugins.
+Scikit-build-core supports dynamic metadata with four built-in plugins.
 
 :::{warning}
 
@@ -58,6 +58,7 @@ If you want to pull a string-valued expression (usually version) from an
 existing file, you can the integrated `regex` plugin to pull the information.
 
 ```toml
+[project]
 name = "mypackage"
 dynamic = ["version"]
 
@@ -148,7 +149,7 @@ similar to the other dynamic metadata it injects the additional
 `build-system.requires`.
 
 ```toml
-[package]
+[project]
 name = "mypackage"
 
 [tool.scikit-build]

--- a/docs/examples/getting_started/abi3/pyproject.toml
+++ b/docs/examples/getting_started/abi3/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "scikit_build_core.build"
 name = "example"
 version = "0.0.1"
 
-[tool.scikit-build-core]
+[tool.scikit-build]
 wheel.py-api = "cp38"

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -186,7 +186,7 @@ scikit_build_core-0.1.2-py3-none-any.whl
 The three new items here (compared to SDists) are the [compatibility tags][]:
 
 - `python tag`: The first version of Python the wheel is compatible with. Often
-  `py3` for pure Python wheels, or `py312` (etc) for compiled wheels.
+  `py3` for pure Python wheels, or `cp312` (etc) for compiled wheels.
 - `abi tag`: The interpreter ABI this was built for. `none` for pure Python
   wheels or compiled wheels that don't use the Python API, `abi3` for stable ABI
   / limited API wheels, `abi3t` for free-threaded stable ABI wheels, and `cp312`

--- a/docs/guide/crosscompile.md
+++ b/docs/guide/crosscompile.md
@@ -117,8 +117,8 @@ CMake's guide on how to write the [toolchain file].
 You can pass the toolchain file using the environment variable
 `CMAKE_TOOLCHAIN_FILE`, or the `cmake.toolchain-file` pyproject option. You may
 also need to use `wheel.tags` to manually specify the wheel tags to use for the
-file and `cmake.no-python-hints` if the target python should be detected using
-the toolchain file instead.
+file and `cmake.python-hints = false` if the target python should be detected
+using the toolchain file instead.
 
 :::{note}
 

--- a/docs/guide/migration_guide.md
+++ b/docs/guide/migration_guide.md
@@ -64,5 +64,5 @@ python_add_library(${LIBRARY} MODULE WITH_SOABI ${FILENAME})
   `SKBUILD_CMAKE_ARGS` for consistency.
 - The `SKBUILD_BUILD_OPTIONS` environment variable is not supported. Some
   specific features are accessible using alternative variables. In particular,
-  use `CMAKE_BUILD_PARALLEL_LEVEL` or `SKBUILD_CMAKE_VERBOSE` to control build
+  use `CMAKE_BUILD_PARALLEL_LEVEL` or `SKBUILD_BUILD_VERBOSE` to control build
   parallelism or CMake verbosity directly.

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -67,7 +67,6 @@ Key limitations:
 
 - You need to leave `cmake.wheel` on. No `wheel.platlib = False` builds.
 - Using cmake in SDist step is not supported yet.
-- Editable installs are not supported yet.
 - `scikit-build.generate` and `scikit-build.metadata` is not supported.
 - `${SKBUILD_HEADER_DIR}` is not supported, request support in Hatching if
   needed.


### PR DESCRIPTION
From #1363.

:robot: _AI text below_ :robot:

## Summary

Fixes seven confirmed documentation bugs — factual/technical errors in examples and reference pages. No source or model changes; `nox -t gen` is not needed.

- **`docs/examples/getting_started/abi3/pyproject.toml`**: `[tool.scikit-build-core]` → `[tool.scikit-build]`. The wrong table header silently dropped the `wheel.py-api = "cp38"` setting, breaking abi3 tagging.
- **`docs/guide/crosscompile.md`**: Nonexistent option `cmake.no-python-hints` replaced with the real boolean option `cmake.python-hints = false`.
- **`docs/plugins/hatchling.md`**: Removed stale bullet "Editable installs are not supported yet." — both redirect and inplace editable modes are fully implemented in `src/scikit_build_core/hatch/plugin.py`.
- **`docs/guide/migration_guide.md`**: `SKBUILD_CMAKE_VERBOSE` → `SKBUILD_BUILD_VERBOSE` (the correct env form of `build.verbose`; `cmake.verbose` was deprecated in 0.10).
- **`docs/guide/build.md`**: Python tag example `py312` → `cp312` for compiled CPython wheels.
- **`docs/configuration/dynamic.md`**: "three built-in plugins" → "four built-in plugins" (setuptools_scm, regex, fancy_pypi_readme, template are all documented on the page).
- **`docs/configuration/dynamic.md`**: Two TOML table header errors: `[package]` → `[project]` in the `build.requires` example, and added the missing `[project]` header in the Regex example.

## Test plan

- [ ] Doc build: `nox --non-interactive -s docs` should succeed with no errors
- [ ] Confirm each TOML example now parses correctly as valid TOML with the right table structure