### PR TITLE
docs: refresh stale guidance and version pins

### DIFF
--- a/docs/examples/downstream/nanobind_example/CMakeLists.txt
+++ b/docs/examples/downstream/nanobind_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(nanobind_example LANGUAGES CXX)
 

--- a/docs/examples/downstream/pybind11_example/CMakeLists.txt
+++ b/docs/examples/downstream/pybind11_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/docs/examples/getting_started/abi3/CMakeLists.txt
+++ b/docs/examples/getting_started/abi3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/docs/examples/getting_started/c/CMakeLists.txt
+++ b/docs/examples/getting_started/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/docs/examples/getting_started/cython/CMakeLists.txt
+++ b/docs/examples/getting_started/cython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/docs/examples/getting_started/fortran/CMakeLists.txt
+++ b/docs/examples/getting_started/fortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.2...3.29)
+cmake_minimum_required(VERSION 3.17.2...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/docs/examples/getting_started/nanobind/CMakeLists.txt
+++ b/docs/examples/getting_started/nanobind/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development.Module)

--- a/docs/examples/getting_started/pybind11/CMakeLists.txt
+++ b/docs/examples/getting_started/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 set(PYBIND11_FINDPYTHON ON)

--- a/docs/examples/getting_started/swig/CMakeLists.txt
+++ b/docs/examples/getting_started/swig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -237,11 +237,13 @@ To create your first compiled package, start with a pyproject.toml like this:
 ```
 
 ```{warning}
-The module you build will require an equal or newer version to the version of
-NumPy it built with. You should use `oldest-supported-numpy` or manually set
-the NumPy version, though you will then be stuck with older versions of f2py.
-Also it's hard to compile Fortran on Windows as it's not supported by MSVC and
-macOS as it's not supported by Clang.
+The module you build will require an equal or newer version of NumPy at runtime
+than the version it built with. The modern approach is to build against
+`numpy>=2.0`; NumPy 2.0 wheels are backward-compatible at the C ABI level, so a
+module built against NumPy 2.0 keeps working with older NumPy at runtime. Add a
+runtime floor (in `[project]` `dependencies`) only if your code needs newer NumPy
+features. Also it's hard to compile Fortran on Windows as it's not supported by
+MSVC and macOS as it's not supported by Clang.
 ```
 
 


### PR DESCRIPTION
From #1363.

:robot: _AI text below_ :robot:

Refreshes stale guidance in the docs.

- **`docs/guide/getting_started.md`** — Fortran/f2py section no longer recommends the deprecated/EOL `oldest-supported-numpy`. It now recommends building against `numpy>=2.0` (backward-compatible at the C ABI level with older runtime NumPy), with a runtime floor only if needed.
- **`docs/examples/**/CMakeLists.txt`** — unified the `cmake_minimum_required` upper ceiling to `4.3` across all 9 example files (was `...3.26`, Fortran `...3.29`). Lower bounds preserved.

### Rebased onto current `main`
Two items from the original PR were dropped during rebase because #1358 already addressed them (and did so more thoroughly):
- The `scikit-build-core[hatchling]` extra in `docs/plugins/hatchling.md` — already done by #1358.
- The editable-resources Python-version note in `docs/configuration/index.md` — #1358 rewrote it to state resources are fully supported, superseding this change.

Left as-is: the downstream `pybind11_example` pin (`scikit-build-core>=0.3.3`), since those examples mirror upstream verbatim.