### PR TITLE
docs: fix typos and grammar

### DIFF
--- a/docs/about/projects.md
+++ b/docs/about/projects.md
@@ -127,7 +127,7 @@ scikit-build-core, but they are not published on PyPI. A few of them are:
 
 The [Insight Toolkit (ITK)](https://docs.itk.org), the initial target project
 for scikit-build classic, has
-[transitioned to sckit-build-core](https://github.com/InsightSoftwareConsortium/ITKPythonPackage/blob/master/scripts/pyproject.toml.in).
+[transitioned to scikit-build-core](https://github.com/InsightSoftwareConsortium/ITKPythonPackage/blob/master/scripts/pyproject.toml.in).
 ITK currently provides one example of a production SWIG-based deployment. In
 addition, dozens of
 [ITK-based extension packages are configured with scikit-build-core](https://github.com/topics/itk-module).

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -55,7 +55,7 @@ the `--sdist` flag. For example, `pipx run build --sdist`. This:
 
 1. Reads `pyproject.toml` to get the `build-system` table.
 2. Set up a new isolated environment with the packages listed in
-   `build-system.requires`..
+   `build-system.requires`.
 3. Run `.get_requires_for_build_sdist(...)` inside the module listed in
    `build-system.build-backend`, if it exists. If this returns a list, install
    all the packages requested. This allows a backend to dynamically declare
@@ -94,7 +94,7 @@ This:
 
 1. Reads `pyproject.toml` to get the `build-system` table.
 2. Set up a new isolated environment with the packages listed in
-   `build-system.requires`..
+   `build-system.requires`.
 3. Run `.get_requires_for_build_wheel(...)` inside the module listed in
    `build-system.build-backend`, if it exists. If this returns a list, install
    all the packages requested. This allows a backend to dynamically declare

--- a/docs/guide/dynamic_link.md
+++ b/docs/guide/dynamic_link.md
@@ -30,7 +30,7 @@ these tools in its [repair wheel] feature.
 
 These tools also rename the library with a unique hash to avoid any potential
 name collision if the same library is being bundled by a different package, and
-check if the packages confirm to standards like [PEP600] (`manylinux_X_Y`).
+check if the packages conform to standards like [PEP600] (`manylinux_X_Y`).
 These tools do not allow to have cross wheel library dependency.
 
 ## Manual patching

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -71,8 +71,8 @@ scikit-build builder
 
 ## Repairing wheels
 
-Like most other backends[^1], scikit-build-core produced `linux` wheels, which
-are not redistrubutable cannot be uploaded to PyPI[^2]. You have to run your
+Like most other backends[^1], scikit-build-core produces `linux` wheels, which
+are not redistributable and cannot be uploaded to PyPI[^2]. You have to run your
 wheels through `auditwheel` to make `manylinux` wheels. `cibuildwheel`
 automatically does this for you. See [repairing](#repairing-wheels).
 
@@ -84,7 +84,7 @@ recipes][]. There are a few things to keep in mind.
 You need to recreate your `build-system.requires` in the `host` table, with the
 conda versions of your dependencies. You also need to add `cmake` and either
 `make` or `ninja` to your `build:` table. Conda-build hard-codes
-`CMAKE_GENERATOR="Unix Makefiles` on UNIX systems, so you have to set or unset
+`CMAKE_GENERATOR="Unix Makefiles"` on UNIX systems, so you have to set or unset
 this to use Ninja if you prefer Ninja. The `scikit-build-core` recipe cannot
 depend on `cmake`, `make`, or `ninja`, because that would add those to the wrong
 table (`host` instead of `build`). Here's an example:

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -405,7 +405,7 @@ your `pyproject.toml`. You should specify exactly what language you use to keep
 CMake from searching for both `C` and `CXX` compilers (the default).
 
 You'll need to handle the generation of files by NumPy directly at the moment.
-A helper (similar to scikti-build classic) might be added in the future. You'll
+A helper (similar to scikit-build classic) might be added in the future. You'll
 need gfortran on macOS.
 
 ````

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -69,7 +69,7 @@ Key limitations:
 - Using cmake in SDist step is not supported yet.
 - Editable installs are not supported yet.
 - `scikit-build.generate` and `scikit-build.metadata` is not supported.
-- `${SKBUILD_HEADER_DIR}` is not supported, request support in Hatching if
+- `${SKBUILD_HEADER_DIR}` is not supported, request support in Hatchling if
   needed.
 - Anything in `${SKBUILD_METADATA_DIR}` must be placed in an `extra_metadata`
   folder.

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -16,7 +16,7 @@ version of setuptools (recommended!).
 
 To use the plugin, make sure you have both setuptools and scikit-build-core in
 your `build-system.requires` table. You can use either `setuptools.build_meta`
-or `scikit-build-core.setuptools.build_meta` as `build-system.build-backend`,
+or `scikit_build_core.setuptools.build_meta` as `build-system.build-backend`,
 but the latter will give you the auto-inclusion of `cmake` and `ninja` as
 needed, so it is recommended.
 


### PR DESCRIPTION
From #1363.

:robot: _AI text below_ :robot:

## Summary
Fixed 8 documentation typos and grammar errors across 7 files:

1. **docs/guide/getting_started.md** - "scikti-build" → "scikit-build"
2. **docs/plugins/hatchling.md** - "Hatching" → "Hatchling"
3. **docs/about/projects.md** - "sckit-build-core" → "scikit-build-core"
4. **docs/plugins/setuptools.md** - "scikit-build-core.setuptools.build_meta" → "scikit_build_core.setuptools.build_meta" (prose only; code already correct)
5. **docs/guide/faqs.md** - Fixed three issues:
   - "produced" → "produces"
   - "redistrubutable" → "redistributable"
   - Added missing conjunction "and" to make "which are not redistributable and cannot be uploaded"
   - Closed unclosed quote in `CMAKE_GENERATOR="Unix Makefiles"`
6. **docs/guide/dynamic_link.md** - "confirm" → "conform"
7. **docs/guide/build.md** - Fixed doubled periods ".." → "." (two occurrences)

All changes are documentation-only. No code changes, no `nox -t gen` needed.