### PR TITLE
docs: document cmake.module entry point and metadata states

### DIFF
--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -138,6 +138,11 @@ This is often combined with `if.any`.
 The state of the build, one of `sdist`, `wheel`, `editable`, `metadata_wheel`,
 and `metadata_editable`. Takes a regex.
 
+The `metadata_wheel` and `metadata_editable` states correspond to the
+`prepare_metadata_for_build_wheel` and `prepare_metadata_for_build_editable` PEP
+517 hooks, respectively; these are metadata-only preparation passes that a
+frontend may run without building the full wheel.
+
 Note that you can build directly to wheel; you don't have to go through an
 SDist.
 

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -77,5 +77,12 @@ MyProject = "myproject"
 
 Scikit-build-core also populates `CMAKE_MODULE_PATH` variable used to search for
 CMake modules using the `include()` command (if the `.cmake` suffix is omitted).
+This is populated by reading the entry-point `cmake.module` of the dependent
+projects, which is similarly exported as
+
+```toml
+[project.entry-points."cmake.module"]
+MyProject = "myproject"
+```
 
 [`CMAKE_PREFIX_PATH`]: #cmake-prefix-path

--- a/docs/examples/getting_started/fortran/CMakeLists.txt
+++ b/docs/examples/getting_started/fortran/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(
 
 # F2PY headers
 execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c
+  COMMAND "${Python_EXECUTABLE}" -c
           "import numpy.f2py; print(numpy.f2py.get_include())"
   OUTPUT_VARIABLE F2PY_INCLUDE_DIR
   OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/docs/man.md
+++ b/docs/man.md
@@ -9,6 +9,26 @@ Scikit-build-core is a complete ground-up rewrite of scikit-build on top of
 modern packaging APIs. It provides a bridge between CMake and the Python build
 system, allowing you to make Python modules with CMake.
 
+## Synopsis
+
+**scikit-build** [*COMMAND*] ...
+
+Scikit-build-core is normally used as a PEP 517 build backend and invoked by a
+build frontend such as `pip` or `build`. It also ships a `scikit-build` command
+(also runnable as `python -m scikit_build_core`) that exposes a few utilities
+for inspecting the build environment:
+
+- **scikit-build build requires** -- show the build requirements.
+- **scikit-build build project-table** -- show the project table (with dynamic
+  metadata).
+- **scikit-build builder** -- show information about the system.
+- **scikit-build builder wheel-tag** -- show the computed wheel tag.
+- **scikit-build builder sysconfig** -- show information from sysconfig.
+- **scikit-build file-api query** -- request the CMake file API.
+- **scikit-build file-api reply** -- process the CMake file API.
+
+See the CLI reference for the full set of options.
+
 ## Features
 
 ```{include} ../README.md


### PR DESCRIPTION
From #1363.

:robot: _AI text below_ :robot:

Fills several documentation gaps. Docs/example-only — no settings model changes, so `nox -t gen` is not needed.

- **`cmake.module` entry point** — Added a `[project.entry-points."cmake.module"]` example to the `CMAKE_MODULE_PATH` section of `docs/configuration/search_paths.md`, parallel to the existing `cmake.prefix`/`cmake.root` examples. Verified against `src/scikit_build_core/builder/builder.py` (the `cmake.module` entry point populates `config.module_dirs`).
- **`metadata_wheel` / `metadata_editable` states** — Added a note in `docs/configuration/overrides.md` explaining these `state` values correspond to the `prepare_metadata_for_build_wheel` / `prepare_metadata_for_build_editable` PEP 517 hooks (metadata-only passes). Verified against `build/wheel.py` (`state = "metadata_editable" if editable else "metadata_wheel"` when `wheel_directory is None`) and the hooks in `build/__init__.py`.
- **Fortran example** — Unified `${PYTHON_EXECUTABLE}` to the canonical `${Python_EXECUTABLE}` in `docs/examples/getting_started/fortran/CMakeLists.txt` (the file already calls `find_package(Python ...)`). Only the variable name changed; the `cmake_minimum_required` line was left untouched (owned by another PR).
- **man page** — Added a short CLI synopsis section to `docs/man.md` listing the `scikit-build` subcommands (sourced from `src/scikit_build_core/__main__.py`), with a pointer to the CLI reference. The `orphan:`/`nosearch:` front matter and README include are preserved.

`prek -a --quiet` passes on touched files (prettier reflowed one paragraph). The pre-existing check-sdist failure is unrelated (untracked `.claude/settings.local.json`).