### PR TITLE
feat: add force-include for sdist, wheel, and build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ sdist.reproducible = true
 # If set to True, CMake will be run before building the SDist.
 sdist.cmake = false
 
+# Force-include files into the SDist.
+sdist.force-include = {}
+
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["src/<package>", "python/<package>", "<package>"]
 
@@ -230,6 +233,9 @@ wheel.exclude = []
 
 # The build tag to use for the wheel. If empty, no build tag is used.
 wheel.build-tag = ""
+
+# Force-include files into the wheel.
+wheel.force-include = {}
 
 # If CMake is less than this value, backport a copy of FindPython.
 backport.find-python = "3.26.1"
@@ -287,9 +293,6 @@ search.site-packages = true
 
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
-
-# Force-include files into the distributions.
-force-include = {}
 
 # Strictly check all config options.
 strict-config = true

--- a/README.md
+++ b/README.md
@@ -288,6 +288,9 @@ search.site-packages = true
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
 
+# Force-include files into the distributions.
+force-include = {}
+
 # Strictly check all config options.
 strict-config = true
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -378,22 +378,19 @@ file or a directory, and directories are copied recursively (skipping VCS and
 the platlib (the package area). Force-included files are placed last, so they
 override discovered package files and CMake output at the same destination.
 
-For more control, the value can be an inline table targeting any subset of the
-`sdist`, `wheel`, and `build` outputs independently:
+For more control, the value can be an inline table targeting the `sdist` and
+`wheel` outputs independently:
 
 ```toml
 [tool.scikit-build.force-include]
 # vendor an external data file into both the SDist and the wheel
 "../shared/data.json" = {sdist = "mypackage/data.json", wheel = "mypackage/data.json"}
-# drop a file into the CMake build directory before configure, for CMake to use
-"toolchain.cmake" = {build = "toolchain.cmake"}
 ```
 
 The `wheel` destination also accepts a leading `/data`, `/scripts`, `/headers`,
 or `/metadata` to target that wheel tree instead of the platlib (this requires
 `experimental = true`, like `wheel.install-dir`). The `sdist` destination is
-relative to the SDist root, and `build` is relative to the CMake build
-directory.
+relative to the SDist root.
 
 A missing source is an error by default, unless the entry sets
 `missing-ok = true` (the bare-string form always does, like hatchling):
@@ -403,11 +400,11 @@ A missing source is an error by default, unless the entry sets
 "../maybe-built.so" = {wheel = "mypackage/_lib.so", missing-ok = true}
 ```
 
-When a wheel or build is produced from an SDist rather than a source tree, an
-entry with an `sdist` destination is read from that vendored SDist location
-instead of the original source. So vendoring an external source into the SDist
-(via the `sdist` target) keeps the wheel buildable from the SDist, where the
-original `../` source is gone.
+When a wheel is built from an SDist rather than a source tree, an entry with an
+`sdist` destination is read from that vendored SDist location instead of the
+original source. So vendoring an external source into the SDist (via the `sdist`
+target) keeps the wheel buildable from the SDist, where the original `../`
+source is gone.
 
 The inline-table form is only available in `pyproject.toml`; the bare-string
 (wheel) form can also be set via config-settings or `SKBUILD_FORCE_INCLUDE`.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -394,10 +394,6 @@ destination. A force-included _directory_ stays subject to that exclude, so a
 bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
 directory and exclude `**/*.bzl` to drop the Bazel files from it).
 
-Both tables can be set through any config source, including config-settings and
-the `SKBUILD_SDIST_FORCE_INCLUDE` / `SKBUILD_WHEEL_FORCE_INCLUDE` environment
-variables.
-
 #### Building a wheel from an SDist
 
 A common pattern vendors an external (`../`) source into the SDist and then
@@ -421,9 +417,9 @@ on-disk file always wins, so the vendored copy is preferred when present.
 
 For cases the automatic resolution cannot express — e.g. the wheel source is the
 _original_ external path rather than the SDist output — use
-[overrides](#overrides) keyed on `from-sdist`. Because override dicts merge
-rather than replace, keep the external entry in the `from-sdist = false`
-override (not the base table):
+[overrides](#overrides) keyed on `from-sdist`, with a separate
+`wheel.force-include` entry gated on each build mode (source tree vs.
+wheel-from-SDist):
 
 ```toml
 [tool.scikit-build.sdist.force-include]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -359,6 +359,49 @@ assume `wheel.platlib = false` (purelib targeted instead).
 
 :::
 
+### Force-including files
+
+Sometimes you need to place a specific file (or directory) at a specific path in
+a distribution, even if it lives outside your package tree or is produced
+elsewhere. `force-include` is a table mapping source paths to destinations:
+
+```toml
+[tool.scikit-build.force-include]
+"vendor/lib.so" = "mypackage/_lib.so"
+"assets" = "mypackage/assets"
+```
+
+The keys are source paths relative to the project root; they may point outside
+it (e.g. `../shared`), and `~` is expanded. A source may be a file or a
+directory, and directories are copied recursively (skipping VCS and
+`__pycache__` junk). A bare string value is the wheel destination, relative to
+the platlib (the package area). Force-included files are placed last, so they
+override discovered package files and CMake output at the same destination.
+
+For more control, the value can be an inline table targeting any subset of the
+`sdist`, `wheel`, and `build` outputs independently:
+
+```toml
+[tool.scikit-build.force-include]
+# vendor an external data file into both the SDist and the wheel
+"../shared/data.json" = {sdist = "mypackage/data.json", wheel = "mypackage/data.json"}
+# drop a file into the CMake build directory before configure, for CMake to use
+"toolchain.cmake" = {build = "toolchain.cmake"}
+```
+
+The `wheel` destination also accepts a leading `/data`, `/scripts`, `/headers`,
+or `/metadata` to target that wheel tree instead of the platlib (this requires
+`experimental = true`, like `wheel.install-dir`). The `sdist` destination is
+relative to the SDist root, and `build` is relative to the CMake build
+directory.
+
+A missing source is silently skipped, rather than erroring: when a wheel is
+built from an SDist an external source may be gone, but it is assumed to already
+be present at the destination (use the `sdist` target to vendor it into the
+SDist so it is). The inline-table form is only available in `pyproject.toml`;
+the bare-string (wheel) form can also be set via config-settings or
+`SKBUILD_FORCE_INCLUDE`.
+
 ## Customizing the output wheel
 
 The python API tags for your wheel will be correct assuming you are building a

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -363,53 +363,55 @@ assume `wheel.platlib = false` (purelib targeted instead).
 
 Sometimes you need to place a specific file (or directory) at a specific path in
 a distribution, even if it lives outside your package tree or is produced
-elsewhere. `force-include` is a table mapping source paths to destinations:
+elsewhere. Each distribution has its own `force-include` table mapping source
+paths to destinations:
 
 ```toml
-[tool.scikit-build.force-include]
-"vendor/extra.cmake" = "cmake/extra.cmake"
-"assets" = "share/assets"
+[tool.scikit-build.sdist.force-include]
+"../shared/data.json" = "mypackage/data.json"
+
+[tool.scikit-build.wheel.force-include]
+"vendor/lib.so" = "mypackage/_lib.so"
+"tools/run.sh"  = "/scripts/run.sh"
 ```
 
 The keys are source paths relative to the project root; they may point outside
 it (e.g. `../shared`) or be absolute, and `~` is expanded. A source may be a
 file or a directory, and directories are copied recursively (skipping VCS and
-`__pycache__` junk). A bare string value is the SDist destination, relative to
-the SDist root. Force-included files are placed last, so they override
-discovered package files and CMake output at the same destination.
+`__pycache__` junk). A missing source is an error.
 
-For more control, the value can be an inline table targeting the `sdist` and
-`wheel` outputs independently:
+`sdist.force-include` destinations are relative to the SDist root.
+`wheel.force-include` destinations are relative to the platlib (the package
+area), and also accept a leading `/data`, `/scripts`, `/headers`, or `/metadata`
+to target that wheel tree instead (this requires `experimental = true`, like
+`wheel.install-dir`). Force-included wheel files are placed last, so they
+override discovered package files and CMake output at the same destination.
+
+Both tables can be set through any config source, including config-settings and
+the `SKBUILD_SDIST_FORCE_INCLUDE` / `SKBUILD_WHEEL_FORCE_INCLUDE` environment
+variables.
+
+#### Building a wheel from an SDist
+
+When you vendor an external (`../`) source into the SDist, the original path is
+gone when a wheel is later built from the unpacked SDist, so the matching
+`wheel.force-include` entry would error. Use [overrides](#overrides) keyed on
+`from-sdist` to point the wheel at the vendored copy. Because override dicts
+merge rather than replace, keep the external entry in the `from-sdist = false`
+override (not the base table):
 
 ```toml
-[tool.scikit-build.force-include]
-# vendor an external data file into both the SDist and the wheel
-"../shared/data.json" = {sdist = "mypackage/data.json", wheel = "mypackage/data.json"}
-# place a built library into the wheel only
-"vendor/lib.so" = {wheel = "mypackage/_lib.so"}
+[tool.scikit-build.sdist.force-include]
+"../outside.txt" = "vendored/blob.txt"   # vendor it into the SDist
+
+[[tool.scikit-build.overrides]]
+if.from-sdist = false                     # source-tree build: read the original
+wheel.force-include."../outside.txt" = "mypackage/blob.txt"
+
+[[tool.scikit-build.overrides]]
+if.from-sdist = true                      # wheel-from-SDist: read the vendored copy
+wheel.force-include."vendored/blob.txt" = "mypackage/blob.txt"
 ```
-
-The `wheel` destination is relative to the platlib (the package area), and also
-accepts a leading `/data`, `/scripts`, `/headers`, or `/metadata` to target that
-wheel tree instead (this requires `experimental = true`, like
-`wheel.install-dir`). The `sdist` destination is relative to the SDist root.
-
-A missing source is an error by default, unless the entry sets `strict = false`,
-which skips it silently:
-
-```toml
-[tool.scikit-build.force-include]
-"../maybe-built.so" = {wheel = "mypackage/_lib.so", strict = false}
-```
-
-When a wheel is built from an SDist rather than a source tree, an entry with an
-`sdist` destination is read from that vendored SDist location instead of the
-original source. So vendoring an external source into the SDist (via the `sdist`
-target) keeps the wheel buildable from the SDist, where the original `../`
-source is gone.
-
-The inline-table form is only available in `pyproject.toml`; the bare-string
-(SDist) form can also be set via config-settings or `SKBUILD_FORCE_INCLUDE`.
 
 ## Customizing the output wheel
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -372,8 +372,8 @@ elsewhere. `force-include` is a table mapping source paths to destinations:
 ```
 
 The keys are source paths relative to the project root; they may point outside
-it (e.g. `../shared`), and `~` is expanded. A source may be a file or a
-directory, and directories are copied recursively (skipping VCS and
+it (e.g. `../shared`) or be absolute, and `~` is expanded. A source may be a
+file or a directory, and directories are copied recursively (skipping VCS and
 `__pycache__` junk). A bare string value is the wheel destination, relative to
 the platlib (the package area). Force-included files are placed last, so they
 override discovered package files and CMake output at the same destination.
@@ -395,12 +395,22 @@ or `/metadata` to target that wheel tree instead of the platlib (this requires
 relative to the SDist root, and `build` is relative to the CMake build
 directory.
 
-A missing source is silently skipped, rather than erroring: when a wheel is
-built from an SDist an external source may be gone, but it is assumed to already
-be present at the destination (use the `sdist` target to vendor it into the
-SDist so it is). The inline-table form is only available in `pyproject.toml`;
-the bare-string (wheel) form can also be set via config-settings or
-`SKBUILD_FORCE_INCLUDE`.
+A missing source is an error by default, unless the entry sets
+`missing-ok = true` (the bare-string form always does, like hatchling):
+
+```toml
+[tool.scikit-build.force-include]
+"../maybe-built.so" = {wheel = "mypackage/_lib.so", missing-ok = true}
+```
+
+When a wheel or build is produced from an SDist rather than a source tree, an
+entry with an `sdist` destination is read from that vendored SDist location
+instead of the original source. So vendoring an external source into the SDist
+(via the `sdist` target) keeps the wheel buildable from the SDist, where the
+original `../` source is gone.
+
+The inline-table form is only available in `pyproject.toml`; the bare-string
+(wheel) form can also be set via config-settings or `SKBUILD_FORCE_INCLUDE`.
 
 ## Customizing the output wheel
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -387,6 +387,12 @@ to target that wheel tree instead (this requires `experimental = true`, like
 `wheel.install-dir`). Force-included wheel files are placed last, so they
 override discovered package files and CMake output at the same destination.
 
+A force-included _file_ also overrides `wheel.exclude`: naming an exact source
+is an explicit request, so it wins even if an exclude pattern matches its
+destination. A force-included _directory_ stays subject to `wheel.exclude`, so a
+bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
+directory and exclude `**/*.bzl` to drop the Bazel files from it).
+
 Both tables can be set through any config source, including config-settings and
 the `SKBUILD_SDIST_FORCE_INCLUDE` / `SKBUILD_WHEEL_FORCE_INCLUDE` environment
 variables.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -367,16 +367,16 @@ elsewhere. `force-include` is a table mapping source paths to destinations:
 
 ```toml
 [tool.scikit-build.force-include]
-"vendor/lib.so" = "mypackage/_lib.so"
-"assets" = "mypackage/assets"
+"vendor/extra.cmake" = "cmake/extra.cmake"
+"assets" = "share/assets"
 ```
 
 The keys are source paths relative to the project root; they may point outside
 it (e.g. `../shared`) or be absolute, and `~` is expanded. A source may be a
 file or a directory, and directories are copied recursively (skipping VCS and
-`__pycache__` junk). A bare string value is the wheel destination, relative to
-the platlib (the package area). Force-included files are placed last, so they
-override discovered package files and CMake output at the same destination.
+`__pycache__` junk). A bare string value is the SDist destination, relative to
+the SDist root. Force-included files are placed last, so they override
+discovered package files and CMake output at the same destination.
 
 For more control, the value can be an inline table targeting the `sdist` and
 `wheel` outputs independently:
@@ -385,19 +385,21 @@ For more control, the value can be an inline table targeting the `sdist` and
 [tool.scikit-build.force-include]
 # vendor an external data file into both the SDist and the wheel
 "../shared/data.json" = {sdist = "mypackage/data.json", wheel = "mypackage/data.json"}
+# place a built library into the wheel only
+"vendor/lib.so" = {wheel = "mypackage/_lib.so"}
 ```
 
-The `wheel` destination also accepts a leading `/data`, `/scripts`, `/headers`,
-or `/metadata` to target that wheel tree instead of the platlib (this requires
-`experimental = true`, like `wheel.install-dir`). The `sdist` destination is
-relative to the SDist root.
+The `wheel` destination is relative to the platlib (the package area), and also
+accepts a leading `/data`, `/scripts`, `/headers`, or `/metadata` to target that
+wheel tree instead (this requires `experimental = true`, like
+`wheel.install-dir`). The `sdist` destination is relative to the SDist root.
 
-A missing source is an error by default, unless the entry sets
-`missing-ok = true` (the bare-string form always does, like hatchling):
+A missing source is an error by default, unless the entry sets `strict = false`,
+which skips it silently:
 
 ```toml
 [tool.scikit-build.force-include]
-"../maybe-built.so" = {wheel = "mypackage/_lib.so", missing-ok = true}
+"../maybe-built.so" = {wheel = "mypackage/_lib.so", strict = false}
 ```
 
 When a wheel is built from an SDist rather than a source tree, an entry with an
@@ -407,7 +409,7 @@ target) keeps the wheel buildable from the SDist, where the original `../`
 source is gone.
 
 The inline-table form is only available in `pyproject.toml`; the bare-string
-(wheel) form can also be set via config-settings or `SKBUILD_FORCE_INCLUDE`.
+(SDist) form can also be set via config-settings or `SKBUILD_FORCE_INCLUDE`.
 
 ## Customizing the output wheel
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -400,11 +400,29 @@ variables.
 
 #### Building a wheel from an SDist
 
-When you vendor an external (`../`) source into the SDist, the original path is
-gone when a wheel is later built from the unpacked SDist, so the matching
-`wheel.force-include` entry would error. Use [overrides](#overrides) keyed on
-`from-sdist` to point the wheel at the vendored copy. Because override dicts
-merge rather than replace, keep the external entry in the `from-sdist = false`
+A common pattern vendors an external (`../`) source into the SDist and then
+ships that output in the wheel. Reference the SDist destination as the wheel
+source and it works in both build modes:
+
+```toml
+[tool.scikit-build.sdist.force-include]
+"../shared/data.json" = "mypackage/data.json"   # vendor it into the SDist
+
+[tool.scikit-build.wheel.force-include]
+"mypackage/data.json" = "mypackage/data.json"    # ship the SDist output
+```
+
+When the wheel is built from the unpacked SDist, `mypackage/data.json` exists
+and is used directly. When it is built from the source tree (or an editable
+install) the file was never materialized; a `wheel.force-include` source missing
+on disk is then resolved through `sdist.force-include` (by exact destination, or
+under a force-included directory) and read from that original source instead. An
+on-disk file always wins, so the vendored copy is preferred when present.
+
+For cases the automatic resolution cannot express — e.g. the wheel source is the
+_original_ external path rather than the SDist output — use
+[overrides](#overrides) keyed on `from-sdist`. Because override dicts merge
+rather than replace, keep the external entry in the `from-sdist = false`
 override (not the base table):
 
 ```toml

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -387,9 +387,10 @@ to target that wheel tree instead (this requires `experimental = true`, like
 `wheel.install-dir`). Force-included wheel files are placed last, so they
 override discovered package files and CMake output at the same destination.
 
-A force-included _file_ also overrides `wheel.exclude`: naming an exact source
+A force-included _file_ also overrides the matching exclude list
+(`wheel.exclude` for wheels, `sdist.exclude` for SDists): naming an exact source
 is an explicit request, so it wins even if an exclude pattern matches its
-destination. A force-included _directory_ stays subject to `wheel.exclude`, so a
+destination. A force-included _directory_ stays subject to that exclude, so a
 bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
 directory and exclude `**/*.bzl` to drop the Bazel files from it).
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -796,6 +796,11 @@ print(mk_skbuild_docs())
 
   Force-included files are placed last, so they override discovered package
   files and CMake output at the same destination. A missing source is an error.
+
+  A force-included *file* also overrides :confval:`wheel.exclude`, since naming
+  an exact source is an explicit request for that file. A force-included
+  *directory* stays subject to :confval:`wheel.exclude`, so a bulk copy can
+  still be trimmed by an exclude pattern.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -105,16 +105,16 @@ print(mk_skbuild_docs())
   be a file or a directory; directories are copied recursively, skipping VCS
   and ``__pycache__`` junk.
 
-  A bare string value is the wheel destination (the common case). An inline
-  table gives per-target control with any subset of ``sdist`` and ``wheel``
-  keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form
-  is only available in ``pyproject.toml``).
+  A bare string value is the SDist destination. An inline table gives
+  per-target control with any subset of ``sdist`` and ``wheel`` keys, e.g.
+  ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form is only
+  available in ``pyproject.toml``).
 
   Force-included files override package files and CMake output at the same
-  destination. A missing source errors unless ``missing-ok`` is set (the
-  bare-string form sets it). When a wheel is built from an SDist rather than a
-  source tree, an entry with an ``sdist`` destination is read from that SDist
-  location instead of the original source.
+  destination. A missing source errors unless ``strict = false`` is set. When
+  a wheel is built from an SDist rather than a source tree, an entry with an
+  ``sdist`` destination is read from that SDist location instead of the
+  original source.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -92,6 +92,30 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: force-include
+
+  :Type: ``dict[str,str | ForceIncludeTargets]``
+  :Config-settings: ``force-include`` or ``skbuild.force-include``
+  :Environment variable: ``SKBUILD_FORCE_INCLUDE``
+
+  Force-include files into the distributions.
+
+  Keys are source paths relative to the project root; they may point outside
+  it (e.g. ``../shared``), and ``~`` is expanded. A source may be a file or a
+  directory; directories are copied recursively, skipping VCS and
+  ``__pycache__`` junk.
+
+  A bare string value is the wheel destination (the common case). An inline
+  table gives per-target control with any subset of ``sdist``, ``wheel``, and
+  ``build`` keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline
+  table form is only available in ``pyproject.toml``).
+
+  Force-included files override package files and CMake output at the same
+  destination. A missing source is silently skipped (it is assumed to already
+  be present at the destination, e.g. when building a wheel from an SDist).
+```
+
+```{eval-rst}
 .. confval:: metadata
 
   :Type: ``dict[str,dict[str,Any]]``

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -92,32 +92,6 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
-.. confval:: force-include
-
-  :Type: ``dict[str,str | ForceIncludeTargets]``
-  :Config-settings: ``force-include`` or ``skbuild.force-include``
-  :Environment variable: ``SKBUILD_FORCE_INCLUDE``
-
-  Force-include files into the distributions.
-
-  Keys are source paths relative to the project root; they may point outside
-  it (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may
-  be a file or a directory; directories are copied recursively, skipping VCS
-  and ``__pycache__`` junk.
-
-  A bare string value is the SDist destination. An inline table gives
-  per-target control with any subset of ``sdist`` and ``wheel`` keys, e.g.
-  ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form is only
-  available in ``pyproject.toml``).
-
-  Force-included files override package files and CMake output at the same
-  destination. A missing source errors unless ``strict = false`` is set. When
-  a wheel is built from an SDist rather than a source tree, an entry with an
-  ``sdist`` destination is read from that SDist location instead of the
-  original source.
-```
-
-```{eval-rst}
 .. confval:: metadata
 
   :Type: ``dict[str,dict[str,Any]]``
@@ -668,6 +642,24 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: sdist.force-include
+
+  :Type: ``dict[str,str]``
+  :Config-settings: ``sdist.force-include`` or ``skbuild.sdist.force-include``
+  :Environment variable: ``SKBUILD_SDIST_FORCE_INCLUDE``
+
+  Force-include files into the SDist.
+
+  Maps source paths to destinations relative to the SDist root. Keys are
+  relative to the project root; they may point outside it (e.g. ``../shared``)
+  or be absolute, and ``~`` is expanded. A source may be a file or a directory;
+  directories are copied recursively, skipping VCS and ``__pycache__`` junk.
+
+  Force-included files override files at the same destination. A missing source
+  is an error.
+```
+
+```{eval-rst}
 .. confval:: sdist.include
 
   :Type: ``list[str]``
@@ -781,6 +773,29 @@ print(mk_skbuild_docs())
 
   This adds "x86_64" and "arm64" to the list of platforms when "universal2" is used,
   which helps older Pip's (before 21.0.1) find the correct wheel.
+```
+
+```{eval-rst}
+.. confval:: wheel.force-include
+
+  :Type: ``dict[str,str]``
+  :Config-settings: ``wheel.force-include`` or ``skbuild.wheel.force-include``
+  :Environment variable: ``SKBUILD_WHEEL_FORCE_INCLUDE``
+
+  Force-include files into the wheel.
+
+  Maps source paths to destinations relative to the platlib (the package
+  area). Keys are relative to the project root; they may point outside it
+  (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may be a
+  file or a directory; directories are copied recursively, skipping VCS and
+  ``__pycache__`` junk.
+
+  A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
+  ``/metadata`` destination targets that wheel tree instead of the platlib
+  (this requires :confval:`experimental`).
+
+  Force-included files are placed last, so they override discovered package
+  files and CMake output at the same destination. A missing source is an error.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -806,6 +806,12 @@ print(mk_skbuild_docs())
   an exact source is an explicit request for that file. A force-included
   *directory* stays subject to :confval:`wheel.exclude`, so a bulk copy can
   still be trimmed by an exclude pattern.
+
+  If a source is missing on disk, it is looked up through
+  :confval:`sdist.force-include` (by exact destination or under a force-included
+  directory) and read from that original source instead. This lets a source
+  that names an sdist output (vendored via :confval:`sdist.force-include`) build
+  from both a source tree and an unpacked sdist.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -106,15 +106,15 @@ print(mk_skbuild_docs())
   and ``__pycache__`` junk.
 
   A bare string value is the wheel destination (the common case). An inline
-  table gives per-target control with any subset of ``sdist``, ``wheel``, and
-  ``build`` keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline
-  table form is only available in ``pyproject.toml``).
+  table gives per-target control with any subset of ``sdist`` and ``wheel``
+  keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form
+  is only available in ``pyproject.toml``).
 
   Force-included files override package files and CMake output at the same
   destination. A missing source errors unless ``missing-ok`` is set (the
-  bare-string form sets it). When a wheel or build is produced from an SDist
-  rather than a source tree, an entry with an ``sdist`` destination is read
-  from that SDist location instead of the original source.
+  bare-string form sets it). When a wheel is built from an SDist rather than a
+  source tree, an entry with an ``sdist`` destination is read from that SDist
+  location instead of the original source.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -101,9 +101,9 @@ print(mk_skbuild_docs())
   Force-include files into the distributions.
 
   Keys are source paths relative to the project root; they may point outside
-  it (e.g. ``../shared``), and ``~`` is expanded. A source may be a file or a
-  directory; directories are copied recursively, skipping VCS and
-  ``__pycache__`` junk.
+  it (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may
+  be a file or a directory; directories are copied recursively, skipping VCS
+  and ``__pycache__`` junk.
 
   A bare string value is the wheel destination (the common case). An inline
   table gives per-target control with any subset of ``sdist``, ``wheel``, and
@@ -111,8 +111,10 @@ print(mk_skbuild_docs())
   table form is only available in ``pyproject.toml``).
 
   Force-included files override package files and CMake output at the same
-  destination. A missing source is silently skipped (it is assumed to already
-  be present at the destination, e.g. when building a wheel from an SDist).
+  destination. A missing source errors unless ``missing-ok`` is set (the
+  bare-string form sets it). When a wheel or build is produced from an SDist
+  rather than a source tree, an entry with an ``sdist`` destination is read
+  from that SDist location instead of the original source.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -657,6 +657,11 @@ print(mk_skbuild_docs())
 
   Force-included files override files at the same destination. A missing source
   is an error.
+
+  A force-included *file* is forced in even if :confval:`sdist.exclude` matches
+  its destination, since naming an exact source is an explicit request. A
+  force-included *directory* stays subject to :confval:`sdist.exclude`, so a
+  bulk copy can still be trimmed by an exclude pattern.
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Literal
 
 import pathspec
@@ -130,7 +130,18 @@ def iter_force_include(
     ``__pycache__`` junk) with each file mapped under ``base / dest``. A source
     that does not exist yields nothing -- it is assumed to already be present at
     the destination (e.g. when building a wheel from an SDist).
+
+    ``dest`` must be a relative path within ``base``; an absolute path or one
+    with ``..`` components (which would escape ``base``) is rejected. Wheel-tree
+    selection (a leading ``/``) is handled earlier by :func:`resolve_wheel_tree`.
     """
+    dest_path = PurePosixPath(dest)
+    if dest_path.is_absolute() or ".." in dest_path.parts:
+        msg = (
+            f"Force-include destination {dest!r} for {source!r} must be a "
+            "relative path without '..'"
+        )
+        raise AssertionError(msg)
     src = Path(source).expanduser()
     if src.is_file():
         yield src, base / dest

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -8,12 +8,14 @@ from typing import TYPE_CHECKING, Literal
 import pathspec
 
 from .._logging import logger
+from ..settings.skbuild_model import ForceIncludeTargets
 from ._file_processor import EXCLUDE_LINES, each_unignored_file
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 
 __all__ = [
+    "force_include_targets",
     "is_module",
     "is_trackable",
     "iter_force_include",
@@ -118,18 +120,34 @@ def resolve_wheel_tree(
     return wheel_dirs[targetlib], dest
 
 
+def force_include_targets(fi_value: str | ForceIncludeTargets) -> ForceIncludeTargets:
+    """
+    Normalize a force-include value into a :class:`ForceIncludeTargets`.
+
+    A bare string is the wheel destination only and implies ``missing-ok`` (it is
+    lenient like hatchling). An inline table is returned unchanged, so it errors
+    on a missing source unless it sets ``missing-ok``.
+    """
+    if isinstance(fi_value, str):
+        return ForceIncludeTargets(wheel=fi_value, missing_ok=True)
+    return fi_value
+
+
 def iter_force_include(
-    source: str, dest: str, base: Path
+    source: str, dest: str, base: Path, *, missing_ok: bool = False
 ) -> Iterator[tuple[Path, Path]]:
     """
     Yield ``(source_file, target_path)`` pairs for a force-include entry.
 
     ``source`` may be a file or a directory (relative to the project root, may
-    point outside it, with ``~`` expanded). A file yields a single pair mapped to
-    ``base / dest``; a directory is walked recursively (skipping VCS and
-    ``__pycache__`` junk) with each file mapped under ``base / dest``. A source
-    that does not exist yields nothing -- it is assumed to already be present at
-    the destination (e.g. when building a wheel from an SDist).
+    point outside it or be absolute, with ``~`` expanded). A file yields a single
+    pair mapped to ``base / dest``; a directory is walked recursively (skipping
+    VCS and ``__pycache__`` junk) with each file mapped under ``base / dest``.
+
+    If the source does not exist, a :class:`FileNotFoundError` is raised unless
+    ``missing_ok`` is set, in which case it yields nothing -- the source is
+    assumed to already be present at the destination (e.g. when building a wheel
+    from an SDist).
 
     ``dest`` must be a relative path within ``base``; an absolute path or one
     with ``..`` components (which would escape ``base``) is rejected. Wheel-tree
@@ -151,8 +169,11 @@ def iter_force_include(
             rel_path = filepath.relative_to(src)
             if not exclude_spec.match_file(rel_path):
                 yield filepath, base / dest / rel_path
-    else:
+    elif missing_ok:
         logger.debug("Force-include source {!r} not found, skipping", source)
+    else:
+        msg = f"Force-include source {source!r} not found"
+        raise FileNotFoundError(msg)
 
 
 def is_trackable(path: Path) -> bool:

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -7,15 +7,12 @@ from typing import TYPE_CHECKING, Literal
 
 import pathspec
 
-from .._logging import logger
-from ..settings.skbuild_model import ForceIncludeTargets
 from ._file_processor import EXCLUDE_LINES, each_unignored_file
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 
 __all__ = [
-    "force_include_targets",
     "is_module",
     "is_trackable",
     "iter_force_include",
@@ -120,20 +117,8 @@ def resolve_wheel_tree(
     return wheel_dirs[targetlib], dest
 
 
-def force_include_targets(fi_value: str | ForceIncludeTargets) -> ForceIncludeTargets:
-    """
-    Normalize a force-include value into a :class:`ForceIncludeTargets`.
-
-    A bare string is the SDist destination only. An inline table is returned
-    unchanged.
-    """
-    if isinstance(fi_value, str):
-        return ForceIncludeTargets(sdist=fi_value)
-    return fi_value
-
-
 def iter_force_include(
-    source: str, dest: str, base: Path, *, strict: bool = True
+    source: str, dest: str, base: Path
 ) -> Iterator[tuple[Path, Path]]:
     """
     Yield ``(source_file, target_path)`` pairs for a force-include entry.
@@ -143,10 +128,7 @@ def iter_force_include(
     pair mapped to ``base / dest``; a directory is walked recursively (skipping
     VCS and ``__pycache__`` junk) with each file mapped under ``base / dest``.
 
-    If the source does not exist, a :class:`FileNotFoundError` is raised unless
-    ``strict`` is ``False``, in which case it yields nothing -- the source is
-    assumed to already be present at the destination (e.g. when building a wheel
-    from an SDist).
+    A missing source raises :class:`FileNotFoundError`.
 
     ``dest`` must be a relative path within ``base``; anything that could escape
     it is rejected -- an absolute path, ``..`` components, a backslash, or a
@@ -175,8 +157,6 @@ def iter_force_include(
             rel_path = filepath.relative_to(src)
             if not exclude_spec.match_file(rel_path):
                 yield filepath, base / dest / rel_path
-    elif not strict:
-        logger.debug("Force-include source {!r} not found, skipping", source)
     else:
         msg = f"Force-include source {source!r} not found"
         raise FileNotFoundError(msg)

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import os
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Literal
 
 import pathspec
@@ -149,15 +149,22 @@ def iter_force_include(
     assumed to already be present at the destination (e.g. when building a wheel
     from an SDist).
 
-    ``dest`` must be a relative path within ``base``; an absolute path or one
-    with ``..`` components (which would escape ``base``) is rejected. Wheel-tree
-    selection (a leading ``/``) is handled earlier by :func:`resolve_wheel_tree`.
+    ``dest`` must be a relative path within ``base``; anything that could escape
+    it is rejected -- an absolute path, ``..`` components, a backslash, or a
+    Windows drive (e.g. ``C:/x``), which would otherwise escape on Windows where
+    ``base / dest`` treats those as filesystem syntax. Wheel-tree selection (a
+    leading ``/``) is handled earlier by :func:`resolve_wheel_tree`.
     """
-    dest_path = PurePosixPath(dest)
-    if dest_path.is_absolute() or ".." in dest_path.parts:
+    posix_dest = PurePosixPath(dest)
+    if (
+        "\\" in dest
+        or PureWindowsPath(dest).drive
+        or posix_dest.is_absolute()
+        or ".." in posix_dest.parts
+    ):
         msg = (
             f"Force-include destination {dest!r} for {source!r} must be a "
-            "relative path without '..'"
+            "relative path without '..', a drive, or backslashes"
         )
         raise AssertionError(msg)
     src = Path(source).expanduser()

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -7,17 +7,20 @@ from typing import TYPE_CHECKING, Literal
 
 import pathspec
 
-from ._file_processor import each_unignored_file
+from .._logging import logger
+from ._file_processor import EXCLUDE_LINES, each_unignored_file
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping, Sequence
+    from collections.abc import Generator, Iterator, Mapping, Sequence
 
 __all__ = [
     "is_module",
     "is_trackable",
+    "iter_force_include",
     "module_loader_rank",
     "packages_to_file_mapping",
     "path_to_module",
+    "resolve_wheel_tree",
     "scantree",
 ]
 
@@ -83,6 +86,62 @@ def packages_to_file_mapping(
                 mapping[str(filepath)] = str(target_path)
 
     return mapping
+
+
+def resolve_wheel_tree(
+    dest: str,
+    *,
+    wheel_dirs: Mapping[str, Path],
+    targetlib: str,
+    experimental: bool,
+) -> tuple[Path, str]:
+    """
+    Resolve a wheel destination into a ``(base_dir, relative_dest)`` pair.
+
+    A plain ``dest`` is relative to the target lib (platlib/purelib). A leading
+    ``/`` selects a wheel tree (``/data``, ``/scripts``, ``/headers``,
+    ``/platlib``, ``/metadata``, ...) and requires experimental features, since
+    this gives access one level above the platlib root.
+    """
+    if ".." in dest:
+        msg = f"Wheel destination must not contain '..', got {dest!r}"
+        raise AssertionError(msg)
+    if dest.startswith("/"):
+        if not experimental:
+            msg = "Experimental features must be enabled to use absolute paths (a leading '/') in a wheel destination"
+            raise AssertionError(msg)
+        tree, _, rest = dest[1:].partition("/")
+        if tree not in wheel_dirs:
+            msg = f"Must target a valid wheel directory, not {tree!r}"
+            raise AssertionError(msg)
+        return wheel_dirs[tree], rest
+    return wheel_dirs[targetlib], dest
+
+
+def iter_force_include(
+    source: str, dest: str, base: Path
+) -> Iterator[tuple[Path, Path]]:
+    """
+    Yield ``(source_file, target_path)`` pairs for a force-include entry.
+
+    ``source`` may be a file or a directory (relative to the project root, may
+    point outside it, with ``~`` expanded). A file yields a single pair mapped to
+    ``base / dest``; a directory is walked recursively (skipping VCS and
+    ``__pycache__`` junk) with each file mapped under ``base / dest``. A source
+    that does not exist yields nothing -- it is assumed to already be present at
+    the destination (e.g. when building a wheel from an SDist).
+    """
+    src = Path(source).expanduser()
+    if src.is_file():
+        yield src, base / dest
+    elif src.is_dir():
+        exclude_spec = pathspec.GitIgnoreSpec.from_lines(EXCLUDE_LINES)
+        for filepath in scantree(src):
+            rel_path = filepath.relative_to(src)
+            if not exclude_spec.match_file(rel_path):
+                yield filepath, base / dest / rel_path
+    else:
+        logger.debug("Force-include source {!r} not found, skipping", source)
 
 
 def is_trackable(path: Path) -> bool:

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -124,17 +124,16 @@ def force_include_targets(fi_value: str | ForceIncludeTargets) -> ForceIncludeTa
     """
     Normalize a force-include value into a :class:`ForceIncludeTargets`.
 
-    A bare string is the wheel destination only and implies ``missing-ok`` (it is
-    lenient like hatchling). An inline table is returned unchanged, so it errors
-    on a missing source unless it sets ``missing-ok``.
+    A bare string is the SDist destination only. An inline table is returned
+    unchanged.
     """
     if isinstance(fi_value, str):
-        return ForceIncludeTargets(wheel=fi_value, missing_ok=True)
+        return ForceIncludeTargets(sdist=fi_value)
     return fi_value
 
 
 def iter_force_include(
-    source: str, dest: str, base: Path, *, missing_ok: bool = False
+    source: str, dest: str, base: Path, *, strict: bool = True
 ) -> Iterator[tuple[Path, Path]]:
     """
     Yield ``(source_file, target_path)`` pairs for a force-include entry.
@@ -145,7 +144,7 @@ def iter_force_include(
     VCS and ``__pycache__`` junk) with each file mapped under ``base / dest``.
 
     If the source does not exist, a :class:`FileNotFoundError` is raised unless
-    ``missing_ok`` is set, in which case it yields nothing -- the source is
+    ``strict`` is ``False``, in which case it yields nothing -- the source is
     assumed to already be present at the destination (e.g. when building a wheel
     from an SDist).
 
@@ -176,7 +175,7 @@ def iter_force_include(
             rel_path = filepath.relative_to(src)
             if not exclude_spec.match_file(rel_path):
                 yield filepath, base / dest / rel_path
-    elif missing_ok:
+    elif not strict:
         logger.debug("Force-include source {!r} not found, skipping", source)
     else:
         msg = f"Force-include source {source!r} not found"

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -19,6 +19,7 @@ __all__ = [
     "module_loader_rank",
     "packages_to_file_mapping",
     "path_to_module",
+    "resolve_from_sdist_force_include",
     "resolve_wheel_tree",
     "scantree",
 ]
@@ -119,6 +120,43 @@ def resolve_wheel_tree(
             raise AssertionError(msg)
         return wheel_dirs[tree], rest
     return wheel_dirs[targetlib], dest
+
+
+def resolve_from_sdist_force_include(
+    source: str, sdist_force_include: Mapping[str, str]
+) -> str:
+    """
+    Resolve a ``wheel.force-include`` source through the ``sdist.force-include`` map.
+
+    A common pattern vendors an external file into the sdist with
+    ``sdist.force-include`` and then ships that output via ``wheel.force-include``
+    (e.g. source ``mypackage/data.json`` for both). The file only exists on disk
+    when building from an unpacked sdist; a source-tree or editable build never
+    materialized it. In that case, map ``source`` back through
+    ``sdist_force_include`` (``{sdist_source: sdist_dest}``) to the original
+    source so the file is found either way.
+
+    An on-disk file always wins: if ``source`` exists it is returned unchanged.
+    Otherwise the longest ``sdist_dest`` that equals ``source`` or is a parent
+    directory of it wins, and its ``sdist_source`` (plus any remainder) is
+    returned -- ``~`` / ``..`` are left intact for :func:`iter_force_include` to
+    expand. With no match, ``source`` is returned unchanged and the caller raises
+    :class:`FileNotFoundError`.
+    """
+    if Path(source).expanduser().exists():
+        return source
+    src = PurePosixPath(source)
+    best_depth = -1
+    resolved = source
+    for sdist_source, sdist_dest in sdist_force_include.items():
+        dest = PurePosixPath(sdist_dest)
+        if src != dest and dest not in src.parents:
+            continue
+        depth = len(dest.parts)
+        if depth > best_depth:
+            best_depth = depth
+            resolved = str(PurePosixPath(sdist_source) / src.relative_to(dest))
+    return resolved
 
 
 def iter_force_include(

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -103,8 +103,10 @@ def resolve_wheel_tree(
     ``/platlib``, ``/metadata``, ...) and requires experimental features, since
     this gives access one level above the platlib root.
     """
-    if ".." in dest:
-        msg = f"Wheel destination must not contain '..', got {dest!r}"
+    # Reject a '..' parent-directory component (the traversal risk), but allow
+    # adjacent dots inside a normal filename like 'data..json'.
+    if ".." in PurePosixPath(dest).parts:
+        msg = f"Wheel destination must not contain a '..' path component, got {dest!r}"
         raise AssertionError(msg)
     if dest.startswith("/"):
         if not experimental:

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -110,6 +110,10 @@ def resolve_wheel_tree(
             msg = "Experimental features must be enabled to use absolute paths (a leading '/') in a wheel destination"
             raise AssertionError(msg)
         tree, _, rest = dest[1:].partition("/")
+        # platlib/purelib both name the target lib; map either to whichever this
+        # wheel actually has (pure wheels are keyed by purelib, not platlib).
+        if tree in {"platlib", "purelib"}:
+            tree = targetlib
         if tree not in wheel_dirs:
             msg = f"Must target a valid wheel directory, not {tree!r}"
             raise AssertionError(msg)

--- a/src/scikit_build_core/build/_scripts.py
+++ b/src/scikit_build_core/build/_scripts.py
@@ -33,5 +33,8 @@ def process_script_dir(script_dir: Path) -> None:
             if match:
                 content = [f"#!python{match.group(1) or ''}\n", *file_iter]
         if content:
-            with item.open("w", encoding="utf-8") as f:
+            # newline="\n" keeps the rewritten shebang on LF on every platform;
+            # the default text mode would emit CRLF on Windows, which is wrong in
+            # a "#!" line and made the wheel script bytes platform-dependent.
+            with item.open("w", encoding="utf-8", newline="\n") as f:
                 f.writelines(content)

--- a/src/scikit_build_core/build/_scripts.py
+++ b/src/scikit_build_core/build/_scripts.py
@@ -35,6 +35,6 @@ def process_script_dir(script_dir: Path) -> None:
         if content:
             # newline="\n" keeps the rewritten shebang on LF on every platform;
             # the default text mode would emit CRLF on Windows, which is wrong in
-            # a "#!" line and made the wheel script bytes platform-dependent.
+            # a "#!" line and would make the wheel script bytes platform-dependent.
             with item.open("w", encoding="utf-8", newline="\n") as f:
                 f.writelines(content)

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -161,7 +161,10 @@ class WheelWriter:
         }
 
     def build(
-        self, wheel_dirs: Mapping[str, Path], exclude: Sequence[str] = ()
+        self,
+        wheel_dirs: Mapping[str, Path],
+        exclude: Sequence[str] = (),
+        exclude_exempt: AbstractSet[Path] = frozenset(),
     ) -> None:
         (targetlib,) = {"platlib", "purelib"} & set(wheel_dirs)
         assert {
@@ -191,7 +194,11 @@ class WheelWriter:
                 if filename.suffix in {".pyc", ".pyo"}:
                     continue
                 relpath = filename.relative_to(path)
-                if exclude_spec.match_file(relpath):
+                # Force-included files are exempt from wheel.exclude.
+                if (
+                    exclude_spec.match_file(relpath)
+                    and filename.resolve() not in exclude_exempt
+                ):
                     continue
                 target = Path(data_dir) / key / relpath if key else relpath
                 self.write(str(filename), str(target))

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -17,7 +17,7 @@ from .._logging import rich_print
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
 from ._init import setup_logging
-from ._pathutil import iter_force_include
+from ._pathutil import force_include_targets, iter_force_include
 from .generate import generate_file_contents
 from .metadata import get_standard_metadata
 from .wheel import _build_wheel_impl
@@ -158,11 +158,11 @@ def build_sdist(
 
         for source, fi_value in settings.force_include.items():
             # A bare string targets the wheel only, so it is skipped here.
-            sdist_dest = None if isinstance(fi_value, str) else fi_value.sdist
-            if sdist_dest is None:
+            targets = force_include_targets(fi_value)
+            if targets.sdist is None:
                 continue
             for src_file, target in iter_force_include(
-                source, sdist_dest, Path(srcdirname)
+                source, targets.sdist, Path(srcdirname), missing_ok=targets.missing_ok
             ):
                 tar.add(
                     src_file,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -17,7 +17,7 @@ from .._logging import rich_print
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
 from ._init import setup_logging
-from ._pathutil import force_include_targets, iter_force_include
+from ._pathutil import iter_force_include
 from .generate import generate_file_contents
 from .metadata import get_standard_metadata
 from .wheel import _build_wheel_impl
@@ -156,15 +156,8 @@ def build_sdist(
                 filter=normalize_tar_info if reproducible else lambda x: x,
             )
 
-        for source, fi_value in settings.force_include.items():
-            # A bare string is the SDist destination; an inline table needs an
-            # explicit sdist key, otherwise it is skipped here.
-            targets = force_include_targets(fi_value)
-            if targets.sdist is None:
-                continue
-            for src_file, target in iter_force_include(
-                source, targets.sdist, Path(srcdirname), strict=targets.strict
-            ):
+        for source, dest in settings.sdist.force_include.items():
+            for src_file, target in iter_force_include(source, dest, Path(srcdirname)):
                 tar.add(
                     src_file,
                     arcname=target,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -9,6 +9,7 @@ import os
 import tarfile
 from pathlib import Path
 
+import pathspec
 from packaging.utils import canonicalize_name
 
 from .. import __version__
@@ -156,19 +157,21 @@ def build_sdist(
                 filter=normalize_tar_info if reproducible else lambda x: x,
             )
 
-        # Sort forced entries by archive name so the tar member order (and thus
-        # the reproducible .tar.gz bytes) does not depend on filesystem ordering
-        # when a forced source is a directory.
-        forced = sorted(
-            (
-                (src_file, target)
-                for source, dest in settings.sdist.force_include.items()
-                for src_file, target in iter_force_include(
-                    source, dest, Path(srcdirname)
-                )
-            ),
-            key=lambda pair: pair[1],
-        )
+        # A force-included file is forced in; a force-included directory's
+        # members stay subject to sdist.exclude (mirrors wheel.force-include).
+        sdist_exclude_spec = pathspec.GitIgnoreSpec.from_lines(settings.sdist.exclude)
+        forced = []
+        for source, dest in settings.sdist.force_include.items():
+            source_is_file = Path(source).expanduser().is_file()
+            for src_file, target in iter_force_include(source, dest, Path(srcdirname)):
+                if not source_is_file and sdist_exclude_spec.match_file(
+                    target.relative_to(srcdirname)
+                ):
+                    continue
+                forced.append((src_file, target))
+        # Sort by archive name so the tar member order (and thus the reproducible
+        # .tar.gz bytes) does not depend on filesystem ordering for directories.
+        forced.sort(key=lambda pair: pair[1])
         for src_file, target in forced:
             tar.add(
                 src_file,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -156,13 +156,25 @@ def build_sdist(
                 filter=normalize_tar_info if reproducible else lambda x: x,
             )
 
-        for source, dest in settings.sdist.force_include.items():
-            for src_file, target in iter_force_include(source, dest, Path(srcdirname)):
-                tar.add(
-                    src_file,
-                    arcname=target,
-                    filter=normalize_tar_info if reproducible else lambda x: x,
+        # Sort forced entries by archive name so the tar member order (and thus
+        # the reproducible .tar.gz bytes) does not depend on filesystem ordering
+        # when a forced source is a directory.
+        forced = sorted(
+            (
+                (src_file, target)
+                for source, dest in settings.sdist.force_include.items()
+                for src_file, target in iter_force_include(
+                    source, dest, Path(srcdirname)
                 )
+            ),
+            key=lambda pair: pair[1],
+        )
+        for src_file, target in forced:
+            tar.add(
+                src_file,
+                arcname=target,
+                filter=normalize_tar_info if reproducible else lambda x: x,
+            )
 
         add_bytes_to_tar(
             tar, pkg_info, f"{srcdirname}/PKG-INFO", normalize=reproducible

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -157,12 +157,13 @@ def build_sdist(
             )
 
         for source, fi_value in settings.force_include.items():
-            # A bare string targets the wheel only, so it is skipped here.
+            # A bare string is the SDist destination; an inline table needs an
+            # explicit sdist key, otherwise it is skipped here.
             targets = force_include_targets(fi_value)
             if targets.sdist is None:
                 continue
             for src_file, target in iter_force_include(
-                source, targets.sdist, Path(srcdirname), missing_ok=targets.missing_ok
+                source, targets.sdist, Path(srcdirname), strict=targets.strict
             ):
                 tar.add(
                     src_file,

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -17,6 +17,7 @@ from .._logging import rich_print
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
 from ._init import setup_logging
+from ._pathutil import iter_force_include
 from .generate import generate_file_contents
 from .metadata import get_standard_metadata
 from .wheel import _build_wheel_impl
@@ -154,6 +155,20 @@ def build_sdist(
                 arcname=srcdirname / filepath,
                 filter=normalize_tar_info if reproducible else lambda x: x,
             )
+
+        for source, fi_value in settings.force_include.items():
+            # A bare string targets the wheel only, so it is skipped here.
+            sdist_dest = None if isinstance(fi_value, str) else fi_value.sdist
+            if sdist_dest is None:
+                continue
+            for src_file, target in iter_force_include(
+                source, sdist_dest, Path(srcdirname)
+            ):
+                tar.add(
+                    src_file,
+                    arcname=target,
+                    filter=normalize_tar_info if reproducible else lambda x: x,
+                )
 
         add_bytes_to_tar(
             tar, pkg_info, f"{srcdirname}/PKG-INFO", normalize=reproducible

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -85,7 +85,7 @@ def _force_include_into_wheel(
     wheel_dirs: dict[str, Path],
     targetlib: str,
     only_metadata: bool = False,
-) -> None:
+) -> set[Path]:
     """
     Copy ``wheel.force-include`` entries into the staged wheel trees.
 
@@ -93,7 +93,11 @@ def _force_include_into_wheel(
     files at the same destination. ``only_metadata`` restricts the copy to the
     metadata tree; the prepare-metadata path uses it so the prepared
     ``.dist-info`` matches the final wheel.
+
+    Returns the resolved target paths written, so the caller can exempt them from
+    ``wheel.exclude`` (force-include means force, even past an exclude pattern).
     """
+    written: set[Path] = set()
     for source, dest in settings.wheel.force_include.items():
         base, rest = resolve_wheel_tree(
             dest,
@@ -106,6 +110,8 @@ def _force_include_into_wheel(
         for src_file, target in iter_force_include(source, rest, base):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
+            written.add(target.resolve())
+    return written
 
 
 @dataclasses.dataclass
@@ -506,7 +512,7 @@ def _build_wheel_impl_impl(
         # Force-include into the wheel, always (even for editable installs, as
         # these files are not redirectable) and after the package copy, so they
         # override package files and CMake output at the same destination.
-        _force_include_into_wheel(
+        force_included = _force_include_into_wheel(
             settings,
             wheel_dirs=wheel_dirs,
             targetlib=targetlib,
@@ -519,7 +525,11 @@ def _build_wheel_impl_impl(
         process_script_dir(wheel_dirs["scripts"])
 
         with make_wheel(folder=Path(wheel_directory)) as wheel:
-            wheel.build(wheel_dirs, exclude=settings.wheel.exclude)
+            wheel.build(
+                wheel_dirs,
+                exclude=settings.wheel.exclude,
+                exclude_exempt=force_included,
+            )
 
             str_pkgs = (
                 str(Path.cwd().joinpath(p).parent.resolve()) for p in packages.values()

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -94,8 +94,10 @@ def _force_include_into_wheel(
     metadata tree; the prepare-metadata path uses it so the prepared
     ``.dist-info`` matches the final wheel.
 
-    Returns the resolved target paths written, so the caller can exempt them from
-    ``wheel.exclude`` (force-include means force, even past an exclude pattern).
+    Returns the resolved target paths of force-included *files*, so the caller
+    can exempt them from ``wheel.exclude`` (naming an exact file forces it past
+    an exclude pattern). Files copied from a force-included *directory* are not
+    returned, so a bulk directory copy stays subject to ``wheel.exclude``.
     """
     written: set[Path] = set()
     for source, dest in settings.wheel.force_include.items():
@@ -107,10 +109,12 @@ def _force_include_into_wheel(
         )
         if only_metadata and base != wheel_dirs["metadata"]:
             continue
+        source_is_file = Path(source).expanduser().is_file()
         for src_file, target in iter_force_include(source, rest, base):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
-            written.add(target.resolve())
+            if source_is_file:
+                written.add(target.resolve())
     return written
 
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -528,9 +528,10 @@ def _build_wheel_impl_impl(
         )
 
         # Normalize script shebangs after force-includes, so force-included
-        # scripts (e.g. wheel = "/scripts/...") are processed too.
-        if not editable:
-            process_script_dir(wheel_dirs["scripts"])
+        # scripts (e.g. wheel = "/scripts/...") are processed too. Editable
+        # installs still ship scripts (CMake-installed or force-included), so
+        # normalize them as well.
+        process_script_dir(wheel_dirs["scripts"])
 
         with make_wheel(folder=Path(wheel_directory)) as wheel:
             wheel.build(wheel_dirs, exclude=settings.wheel.exclude)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -447,21 +447,6 @@ def _build_wheel_impl_impl(
                 config=config,
             )
 
-            for source, fi_value in settings.force_include.items():
-                targets = force_include_targets(fi_value)
-                if targets.build is None:
-                    continue
-                src = (
-                    targets.sdist
-                    if from_sdist and targets.sdist is not None
-                    else source
-                )
-                for src_file, target in iter_force_include(
-                    src, targets.build, build_dir, missing_ok=targets.missing_ok
-                ):
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src_file, target)
-
             rich_print("{green}***", "{bold}Configuring CMake...")
             # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
             # Otherwise `cmake --install --prefix` would work by itself

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -33,6 +33,7 @@ from ..settings.skbuild_read_settings import SettingsReader
 from ._editable import editable_inplace_files, editable_redirect_files, get_packages
 from ._init import setup_logging
 from ._pathutil import (
+    force_include_targets,
     iter_force_include,
     packages_to_file_mapping,
     resolve_wheel_tree,
@@ -208,6 +209,11 @@ def _build_wheel_impl_impl(
 
     # Get the closest (normally) importable name
     normalized_name = metadata.name.replace("-", "_").replace(".", "_")
+
+    # A PKG-INFO at the root means we are building from an unpacked SDist rather
+    # than a source tree; force-include entries with an ``sdist`` destination are
+    # then read from that vendored location instead of the original source.
+    from_sdist = Path("PKG-INFO").is_file()
 
     if settings.wheel.cmake:
         cmake = CMake.default_search(version=settings.cmake.version, env=os.environ)
@@ -397,11 +403,16 @@ def _build_wheel_impl_impl(
             )
 
             for source, fi_value in settings.force_include.items():
-                build_dest = None if isinstance(fi_value, str) else fi_value.build
-                if build_dest is None:
+                targets = force_include_targets(fi_value)
+                if targets.build is None:
                     continue
+                src = (
+                    targets.sdist
+                    if from_sdist and targets.sdist is not None
+                    else source
+                )
                 for src_file, target in iter_force_include(
-                    source, build_dest, build_dir
+                    src, targets.build, build_dir, missing_ok=targets.missing_ok
                 ):
                     target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src_file, target)
@@ -482,16 +493,19 @@ def _build_wheel_impl_impl(
         # these files are not redirectable) and after the package copy, so they
         # override package files and CMake output at the same destination.
         for source, fi_value in settings.force_include.items():
-            wheel_dest = fi_value if isinstance(fi_value, str) else fi_value.wheel
-            if wheel_dest is None:
+            targets = force_include_targets(fi_value)
+            if targets.wheel is None:
                 continue
+            src = targets.sdist if from_sdist and targets.sdist is not None else source
             base, rest = resolve_wheel_tree(
-                wheel_dest,
+                targets.wheel,
                 wheel_dirs=wheel_dirs,
                 targetlib=targetlib,
                 experimental=settings.experimental,
             )
-            for src_file, target in iter_force_include(source, rest, base):
+            for src_file, target in iter_force_include(
+                src, rest, base, missing_ok=targets.missing_ok
+            ):
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src_file, target)
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -113,9 +113,11 @@ def _force_include_into_wheel(
         # A source that names an sdist output exists only in an unpacked-sdist
         # build; from a source tree or editable build, fall back through the
         # sdist.force-include map to the original source.
-        source = resolve_from_sdist_force_include(source, settings.sdist.force_include)
-        source_is_file = Path(source).expanduser().is_file()
-        for src_file, target in iter_force_include(source, rest, base):
+        resolved = resolve_from_sdist_force_include(
+            source, settings.sdist.force_include
+        )
+        source_is_file = Path(resolved).expanduser().is_file()
+        for src_file, target in iter_force_include(resolved, rest, base):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
             if source_is_file:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -33,7 +33,9 @@ from ..settings.skbuild_read_settings import SettingsReader
 from ._editable import editable_inplace_files, editable_redirect_files, get_packages
 from ._init import setup_logging
 from ._pathutil import (
+    iter_force_include,
     packages_to_file_mapping,
+    resolve_wheel_tree,
 )
 from ._scripts import process_script_dir
 from ._wheelfile import WheelMetadata, WheelWriter
@@ -299,19 +301,13 @@ def _build_wheel_impl_impl(
             ),
         )
 
-        if ".." in settings.wheel.install_dir:
-            msg = "wheel.install_dir must not contain '..'"
-            raise AssertionError(msg)
-        if settings.wheel.install_dir.startswith("/"):
-            if not settings.experimental:
-                msg = "Experimental features must be enabled to use absolute paths in wheel.install_dir"
-                raise AssertionError(msg)
-            if settings.wheel.install_dir[1:].split("/")[0] not in wheel_dirs:
-                msg = "Must target a valid wheel directory"
-                raise AssertionError(msg)
-            install_dir = wheel_dir / settings.wheel.install_dir[1:]
-        else:
-            install_dir = wheel_dirs[targetlib] / settings.wheel.install_dir
+        install_base, install_rest = resolve_wheel_tree(
+            settings.wheel.install_dir,
+            wheel_dirs=wheel_dirs,
+            targetlib=targetlib,
+            experimental=settings.experimental,
+        )
+        install_dir = install_base / install_rest
 
         # Include the metadata license.file entry if provided
         if metadata.license_files is not None:
@@ -400,6 +396,16 @@ def _build_wheel_impl_impl(
                 config=config,
             )
 
+            for source, fi_value in settings.force_include.items():
+                build_dest = None if isinstance(fi_value, str) else fi_value.build
+                if build_dest is None:
+                    continue
+                for src_file, target in iter_force_include(
+                    source, build_dest, build_dir
+                ):
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src_file, target)
+
             rich_print("{green}***", "{bold}Configuring CMake...")
             # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
             # Otherwise `cmake --install --prefix` would work by itself
@@ -471,6 +477,23 @@ def _build_wheel_impl_impl(
                 shutil.copy2(filepath, package_dir)
 
             process_script_dir(wheel_dirs["scripts"])
+
+        # Force-include into the wheel, always (even for editable installs, as
+        # these files are not redirectable) and after the package copy, so they
+        # override package files and CMake output at the same destination.
+        for source, fi_value in settings.force_include.items():
+            wheel_dest = fi_value if isinstance(fi_value, str) else fi_value.wheel
+            if wheel_dest is None:
+                continue
+            base, rest = resolve_wheel_tree(
+                wheel_dest,
+                wheel_dirs=wheel_dirs,
+                targetlib=targetlib,
+                experimental=settings.experimental,
+            )
+            for src_file, target in iter_force_include(source, rest, base):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src_file, target)
 
         with make_wheel(folder=Path(wheel_directory)) as wheel:
             wheel.build(wheel_dirs, exclude=settings.wheel.exclude)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -80,6 +80,42 @@ def _make_editable(
         wheel.writestr(filename, contents)
 
 
+def _force_include_into_wheel(
+    settings: ScikitBuildSettings,
+    *,
+    wheel_dirs: dict[str, Path],
+    targetlib: str,
+    from_sdist: bool,
+    only_metadata: bool = False,
+) -> None:
+    """
+    Copy force-include entries into the staged wheel trees.
+
+    Run after the package copy and CMake install so force-included files override
+    files at the same destination. ``only_metadata`` restricts the copy to the
+    metadata tree; the prepare-metadata path uses it so the prepared
+    ``.dist-info`` matches the final wheel.
+    """
+    for source, fi_value in settings.force_include.items():
+        targets = force_include_targets(fi_value)
+        if targets.wheel is None:
+            continue
+        base, rest = resolve_wheel_tree(
+            targets.wheel,
+            wheel_dirs=wheel_dirs,
+            targetlib=targetlib,
+            experimental=settings.experimental,
+        )
+        if only_metadata and base != wheel_dirs["metadata"]:
+            continue
+        src = targets.sdist if from_sdist and targets.sdist is not None else source
+        for src_file, target in iter_force_include(
+            src, rest, base, missing_ok=targets.missing_ok
+        ):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_file, target)
+
+
 @dataclasses.dataclass
 class WheelImplReturn:
     wheel_filename: str
@@ -362,6 +398,15 @@ def _build_wheel_impl_impl(
             if metadata_directory is None:
                 msg = "metadata_directory must be specified if wheel_directory is None"
                 raise AssertionError(msg)
+            # Metadata-tree force-includes must land here too, so the prepared
+            # .dist-info matches the final wheel (it is compared on build).
+            _force_include_into_wheel(
+                settings,
+                wheel_dirs=wheel_dirs,
+                targetlib=targetlib,
+                from_sdist=from_sdist,
+                only_metadata=True,
+            )
             wheel = make_wheel(folder=Path(metadata_directory))
             dist_info_contents = wheel.dist_info_contents()
             dist_info = Path(metadata_directory) / f"{wheel.name_ver}.dist-info"
@@ -487,27 +532,20 @@ def _build_wheel_impl_impl(
                 Path(package_dir).parent.mkdir(exist_ok=True, parents=True)
                 shutil.copy2(filepath, package_dir)
 
-            process_script_dir(wheel_dirs["scripts"])
-
         # Force-include into the wheel, always (even for editable installs, as
         # these files are not redirectable) and after the package copy, so they
         # override package files and CMake output at the same destination.
-        for source, fi_value in settings.force_include.items():
-            targets = force_include_targets(fi_value)
-            if targets.wheel is None:
-                continue
-            src = targets.sdist if from_sdist and targets.sdist is not None else source
-            base, rest = resolve_wheel_tree(
-                targets.wheel,
-                wheel_dirs=wheel_dirs,
-                targetlib=targetlib,
-                experimental=settings.experimental,
-            )
-            for src_file, target in iter_force_include(
-                src, rest, base, missing_ok=targets.missing_ok
-            ):
-                target.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src_file, target)
+        _force_include_into_wheel(
+            settings,
+            wheel_dirs=wheel_dirs,
+            targetlib=targetlib,
+            from_sdist=from_sdist,
+        )
+
+        # Normalize script shebangs after force-includes, so force-included
+        # scripts (e.g. wheel = "/scripts/...") are processed too.
+        if not editable:
+            process_script_dir(wheel_dirs["scripts"])
 
         with make_wheel(folder=Path(wheel_directory)) as wheel:
             wheel.build(wheel_dirs, exclude=settings.wheel.exclude)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -33,7 +33,6 @@ from ..settings.skbuild_read_settings import SettingsReader
 from ._editable import editable_inplace_files, editable_redirect_files, get_packages
 from ._init import setup_logging
 from ._pathutil import (
-    force_include_targets,
     iter_force_include,
     packages_to_file_mapping,
     resolve_wheel_tree,
@@ -85,33 +84,26 @@ def _force_include_into_wheel(
     *,
     wheel_dirs: dict[str, Path],
     targetlib: str,
-    from_sdist: bool,
     only_metadata: bool = False,
 ) -> None:
     """
-    Copy force-include entries into the staged wheel trees.
+    Copy ``wheel.force-include`` entries into the staged wheel trees.
 
     Run after the package copy and CMake install so force-included files override
     files at the same destination. ``only_metadata`` restricts the copy to the
     metadata tree; the prepare-metadata path uses it so the prepared
     ``.dist-info`` matches the final wheel.
     """
-    for source, fi_value in settings.force_include.items():
-        targets = force_include_targets(fi_value)
-        if targets.wheel is None:
-            continue
+    for source, dest in settings.wheel.force_include.items():
         base, rest = resolve_wheel_tree(
-            targets.wheel,
+            dest,
             wheel_dirs=wheel_dirs,
             targetlib=targetlib,
             experimental=settings.experimental,
         )
         if only_metadata and base != wheel_dirs["metadata"]:
             continue
-        src = targets.sdist if from_sdist and targets.sdist is not None else source
-        for src_file, target in iter_force_include(
-            src, rest, base, strict=targets.strict
-        ):
+        for src_file, target in iter_force_include(source, rest, base):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
 
@@ -245,11 +237,6 @@ def _build_wheel_impl_impl(
 
     # Get the closest (normally) importable name
     normalized_name = metadata.name.replace("-", "_").replace(".", "_")
-
-    # A PKG-INFO at the root means we are building from an unpacked SDist rather
-    # than a source tree; force-include entries with an ``sdist`` destination are
-    # then read from that vendored location instead of the original source.
-    from_sdist = Path("PKG-INFO").is_file()
 
     if settings.wheel.cmake:
         cmake = CMake.default_search(version=settings.cmake.version, env=os.environ)
@@ -404,7 +391,6 @@ def _build_wheel_impl_impl(
                 settings,
                 wheel_dirs=wheel_dirs,
                 targetlib=targetlib,
-                from_sdist=from_sdist,
                 only_metadata=True,
             )
             wheel = make_wheel(folder=Path(metadata_directory))
@@ -524,7 +510,6 @@ def _build_wheel_impl_impl(
             settings,
             wheel_dirs=wheel_dirs,
             targetlib=targetlib,
-            from_sdist=from_sdist,
         )
 
         # Normalize script shebangs after force-includes, so force-included

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -35,6 +35,7 @@ from ._init import setup_logging
 from ._pathutil import (
     iter_force_include,
     packages_to_file_mapping,
+    resolve_from_sdist_force_include,
     resolve_wheel_tree,
 )
 from ._scripts import process_script_dir
@@ -109,6 +110,10 @@ def _force_include_into_wheel(
         )
         if only_metadata and base != wheel_dirs["metadata"]:
             continue
+        # A source that names an sdist output exists only in an unpacked-sdist
+        # build; from a source tree or editable build, fall back through the
+        # sdist.force-include map to the original source.
+        source = resolve_from_sdist_force_include(source, settings.sdist.force_include)
         source_is_file = Path(source).expanduser().is_file()
         for src_file, target in iter_force_include(source, rest, base):
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -110,7 +110,7 @@ def _force_include_into_wheel(
             continue
         src = targets.sdist if from_sdist and targets.sdist is not None else source
         for src_file, target in iter_force_include(
-            src, rest, base, missing_ok=targets.missing_ok
+            src, rest, base, strict=targets.strict
         ):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -115,7 +115,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             raise ValueError(msg)
 
         if settings.sdist.force_include or settings.wheel.force_include:
-            msg = "Force-include is not supported for hatch builds"
+            msg = "scikit-build.*.force-include is not supported, use hatch's force-include instead"
             raise ValueError(msg)
 
     # Requires Hatchling 1.22.0 to have an effect

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -114,6 +114,10 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             msg = "Metadata is not supported for hatch builds"
             raise ValueError(msg)
 
+        if settings.force_include:
+            msg = "Force-include is not supported for hatch builds"
+            raise ValueError(msg)
+
     # Requires Hatchling 1.22.0 to have an effect
     def dependencies(self) -> list[str]:
         settings = self._read_config().settings

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -23,7 +23,11 @@ from ..build._editable import (
     get_packages,
 )
 from ..build._init import setup_logging
-from ..build._pathutil import packages_to_file_mapping, scantree
+from ..build._pathutil import (
+    packages_to_file_mapping,
+    resolve_wheel_tree,
+    scantree,
+)
 from ..builder.builder import (
     Builder,
     archs_to_tags,
@@ -215,19 +219,13 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         for d in wheel_dirs.values():
             d.mkdir(parents=True)
 
-        if ".." in settings.wheel.install_dir:
-            msg = "wheel.install_dir must not contain '..'"
-            raise AssertionError(msg)
-        if settings.wheel.install_dir.startswith("/"):
-            if not settings.experimental:
-                msg = "Experimental features must be enabled to use absolute paths in wheel.install_dir"
-                raise AssertionError(msg)
-            if settings.wheel.install_dir[1:].split("/")[0] not in wheel_dirs:
-                msg = "Must target a valid wheel directory"
-                raise AssertionError(msg)
-            install_dir = wheel_dir / settings.wheel.install_dir[1:]
-        else:
-            install_dir = wheel_dirs[targetlib] / settings.wheel.install_dir
+        install_base, install_rest = resolve_wheel_tree(
+            settings.wheel.install_dir,
+            wheel_dirs=wheel_dirs,
+            targetlib=targetlib,
+            experimental=settings.experimental,
+        )
+        install_dir = install_base / install_rest
 
         config = CMaker(
             cmake,

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -114,7 +114,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             msg = "Metadata is not supported for hatch builds"
             raise ValueError(msg)
 
-        if settings.force_include:
+        if settings.sdist.force_include or settings.wheel.force_include:
             msg = "Force-include is not supported for hatch builds"
             raise ValueError(msg)
 

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -527,6 +527,11 @@
                 "build": {
                   "type": "string",
                   "description": "The destination path in the CMake build directory, relative to its root."
+                },
+                "missing-ok": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Do not error if the source does not exist; skip it silently instead."
                 }
               }
             }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -190,6 +190,15 @@
           "type": "boolean",
           "default": false,
           "description": "If set to True, CMake will be run before building the SDist."
+        },
+        "force-include": {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": "string"
+            }
+          },
+          "description": "Force-include files into the SDist."
         }
       }
     },
@@ -266,6 +275,15 @@
           },
           "description": "Wheel tags to manually force, {interpreter}-{abi}-{platform} format.",
           "scikit-build:override-only": true
+        },
+        "force-include": {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": "string"
+            }
+          },
+          "description": "Force-include files into the wheel."
         }
       }
     },
@@ -504,38 +522,6 @@
         }
       }
     },
-    "force-include": {
-      "type": "object",
-      "patternProperties": {
-        ".+": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "sdist": {
-                  "type": "string",
-                  "description": "The destination path in the SDist, relative to the SDist root. If unset, the"
-                },
-                "wheel": {
-                  "type": "string",
-                  "description": "The destination path in the wheel, relative to platlib."
-                },
-                "strict": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "Error if the source does not exist. Set to ``false`` to skip a missing"
-                }
-              }
-            }
-          ]
-        }
-      },
-      "description": "Force-include files into the distributions."
-    },
     "strict-config": {
       "type": "boolean",
       "default": true,
@@ -612,6 +598,9 @@
                   },
                   "exclude": {
                     "$ref": "#/$defs/inherit"
+                  },
+                  "force-include": {
+                    "$ref": "#/$defs/inherit"
                   }
                 }
               },
@@ -629,6 +618,9 @@
                     "$ref": "#/$defs/inherit"
                   },
                   "tags": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "force-include": {
                     "$ref": "#/$defs/inherit"
                   }
                 }
@@ -701,9 +693,6 @@
           },
           "metadata": {
             "$ref": "#/properties/metadata"
-          },
-          "force-include": {
-            "$ref": "#/properties/force-include"
           },
           "strict-config": {
             "$ref": "#/properties/strict-config"

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -504,6 +504,37 @@
         }
       }
     },
+    "force-include": {
+      "type": "object",
+      "patternProperties": {
+        ".+": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "sdist": {
+                  "type": "string",
+                  "description": "The destination path in the SDist, relative to the SDist root. If unset, the"
+                },
+                "wheel": {
+                  "type": "string",
+                  "description": "The destination path in the wheel, relative to platlib."
+                },
+                "build": {
+                  "type": "string",
+                  "description": "The destination path in the CMake build directory, relative to its root."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "description": "Force-include files into the distributions."
+    },
     "strict-config": {
       "type": "boolean",
       "default": true,
@@ -669,6 +700,9 @@
           },
           "metadata": {
             "$ref": "#/properties/metadata"
+          },
+          "force-include": {
+            "$ref": "#/properties/force-include"
           },
           "strict-config": {
             "$ref": "#/properties/strict-config"

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -524,10 +524,10 @@
                   "type": "string",
                   "description": "The destination path in the wheel, relative to platlib."
                 },
-                "missing-ok": {
+                "strict": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "Do not error if the source does not exist; skip it silently instead."
+                  "default": true,
+                  "description": "Error if the source does not exist. Set to ``false`` to skip a missing"
                 }
               }
             }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -524,10 +524,6 @@
                   "type": "string",
                   "description": "The destination path in the wheel, relative to platlib."
                 },
-                "build": {
-                  "type": "string",
-                  "description": "The destination path in the CMake build directory, relative to its root."
-                },
                 "missing-ok": {
                   "type": "boolean",
                   "default": false,

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -26,6 +26,8 @@ def __dir__() -> list[str]:
 
 version_display = ".".join(__version__.split(".")[:2])
 
+NoneType = type(None)
+
 
 def _get_value(value: ast.expr) -> str:
     assert isinstance(value, ast.Constant)
@@ -75,7 +77,7 @@ def get_display_type(field_type: type | str) -> str:
         return get_display_type(get_args(field_type)[0])
     if get_origin(field_type) is typing.Union:
         return " | ".join(
-            get_display_type(a) for a in get_args(field_type) if a is not type(None)
+            get_display_type(a) for a in get_args(field_type) if a is not NoneType
         )
     # Handle built-ins
     if get_origin(field_type) is dict:

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -73,6 +73,10 @@ def get_display_type(field_type: type | str) -> str:
     if is_optional(field_type):
         # Special case for optional, we just take the first part
         return get_display_type(get_args(field_type)[0])
+    if get_origin(field_type) is typing.Union:
+        return " | ".join(
+            get_display_type(a) for a in get_args(field_type) if a is not type(None)
+        )
     # Handle built-ins
     if get_origin(field_type) is dict:
         key_display = get_display_type(get_args(field_type)[0])

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -541,12 +541,11 @@ class ForceIncludeTargets:
     :confval:`experimental`). If unset, the source is not added to the wheel.
     """
 
-    missing_ok: bool = False
+    strict: bool = True
     """
-    Do not error if the source does not exist; skip it silently instead.
-
-    By default an inline-table entry errors if the source is missing. The
-    bare-string form always sets this (it is lenient, like hatchling).
+    Error if the source does not exist. Set to ``false`` to skip a missing
+    source silently instead (e.g. a file expected to already be at the
+    destination when building a wheel from an SDist).
     """
 
 
@@ -598,16 +597,16 @@ class ScikitBuildSettings:
     be a file or a directory; directories are copied recursively, skipping VCS
     and ``__pycache__`` junk.
 
-    A bare string value is the wheel destination (the common case). An inline
-    table gives per-target control with any subset of ``sdist`` and ``wheel``
-    keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form
-    is only available in ``pyproject.toml``).
+    A bare string value is the SDist destination. An inline table gives
+    per-target control with any subset of ``sdist`` and ``wheel`` keys, e.g.
+    ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form is only
+    available in ``pyproject.toml``).
 
     Force-included files override package files and CMake output at the same
-    destination. A missing source errors unless ``missing-ok`` is set (the
-    bare-string form sets it). When a wheel is built from an SDist rather than a
-    source tree, an entry with an ``sdist`` destination is read from that SDist
-    location instead of the original source.
+    destination. A missing source errors unless ``strict = false`` is set. When
+    a wheel is built from an SDist rather than a source tree, an entry with an
+    ``sdist`` destination is read from that SDist location instead of the
+    original source.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -13,6 +13,7 @@ __all__ = [
     "CMakeSettings",
     "CMakeSettingsDefine",
     "EditableSettings",
+    "ForceIncludeTargets",
     "GenerateSettings",
     "InstallSettings",
     "LoggingSettings",
@@ -524,6 +525,32 @@ class GenerateSettings:
 
 
 @dataclasses.dataclass
+class ForceIncludeTargets:
+    sdist: Optional[str] = None
+    """
+    The destination path in the SDist, relative to the SDist root. If unset, the
+    source is not added to the SDist.
+    """
+
+    wheel: Optional[str] = None
+    """
+    The destination path in the wheel, relative to platlib.
+
+    A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
+    ``/metadata`` targets that wheel tree instead (this requires
+    :confval:`experimental`). If unset, the source is not added to the wheel.
+    """
+
+    build: Optional[str] = None
+    """
+    The destination path in the CMake build directory, relative to its root.
+
+    The file is copied in before CMake configures, so the build can consume it.
+    If unset, the source is not added to the build directory.
+    """
+
+
+@dataclasses.dataclass
 class MessagesSettings:
     """
     Settings for messages.
@@ -558,6 +585,27 @@ class ScikitBuildSettings:
     metadata: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
     """
     List dynamic metadata fields and hook locations in this table.
+    """
+
+    force_include: Dict[str, Union[str, ForceIncludeTargets]] = dataclasses.field(
+        default_factory=dict
+    )
+    """
+    Force-include files into the distributions.
+
+    Keys are source paths relative to the project root; they may point outside
+    it (e.g. ``../shared``), and ``~`` is expanded. A source may be a file or a
+    directory; directories are copied recursively, skipping VCS and
+    ``__pycache__`` junk.
+
+    A bare string value is the wheel destination (the common case). An inline
+    table gives per-target control with any subset of ``sdist``, ``wheel``, and
+    ``build`` keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline
+    table form is only available in ``pyproject.toml``).
+
+    Force-included files override package files and CMake output at the same
+    destination. A missing source is silently skipped (it is assumed to already
+    be present at the destination, e.g. when building a wheel from an SDist).
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -424,6 +424,12 @@ class WheelSettings:
     an exact source is an explicit request for that file. A force-included
     *directory* stays subject to :confval:`wheel.exclude`, so a bulk copy can
     still be trimmed by an exclude pattern.
+
+    If a source is missing on disk, it is looked up through
+    :confval:`sdist.force-include` (by exact destination or under a force-included
+    directory) and read from that original source instead. This lets a source
+    that names an sdist output (vendored via :confval:`sdist.force-include`) build
+    from both a source tree and an unpacked sdist.
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -285,6 +285,11 @@ class SDistSettings:
 
     Force-included files override files at the same destination. A missing source
     is an error.
+
+    A force-included *file* is forced in even if :confval:`sdist.exclude` matches
+    its destination, since naming an exact source is an explicit request. A
+    force-included *directory* stays subject to :confval:`sdist.exclude`, so a
+    bulk copy can still be trimmed by an exclude pattern.
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -549,6 +549,14 @@ class ForceIncludeTargets:
     If unset, the source is not added to the build directory.
     """
 
+    missing_ok: bool = False
+    """
+    Do not error if the source does not exist; skip it silently instead.
+
+    By default an inline-table entry errors if the source is missing. The
+    bare-string form always sets this (it is lenient, like hatchling).
+    """
+
 
 @dataclasses.dataclass
 class MessagesSettings:
@@ -594,9 +602,9 @@ class ScikitBuildSettings:
     Force-include files into the distributions.
 
     Keys are source paths relative to the project root; they may point outside
-    it (e.g. ``../shared``), and ``~`` is expanded. A source may be a file or a
-    directory; directories are copied recursively, skipping VCS and
-    ``__pycache__`` junk.
+    it (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may
+    be a file or a directory; directories are copied recursively, skipping VCS
+    and ``__pycache__`` junk.
 
     A bare string value is the wheel destination (the common case). An inline
     table gives per-target control with any subset of ``sdist``, ``wheel``, and
@@ -604,8 +612,10 @@ class ScikitBuildSettings:
     table form is only available in ``pyproject.toml``).
 
     Force-included files override package files and CMake output at the same
-    destination. A missing source is silently skipped (it is assumed to already
-    be present at the destination, e.g. when building a wheel from an SDist).
+    destination. A missing source errors unless ``missing-ok`` is set (the
+    bare-string form sets it). When a wheel or build is produced from an SDist
+    rather than a source tree, an entry with an ``sdist`` destination is read
+    from that SDist location instead of the original source.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -13,7 +13,6 @@ __all__ = [
     "CMakeSettings",
     "CMakeSettingsDefine",
     "EditableSettings",
-    "ForceIncludeTargets",
     "GenerateSettings",
     "InstallSettings",
     "LoggingSettings",
@@ -275,6 +274,19 @@ class SDistSettings:
     If set to True, CMake will be run before building the SDist.
     """
 
+    force_include: Dict[str, str] = dataclasses.field(default_factory=dict)
+    """
+    Force-include files into the SDist.
+
+    Maps source paths to destinations relative to the SDist root. Keys are
+    relative to the project root; they may point outside it (e.g. ``../shared``)
+    or be absolute, and ``~`` is expanded. A source may be a file or a directory;
+    directories are copied recursively, skipping VCS and ``__pycache__`` junk.
+
+    Force-included files override files at the same destination. A missing source
+    is an error.
+    """
+
 
 @dataclasses.dataclass
 class WheelSettings:
@@ -384,6 +396,24 @@ class WheelSettings:
     automatically calculated. This cannot be set in the static
     ``[tool.scikit-build]`` table; use it in an override, config-settings, or an
     environment variable.
+    """
+
+    force_include: Dict[str, str] = dataclasses.field(default_factory=dict)
+    """
+    Force-include files into the wheel.
+
+    Maps source paths to destinations relative to the platlib (the package
+    area). Keys are relative to the project root; they may point outside it
+    (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may be a
+    file or a directory; directories are copied recursively, skipping VCS and
+    ``__pycache__`` junk.
+
+    A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
+    ``/metadata`` destination targets that wheel tree instead of the platlib
+    (this requires :confval:`experimental`).
+
+    Force-included files are placed last, so they override discovered package
+    files and CMake output at the same destination. A missing source is an error.
     """
 
 
@@ -525,31 +555,6 @@ class GenerateSettings:
 
 
 @dataclasses.dataclass
-class ForceIncludeTargets:
-    sdist: Optional[str] = None
-    """
-    The destination path in the SDist, relative to the SDist root. If unset, the
-    source is not added to the SDist.
-    """
-
-    wheel: Optional[str] = None
-    """
-    The destination path in the wheel, relative to platlib.
-
-    A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
-    ``/metadata`` targets that wheel tree instead (this requires
-    :confval:`experimental`). If unset, the source is not added to the wheel.
-    """
-
-    strict: bool = True
-    """
-    Error if the source does not exist. Set to ``false`` to skip a missing
-    source silently instead (e.g. a file expected to already be at the
-    destination when building a wheel from an SDist).
-    """
-
-
-@dataclasses.dataclass
 class MessagesSettings:
     """
     Settings for messages.
@@ -584,29 +589,6 @@ class ScikitBuildSettings:
     metadata: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
     """
     List dynamic metadata fields and hook locations in this table.
-    """
-
-    force_include: Dict[str, Union[str, ForceIncludeTargets]] = dataclasses.field(
-        default_factory=dict
-    )
-    """
-    Force-include files into the distributions.
-
-    Keys are source paths relative to the project root; they may point outside
-    it (e.g. ``../shared``) or be absolute, and ``~`` is expanded. A source may
-    be a file or a directory; directories are copied recursively, skipping VCS
-    and ``__pycache__`` junk.
-
-    A bare string value is the SDist destination. An inline table gives
-    per-target control with any subset of ``sdist`` and ``wheel`` keys, e.g.
-    ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form is only
-    available in ``pyproject.toml``).
-
-    Force-included files override package files and CMake output at the same
-    destination. A missing source errors unless ``strict = false`` is set. When
-    a wheel is built from an SDist rather than a source tree, an entry with an
-    ``sdist`` destination is read from that SDist location instead of the
-    original source.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -414,6 +414,11 @@ class WheelSettings:
 
     Force-included files are placed last, so they override discovered package
     files and CMake output at the same destination. A missing source is an error.
+
+    A force-included *file* also overrides :confval:`wheel.exclude`, since naming
+    an exact source is an explicit request for that file. A force-included
+    *directory* stays subject to :confval:`wheel.exclude`, so a bulk copy can
+    still be trimmed by an exclude pattern.
     """
 
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -541,14 +541,6 @@ class ForceIncludeTargets:
     :confval:`experimental`). If unset, the source is not added to the wheel.
     """
 
-    build: Optional[str] = None
-    """
-    The destination path in the CMake build directory, relative to its root.
-
-    The file is copied in before CMake configures, so the build can consume it.
-    If unset, the source is not added to the build directory.
-    """
-
     missing_ok: bool = False
     """
     Do not error if the source does not exist; skip it silently instead.
@@ -607,15 +599,15 @@ class ScikitBuildSettings:
     and ``__pycache__`` junk.
 
     A bare string value is the wheel destination (the common case). An inline
-    table gives per-target control with any subset of ``sdist``, ``wheel``, and
-    ``build`` keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline
-    table form is only available in ``pyproject.toml``).
+    table gives per-target control with any subset of ``sdist`` and ``wheel``
+    keys, e.g. ``{sdist = "data", wheel = "pkg/data"}`` (the inline table form
+    is only available in ``pyproject.toml``).
 
     Force-included files override package files and CMake output at the same
     destination. A missing source errors unless ``missing-ok`` is set (the
-    bare-string form sets it). When a wheel or build is produced from an SDist
-    rather than a source tree, an entry with an ``sdist`` destination is read
-    from that SDist location instead of the original source.
+    bare-string form sets it). When a wheel is built from an SDist rather than a
+    source tree, an entry with an ``sdist`` destination is read from that SDist
+    location instead of the original source.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -173,7 +173,9 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
     inherit_props: dict[str, Any] = {
         k: {
             kk: {"$ref": "#/$defs/inherit"}
-            for kk, vv in v["properties"].items()
+            # Free-form dicts (patternProperties, e.g. force-include) have no
+            # fixed sub-keys to mark inheritable.
+            for kk, vv in v.get("properties", {}).items()
             if vv.get("type", "") in {"object", "array"}
             or any(
                 vvv.get("type", "") in {"object", "array"}

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -734,6 +734,14 @@ class TOMLSource(Source):
                 if isinstance(item, list):
                     return [cls.convert(i, get_inner_type(args[list])) for i in item]
                 return item
+            # A TOML table (dict) can also target a dataclass member of the union
+            # (e.g. ``Union[str, ForceIncludeTargets]``).
+            if isinstance(item, dict):
+                dataclass_args = [
+                    t for t in args.values() if dataclasses.is_dataclass(t)
+                ]
+                if len(dataclass_args) == 1:
+                    return cls.convert(item, dataclass_args[0])
             msg = f"Expected {target}, got {type(item).__name__}"
             raise TypeError(msg)
         if raw_target is Literal:

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -734,14 +734,6 @@ class TOMLSource(Source):
                 if isinstance(item, list):
                     return [cls.convert(i, get_inner_type(args[list])) for i in item]
                 return item
-            # A TOML table (dict) can also target a dataclass member of the union
-            # (e.g. ``Union[str, ForceIncludeTargets]``).
-            if isinstance(item, dict):
-                dataclass_args = [
-                    t for t in args.values() if dataclasses.is_dataclass(t)
-                ]
-                if len(dataclass_args) == 1:
-                    return cls.convert(item, dataclass_args[0])
             msg = f"Expected {target}, got {type(item).__name__}"
             raise TypeError(msg)
         if raw_target is Literal:

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -321,37 +321,6 @@ def test_force_include_sdist_target(chdir_tmp: Path) -> None:
     assert not any("wheel_only" in n for n in names)
 
 
-@pytest.mark.compile
-@pytest.mark.configure
-def test_force_include_build_target_visible_to_cmake(chdir_tmp: Path) -> None:
-    """A {build=...} entry lands in the CMake build dir before configure."""
-    make_pure_pkg(
-        chdir_tmp,
-        extra='force-include = {"injected.cmake" = {build = "injected.cmake"}}',
-        cmake=True,
-    )
-    (chdir_tmp / "injected.cmake").write_text("set(INJECTED_OK TRUE)\n")
-    (chdir_tmp / "CMakeLists.txt").write_text(
-        textwrap.dedent("""\
-        cmake_minimum_required(VERSION 3.15)
-        project(pkg LANGUAGES NONE)
-        if(NOT EXISTS "${CMAKE_BINARY_DIR}/injected.cmake")
-          message(FATAL_ERROR "force-include build target missing")
-        endif()
-        include("${CMAKE_BINARY_DIR}/injected.cmake")
-        if(NOT INJECTED_OK)
-          message(FATAL_ERROR "injected.cmake did not run")
-        endif()
-        install(CODE "message(STATUS configured)")
-        """)
-    )
-
-    dist = chdir_tmp / "dist"
-    build_wheel(str(dist), {})
-    # Build succeeds only if the injected file was present at configure time.
-    assert list(dist.glob("pkg-0.1.0-*.whl"))
-
-
 def _read_force_include(
     tmp_path: Path,
     toml: str = "",
@@ -378,13 +347,11 @@ def test_settings_force_include_toml_forms(tmp_path: Path) -> None:
             [tool.scikit-build.force-include]
             "vendor/lib.so" = "pkg/_lib.so"
             "../data" = {sdist = "data", wheel = "pkg/data"}
-            "toolchain.cmake" = {build = "toolchain.cmake"}
             "maybe.so" = {wheel = "pkg/maybe.so", missing-ok = true}
             """),
     )
     assert fi["vendor/lib.so"] == "pkg/_lib.so"
     assert fi["../data"] == ForceIncludeTargets(sdist="data", wheel="pkg/data")
-    assert fi["toolchain.cmake"] == ForceIncludeTargets(build="toolchain.cmake")
     assert fi["maybe.so"] == ForceIncludeTargets(wheel="pkg/maybe.so", missing_ok=True)
 
 

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -288,6 +288,81 @@ def test_force_include_from_sdist_via_overrides(chdir_tmp: Path) -> None:
     assert wheel_read(dist, "pkg/blob.txt") == b"vendored"
 
 
+def test_force_include_resolves_through_sdist(chdir_tmp: Path) -> None:
+    """A wheel source naming an sdist output is read via sdist.force-include."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.force-include = {"../shared/data.json" = "pkg/data.json"}\n'
+            'wheel.force-include = {"pkg/data.json" = "pkg/data.json"}'
+        ),
+    )
+    shared = chdir_tmp.parent / "shared"
+    shared.mkdir()
+    (shared / "data.json").write_text("external")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/data.json") == b"external"
+
+
+def test_force_include_resolves_through_sdist_directory(chdir_tmp: Path) -> None:
+    """A wheel source under a force-included sdist directory resolves by prefix."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.force-include = {"../shared" = "pkg/vendor"}\n'
+            'wheel.force-include = {"pkg/vendor/a.txt" = "pkg/vendor/a.txt"}'
+        ),
+    )
+    shared = chdir_tmp.parent / "shared"
+    shared.mkdir()
+    (shared / "a.txt").write_text("vendored-a")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/vendor/a.txt") == b"vendored-a"
+
+
+def test_force_include_on_disk_source_wins_over_sdist(chdir_tmp: Path) -> None:
+    """An existing wheel source is used directly, not remapped through the sdist."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.force-include = {"../shared/data.json" = "data/data.json"}\n'
+            'wheel.force-include = {"data/data.json" = "pkg/data.json"}'
+        ),
+    )
+    # The sdist source is absent, but the wheel source exists on disk (the
+    # from-sdist case): it must be used directly without a remap (which would
+    # otherwise look up the missing sdist source and raise).
+    (chdir_tmp / "data").mkdir()
+    (chdir_tmp / "data" / "data.json").write_text("ondisk")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/data.json") == b"ondisk"
+
+
+def test_force_include_unresolvable_through_sdist_errors(chdir_tmp: Path) -> None:
+    """A missing wheel source that matches no sdist destination still errors."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.force-include = {"blob.txt" = "vendored/blob.txt"}\n'
+            'wheel.force-include = {"does-not-exist.txt" = "pkg/x.txt"}'
+        ),
+    )
+    (chdir_tmp / "blob.txt").write_text("x")
+
+    dist = chdir_tmp / "dist"
+    with pytest.raises(FileNotFoundError, match=r"does-not-exist\.txt"):
+        build_wheel(str(dist), {})
+
+
 def test_force_include_survives_wheel_exclude(chdir_tmp: Path) -> None:
     """A force-included file overrides a matching wheel.exclude pattern."""
     make_pure_pkg(

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from scikit_build_core.build import (
+    build_editable,
     build_sdist,
     build_wheel,
     prepare_metadata_for_build_wheel,
@@ -293,6 +294,37 @@ def test_force_include_from_sdist_reads_vendored_location(chdir_tmp: Path) -> No
     build_wheel(str(dist), {})
 
     assert wheel_read(dist, "pkg/blob.txt") == b"vendored"
+
+
+def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
+    """Wheel-target force-includes are baked into the editable wheel (not redirected)."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"extra/data.txt" = {wheel = "pkg/data.txt"}}',
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "pkg/data.txt" in wheel_names(dist)
+    assert wheel_read(dist, "pkg/data.txt") == b"hello"
+
+
+def test_force_include_editable_script_shebang_normalized(chdir_tmp: Path) -> None:
+    """A force-included script's shebang is normalized in an editable wheel too."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"run.py" = {wheel = "/scripts/run.py"}}',
+    )
+    (chdir_tmp / "run.py").write_text("#!/usr/bin/env python\nprint('hi')\n")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    content = wheel_read(dist, "pkg-0.1.0.data/scripts/run.py")
+    assert content.startswith(b"#!python\n")
 
 
 def test_force_include_sdist_target(chdir_tmp: Path) -> None:

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -365,6 +365,52 @@ def test_force_include_sdist_directory_reproducible(chdir_tmp: Path) -> None:
     assert forced == sorted(forced)
 
 
+def test_force_include_sdist_directory_respects_exclude(chdir_tmp: Path) -> None:
+    """A force-included directory's members are still filtered by sdist.exclude."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.exclude = ["vendored/*.tmp"]\n'
+            'sdist.force-include = {"assets" = "vendored"}'
+        ),
+    )
+    assets = chdir_tmp / "assets"
+    assets.mkdir()
+    (assets / "keep.txt").write_text("keep")
+    (assets / "drop.tmp").write_text("drop")
+
+    dist = chdir_tmp / "dist"
+    build_sdist(str(dist), {})
+
+    (sdist,) = dist.glob("pkg-0.1.0.tar.gz")
+    with tarfile.open(sdist) as tf:
+        names = set(tf.getnames())
+
+    assert "pkg-0.1.0/vendored/keep.txt" in names
+    assert "pkg-0.1.0/vendored/drop.tmp" not in names
+
+
+def test_force_include_sdist_file_overrides_exclude(chdir_tmp: Path) -> None:
+    """A force-included file is forced in even if sdist.exclude matches it."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'sdist.exclude = ["vendored/blob.tmp"]\n'
+            'sdist.force-include = {"blob.txt" = "vendored/blob.tmp"}'
+        ),
+    )
+    (chdir_tmp / "blob.txt").write_text("forced")
+
+    dist = chdir_tmp / "dist"
+    build_sdist(str(dist), {})
+
+    (sdist,) = dist.glob("pkg-0.1.0.tar.gz")
+    with tarfile.open(sdist) as tf:
+        names = set(tf.getnames())
+
+    assert "pkg-0.1.0/vendored/blob.tmp" in names
+
+
 def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
     """Wheel-target force-includes are baked into the editable wheel (not redirected)."""
     make_pure_pkg(

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -77,7 +77,7 @@ def chdir_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 def test_force_include_file_into_wheel(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"extra/data.txt" = "pkg/data.txt"}',
+        extra='force-include = {"extra/data.txt" = {wheel = "pkg/data.txt"}}',
     )
     (chdir_tmp / "extra").mkdir()
     (chdir_tmp / "extra" / "data.txt").write_text("hello")
@@ -92,7 +92,7 @@ def test_force_include_file_into_wheel(chdir_tmp: Path) -> None:
 def test_force_include_directory_recurses_and_skips_junk(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"assets" = "pkg/assets"}',
+        extra='force-include = {"assets" = {wheel = "pkg/assets"}}',
     )
     assets = chdir_tmp / "assets"
     (assets / "sub").mkdir(parents=True)
@@ -116,7 +116,7 @@ def test_force_include_directory_recurses_and_skips_junk(chdir_tmp: Path) -> Non
 def test_force_include_external_source(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"../outside.txt" = "pkg/outside.txt"}',
+        extra='force-include = {"../outside.txt" = {wheel = "pkg/outside.txt"}}',
     )
     (chdir_tmp.parent / "outside.txt").write_text("external")
 
@@ -213,7 +213,7 @@ def test_force_include_rejects_escaping_sdist_dest(chdir_tmp: Path, bad: str) ->
 def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"blob.txt" = "../escape.txt"}',
+        extra='force-include = {"blob.txt" = {wheel = "../escape.txt"}}',
     )
     (chdir_tmp / "blob.txt").write_text("x")
 
@@ -225,7 +225,7 @@ def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
 def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"override.py" = "pkg/__init__.py"}',
+        extra='force-include = {"override.py" = {wheel = "pkg/__init__.py"}}',
     )
     (chdir_tmp / "override.py").write_bytes(b"FORCED = True\n")
 
@@ -235,17 +235,16 @@ def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     assert wheel_read(dist, "pkg/__init__.py") == b"FORCED = True\n"
 
 
-def test_force_include_missing_source_skipped(chdir_tmp: Path) -> None:
-    # The bare-string form is lenient (missing-ok), like hatchling.
+def test_force_include_missing_source_bare_errors(chdir_tmp: Path) -> None:
+    # The bare-string (SDist) form is strict by default, so a missing source errors.
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"does-not-exist.txt" = "pkg/missing.txt"}',
+        extra='force-include = {"does-not-exist.txt" = "missing.txt"}',
     )
 
     dist = chdir_tmp / "dist"
-    build_wheel(str(dist), {})
-
-    assert "pkg/missing.txt" not in wheel_names(dist)
+    with pytest.raises(FileNotFoundError, match=r"does-not-exist\.txt"):
+        build_sdist(str(dist), {})
 
 
 def test_force_include_missing_source_table_errors(chdir_tmp: Path) -> None:
@@ -260,12 +259,12 @@ def test_force_include_missing_source_table_errors(chdir_tmp: Path) -> None:
         build_wheel(str(dist), {})
 
 
-def test_force_include_missing_source_table_missing_ok(chdir_tmp: Path) -> None:
+def test_force_include_missing_source_not_strict_skipped(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
         extra=(
             'force-include = {"does-not-exist.txt" = '
-            '{wheel = "pkg/missing.txt", missing-ok = true}}'
+            '{wheel = "pkg/missing.txt", strict = false}}'
         ),
     )
 
@@ -301,8 +300,8 @@ def test_force_include_sdist_target(chdir_tmp: Path) -> None:
         chdir_tmp,
         extra=(
             "force-include = {"
-            '"vendor/blob.txt" = {sdist = "vendored/blob.txt"}, '
-            '"wheel-only.txt" = "pkg/wheel_only.txt"}'
+            '"vendor/blob.txt" = "vendored/blob.txt", '
+            '"wheel-only.txt" = {wheel = "pkg/wheel_only.txt"}}'
         ),
     )
     (chdir_tmp / "vendor").mkdir()
@@ -316,8 +315,9 @@ def test_force_include_sdist_target(chdir_tmp: Path) -> None:
     with tarfile.open(sdist) as tf:
         names = set(tf.getnames())
 
+    # A bare string is the SDist destination.
     assert "pkg-0.1.0/vendored/blob.txt" in names
-    # A bare string is wheel-only, so it must not appear in the SDist.
+    # A wheel-only entry must not appear in the SDist.
     assert not any("wheel_only" in n for n in names)
 
 
@@ -347,12 +347,12 @@ def test_settings_force_include_toml_forms(tmp_path: Path) -> None:
             [tool.scikit-build.force-include]
             "vendor/lib.so" = "pkg/_lib.so"
             "../data" = {sdist = "data", wheel = "pkg/data"}
-            "maybe.so" = {wheel = "pkg/maybe.so", missing-ok = true}
+            "maybe.so" = {wheel = "pkg/maybe.so", strict = false}
             """),
     )
     assert fi["vendor/lib.so"] == "pkg/_lib.so"
     assert fi["../data"] == ForceIncludeTargets(sdist="data", wheel="pkg/data")
-    assert fi["maybe.so"] == ForceIncludeTargets(wheel="pkg/maybe.so", missing_ok=True)
+    assert fi["maybe.so"] == ForceIncludeTargets(wheel="pkg/maybe.so", strict=False)
 
 
 def test_settings_force_include_envvar_bare_string(tmp_path: Path) -> None:

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from scikit_build_core.build import build_sdist, build_wheel
+from scikit_build_core.build import (
+    build_sdist,
+    build_wheel,
+    prepare_metadata_for_build_wheel,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -135,6 +139,41 @@ def test_force_include_leading_slash_targets_scripts(chdir_tmp: Path) -> None:
     assert "pkg-0.1.0.data/scripts/run.sh" in wheel_names(dist)
 
 
+def test_force_include_script_shebang_normalized(chdir_tmp: Path) -> None:
+    """A force-included script's python shebang is normalized to #!python."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"run.py" = {wheel = "/scripts/run.py"}}',
+    )
+    (chdir_tmp / "run.py").write_text("#!/usr/bin/env python\nprint('hi')\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    content = wheel_read(dist, "pkg-0.1.0.data/scripts/run.py")
+    assert content.startswith(b"#!python\n")
+
+
+def test_force_include_metadata_in_prepare(chdir_tmp: Path) -> None:
+    """A force-included metadata file appears in prepared metadata and the wheel."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"extra.txt" = {wheel = "/metadata/extra/extra.txt"}}',
+    )
+    (chdir_tmp / "extra.txt").write_text("meta")
+
+    metadata_dir = chdir_tmp / "meta"
+    metadata_dir.mkdir()
+    dist_info = prepare_metadata_for_build_wheel(str(metadata_dir), {})
+    prepared = metadata_dir / dist_info / "extra" / "extra.txt"
+    assert prepared.read_text() == "meta"
+
+    # Building with that metadata_directory must not raise on a mismatch.
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {}, str(metadata_dir / dist_info))
+    assert "pkg-0.1.0.dist-info/extra/extra.txt" in wheel_names(dist)
+
+
 def test_force_include_leading_slash_requires_experimental(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
@@ -148,11 +187,21 @@ def test_force_include_leading_slash_requires_experimental(chdir_tmp: Path) -> N
         build_wheel(str(dist), {})
 
 
-@pytest.mark.parametrize("bad", ["/abs/escape.txt", "../escape.txt", "a/../../x"])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "/abs/escape.txt",
+        "../escape.txt",
+        "a/../../x",
+        "C:/escape.txt",
+        "..\\escape.txt",
+    ],
+)
 def test_force_include_rejects_escaping_sdist_dest(chdir_tmp: Path, bad: str) -> None:
+    bad_toml = bad.replace("\\", "\\\\")  # escape backslashes for the TOML string
     make_pure_pkg(
         chdir_tmp,
-        extra=f'force-include = {{"blob.txt" = {{sdist = "{bad}"}}}}',
+        extra=f'force-include = {{"blob.txt" = {{sdist = "{bad_toml}"}}}}',
     )
     (chdir_tmp / "blob.txt").write_text("x")
 

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -187,6 +187,7 @@ def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
 
 
 def test_force_include_missing_source_skipped(chdir_tmp: Path) -> None:
+    # The bare-string form is lenient (missing-ok), like hatchling.
     make_pure_pkg(
         chdir_tmp,
         extra='force-include = {"does-not-exist.txt" = "pkg/missing.txt"}',
@@ -196,6 +197,54 @@ def test_force_include_missing_source_skipped(chdir_tmp: Path) -> None:
     build_wheel(str(dist), {})
 
     assert "pkg/missing.txt" not in wheel_names(dist)
+
+
+def test_force_include_missing_source_table_errors(chdir_tmp: Path) -> None:
+    # The inline-table form errors on a missing source by default.
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"does-not-exist.txt" = {wheel = "pkg/missing.txt"}}',
+    )
+
+    dist = chdir_tmp / "dist"
+    with pytest.raises(FileNotFoundError, match=r"does-not-exist\.txt"):
+        build_wheel(str(dist), {})
+
+
+def test_force_include_missing_source_table_missing_ok(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'force-include = {"does-not-exist.txt" = '
+            '{wheel = "pkg/missing.txt", missing-ok = true}}'
+        ),
+    )
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/missing.txt" not in wheel_names(dist)
+
+
+def test_force_include_from_sdist_reads_vendored_location(chdir_tmp: Path) -> None:
+    """A wheel built from an unpacked SDist reads the vendored ``sdist`` path."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'force-include = {"../outside.txt" = '
+            '{sdist = "vendored/blob.txt", wheel = "pkg/blob.txt"}}'
+        ),
+    )
+    # Simulate an unpacked SDist: a PKG-INFO at the root, the original external
+    # source gone, but the vendored copy present at the sdist destination.
+    (chdir_tmp / "PKG-INFO").write_text("Metadata-Version: 2.1\nName: pkg\n")
+    (chdir_tmp / "vendored").mkdir()
+    (chdir_tmp / "vendored" / "blob.txt").write_text("vendored")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/blob.txt") == b"vendored"
 
 
 def test_force_include_sdist_target(chdir_tmp: Path) -> None:
@@ -281,11 +330,13 @@ def test_settings_force_include_toml_forms(tmp_path: Path) -> None:
             "vendor/lib.so" = "pkg/_lib.so"
             "../data" = {sdist = "data", wheel = "pkg/data"}
             "toolchain.cmake" = {build = "toolchain.cmake"}
+            "maybe.so" = {wheel = "pkg/maybe.so", missing-ok = true}
             """),
     )
     assert fi["vendor/lib.so"] == "pkg/_lib.so"
     assert fi["../data"] == ForceIncludeTargets(sdist="data", wheel="pkg/data")
     assert fi["toolchain.cmake"] == ForceIncludeTargets(build="toolchain.cmake")
+    assert fi["maybe.so"] == ForceIncludeTargets(wheel="pkg/maybe.so", missing_ok=True)
 
 
 def test_settings_force_include_envvar_bare_string(tmp_path: Path) -> None:

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -15,8 +15,9 @@ from scikit_build_core.build import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from pathlib import Path
+
+    from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
 
 PYPROJECT = """\
 [build-system]
@@ -78,7 +79,7 @@ def chdir_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 def test_force_include_file_into_wheel(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"extra/data.txt" = {wheel = "pkg/data.txt"}}',
+        extra='wheel.force-include = {"extra/data.txt" = "pkg/data.txt"}',
     )
     (chdir_tmp / "extra").mkdir()
     (chdir_tmp / "extra" / "data.txt").write_text("hello")
@@ -93,7 +94,7 @@ def test_force_include_file_into_wheel(chdir_tmp: Path) -> None:
 def test_force_include_directory_recurses_and_skips_junk(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"assets" = {wheel = "pkg/assets"}}',
+        extra='wheel.force-include = {"assets" = "pkg/assets"}',
     )
     assets = chdir_tmp / "assets"
     (assets / "sub").mkdir(parents=True)
@@ -117,7 +118,7 @@ def test_force_include_directory_recurses_and_skips_junk(chdir_tmp: Path) -> Non
 def test_force_include_external_source(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"../outside.txt" = {wheel = "pkg/outside.txt"}}',
+        extra='wheel.force-include = {"../outside.txt" = "pkg/outside.txt"}',
     )
     (chdir_tmp.parent / "outside.txt").write_text("external")
 
@@ -130,7 +131,7 @@ def test_force_include_external_source(chdir_tmp: Path) -> None:
 def test_force_include_leading_slash_targets_scripts(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"run.sh" = {wheel = "/scripts/run.sh"}}',
+        extra='wheel.force-include = {"run.sh" = "/scripts/run.sh"}',
     )
     (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
 
@@ -144,7 +145,7 @@ def test_force_include_script_shebang_normalized(chdir_tmp: Path) -> None:
     """A force-included script's python shebang is normalized to #!python."""
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"run.py" = {wheel = "/scripts/run.py"}}',
+        extra='wheel.force-include = {"run.py" = "/scripts/run.py"}',
     )
     (chdir_tmp / "run.py").write_text("#!/usr/bin/env python\nprint('hi')\n")
 
@@ -159,7 +160,7 @@ def test_force_include_metadata_in_prepare(chdir_tmp: Path) -> None:
     """A force-included metadata file appears in prepared metadata and the wheel."""
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"extra.txt" = {wheel = "/metadata/extra/extra.txt"}}',
+        extra='wheel.force-include = {"extra.txt" = "/metadata/extra/extra.txt"}',
     )
     (chdir_tmp / "extra.txt").write_text("meta")
 
@@ -178,7 +179,7 @@ def test_force_include_metadata_in_prepare(chdir_tmp: Path) -> None:
 def test_force_include_leading_slash_requires_experimental(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"run.sh" = {wheel = "/scripts/run.sh"}}',
+        extra='wheel.force-include = {"run.sh" = "/scripts/run.sh"}',
         experimental=False,
     )
     (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
@@ -202,7 +203,7 @@ def test_force_include_rejects_escaping_sdist_dest(chdir_tmp: Path, bad: str) ->
     bad_toml = bad.replace("\\", "\\\\")  # escape backslashes for the TOML string
     make_pure_pkg(
         chdir_tmp,
-        extra=f'force-include = {{"blob.txt" = {{sdist = "{bad_toml}"}}}}',
+        extra=f'sdist.force-include = {{"blob.txt" = "{bad_toml}"}}',
     )
     (chdir_tmp / "blob.txt").write_text("x")
 
@@ -214,7 +215,7 @@ def test_force_include_rejects_escaping_sdist_dest(chdir_tmp: Path, bad: str) ->
 def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"blob.txt" = {wheel = "../escape.txt"}}',
+        extra='wheel.force-include = {"blob.txt" = "../escape.txt"}',
     )
     (chdir_tmp / "blob.txt").write_text("x")
 
@@ -226,7 +227,7 @@ def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
 def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"override.py" = {wheel = "pkg/__init__.py"}}',
+        extra='wheel.force-include = {"override.py" = "pkg/__init__.py"}',
     )
     (chdir_tmp / "override.py").write_bytes(b"FORCED = True\n")
 
@@ -236,11 +237,10 @@ def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     assert wheel_read(dist, "pkg/__init__.py") == b"FORCED = True\n"
 
 
-def test_force_include_missing_source_bare_errors(chdir_tmp: Path) -> None:
-    # The bare-string (SDist) form is strict by default, so a missing source errors.
+def test_force_include_missing_sdist_source_errors(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"does-not-exist.txt" = "missing.txt"}',
+        extra='sdist.force-include = {"does-not-exist.txt" = "missing.txt"}',
     )
 
     dist = chdir_tmp / "dist"
@@ -248,11 +248,10 @@ def test_force_include_missing_source_bare_errors(chdir_tmp: Path) -> None:
         build_sdist(str(dist), {})
 
 
-def test_force_include_missing_source_table_errors(chdir_tmp: Path) -> None:
-    # The inline-table form errors on a missing source by default.
+def test_force_include_missing_wheel_source_errors(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"does-not-exist.txt" = {wheel = "pkg/missing.txt"}}',
+        extra='wheel.force-include = {"does-not-exist.txt" = "pkg/missing.txt"}',
     )
 
     dist = chdir_tmp / "dist"
@@ -260,29 +259,22 @@ def test_force_include_missing_source_table_errors(chdir_tmp: Path) -> None:
         build_wheel(str(dist), {})
 
 
-def test_force_include_missing_source_not_strict_skipped(chdir_tmp: Path) -> None:
+def test_force_include_from_sdist_via_overrides(chdir_tmp: Path) -> None:
+    """The documented overrides recipe redirects the wheel source when from-sdist."""
     make_pure_pkg(
         chdir_tmp,
-        extra=(
-            'force-include = {"does-not-exist.txt" = '
-            '{wheel = "pkg/missing.txt", strict = false}}'
-        ),
-    )
+        extra=textwrap.dedent("""\
+            [tool.scikit-build.sdist.force-include]
+            "../outside.txt" = "vendored/blob.txt"
 
-    dist = chdir_tmp / "dist"
-    build_wheel(str(dist), {})
+            [[tool.scikit-build.overrides]]
+            if.from-sdist = false
+            wheel.force-include."../outside.txt" = "pkg/blob.txt"
 
-    assert "pkg/missing.txt" not in wheel_names(dist)
-
-
-def test_force_include_from_sdist_reads_vendored_location(chdir_tmp: Path) -> None:
-    """A wheel built from an unpacked SDist reads the vendored ``sdist`` path."""
-    make_pure_pkg(
-        chdir_tmp,
-        extra=(
-            'force-include = {"../outside.txt" = '
-            '{sdist = "vendored/blob.txt", wheel = "pkg/blob.txt"}}'
-        ),
+            [[tool.scikit-build.overrides]]
+            if.from-sdist = true
+            wheel.force-include."vendored/blob.txt" = "pkg/blob.txt"
+            """),
     )
     # Simulate an unpacked SDist: a PKG-INFO at the root, the original external
     # source gone, but the vendored copy present at the sdist destination.
@@ -300,7 +292,7 @@ def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
     """Wheel-target force-includes are baked into the editable wheel (not redirected)."""
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"extra/data.txt" = {wheel = "pkg/data.txt"}}',
+        extra='wheel.force-include = {"extra/data.txt" = "pkg/data.txt"}',
     )
     (chdir_tmp / "extra").mkdir()
     (chdir_tmp / "extra" / "data.txt").write_text("hello")
@@ -316,7 +308,7 @@ def test_force_include_editable_script_shebang_normalized(chdir_tmp: Path) -> No
     """A force-included script's shebang is normalized in an editable wheel too."""
     make_pure_pkg(
         chdir_tmp,
-        extra='force-include = {"run.py" = {wheel = "/scripts/run.py"}}',
+        extra='wheel.force-include = {"run.py" = "/scripts/run.py"}',
     )
     (chdir_tmp / "run.py").write_text("#!/usr/bin/env python\nprint('hi')\n")
 
@@ -331,9 +323,8 @@ def test_force_include_sdist_target(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,
         extra=(
-            "force-include = {"
-            '"vendor/blob.txt" = "vendored/blob.txt", '
-            '"wheel-only.txt" = {wheel = "pkg/wheel_only.txt"}}'
+            'sdist.force-include = {"vendor/blob.txt" = "vendored/blob.txt"}\n'
+            'wheel.force-include = {"wheel-only.txt" = "pkg/wheel_only.txt"}'
         ),
     )
     (chdir_tmp / "vendor").mkdir()
@@ -347,18 +338,17 @@ def test_force_include_sdist_target(chdir_tmp: Path) -> None:
     with tarfile.open(sdist) as tf:
         names = set(tf.getnames())
 
-    # A bare string is the SDist destination.
     assert "pkg-0.1.0/vendored/blob.txt" in names
     # A wheel-only entry must not appear in the SDist.
     assert not any("wheel_only" in n for n in names)
 
 
-def _read_force_include(
+def _read_settings(
     tmp_path: Path,
     toml: str = "",
     config_settings: dict[str, str] | None = None,
     env: dict[str, str] | None = None,
-) -> Mapping[str, object]:
+) -> ScikitBuildSettings:
     import scikit_build_core.settings.skbuild_read_settings as rs
 
     pyproject_toml = tmp_path / "pyproject.toml"
@@ -367,35 +357,47 @@ def _read_force_include(
         pyproject_toml, config_settings or {}, env=env or {}
     )
     assert list(reader.unrecognized_options()) == []
-    return reader.settings.force_include
+    return reader.settings
 
 
-def test_settings_force_include_toml_forms(tmp_path: Path) -> None:
-    from scikit_build_core.settings.skbuild_model import ForceIncludeTargets
-
-    fi = _read_force_include(
+def test_settings_force_include_toml(tmp_path: Path) -> None:
+    settings = _read_settings(
         tmp_path,
         toml=textwrap.dedent("""\
-            [tool.scikit-build.force-include]
+            [tool.scikit-build.sdist.force-include]
+            "vendor/data" = "data"
+
+            [tool.scikit-build.wheel.force-include]
             "vendor/lib.so" = "pkg/_lib.so"
-            "../data" = {sdist = "data", wheel = "pkg/data"}
-            "maybe.so" = {wheel = "pkg/maybe.so", strict = false}
+            "tools/run.sh" = "/scripts/run.sh"
             """),
     )
-    assert fi["vendor/lib.so"] == "pkg/_lib.so"
-    assert fi["../data"] == ForceIncludeTargets(sdist="data", wheel="pkg/data")
-    assert fi["maybe.so"] == ForceIncludeTargets(wheel="pkg/maybe.so", strict=False)
+    assert settings.sdist.force_include == {"vendor/data": "data"}
+    assert settings.wheel.force_include == {
+        "vendor/lib.so": "pkg/_lib.so",
+        "tools/run.sh": "/scripts/run.sh",
+    }
 
 
-def test_settings_force_include_envvar_bare_string(tmp_path: Path) -> None:
-    fi = _read_force_include(
-        tmp_path, env={"SKBUILD_FORCE_INCLUDE": "a.txt=pkg/a.txt;b.txt=pkg/b.txt"}
+def test_settings_force_include_envvar(tmp_path: Path) -> None:
+    settings = _read_settings(
+        tmp_path,
+        env={
+            "SKBUILD_SDIST_FORCE_INCLUDE": "a.txt=data/a.txt",
+            "SKBUILD_WHEEL_FORCE_INCLUDE": "b.so=pkg/b.so;c.so=pkg/c.so",
+        },
     )
-    assert fi == {"a.txt": "pkg/a.txt", "b.txt": "pkg/b.txt"}
+    assert settings.sdist.force_include == {"a.txt": "data/a.txt"}
+    assert settings.wheel.force_include == {"b.so": "pkg/b.so", "c.so": "pkg/c.so"}
 
 
-def test_settings_force_include_config_settings_bare_string(tmp_path: Path) -> None:
-    fi = _read_force_include(
-        tmp_path, config_settings={"force-include.c.txt": "pkg/c.txt"}
+def test_settings_force_include_config_settings(tmp_path: Path) -> None:
+    settings = _read_settings(
+        tmp_path,
+        config_settings={
+            "sdist.force-include.a.txt": "data/a.txt",
+            "wheel.force-include.b.so": "pkg/b.so",
+        },
     )
-    assert fi == {"c.txt": "pkg/c.txt"}
+    assert settings.sdist.force_include == {"a.txt": "data/a.txt"}
+    assert settings.wheel.force_include == {"b.so": "pkg/b.so"}

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -148,6 +148,31 @@ def test_force_include_leading_slash_requires_experimental(chdir_tmp: Path) -> N
         build_wheel(str(dist), {})
 
 
+@pytest.mark.parametrize("bad", ["/abs/escape.txt", "../escape.txt", "a/../../x"])
+def test_force_include_rejects_escaping_sdist_dest(chdir_tmp: Path, bad: str) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra=f'force-include = {{"blob.txt" = {{sdist = "{bad}"}}}}',
+    )
+    (chdir_tmp / "blob.txt").write_text("x")
+
+    dist = chdir_tmp / "dist"
+    with pytest.raises(AssertionError, match=r"relative path without"):
+        build_sdist(str(dist), {})
+
+
+def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"blob.txt" = "../escape.txt"}',
+    )
+    (chdir_tmp / "blob.txt").write_text("x")
+
+    dist = chdir_tmp / "dist"
+    with pytest.raises(AssertionError):
+        build_wheel(str(dist), {})
+
+
 def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -178,7 +178,7 @@ def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
         chdir_tmp,
         extra='force-include = {"override.py" = "pkg/__init__.py"}',
     )
-    (chdir_tmp / "override.py").write_text("FORCED = True\n")
+    (chdir_tmp / "override.py").write_bytes(b"FORCED = True\n")
 
     dist = chdir_tmp / "dist"
     build_wheel(str(dist), {})

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -288,6 +288,60 @@ def test_force_include_from_sdist_via_overrides(chdir_tmp: Path) -> None:
     assert wheel_read(dist, "pkg/blob.txt") == b"vendored"
 
 
+def test_force_include_survives_wheel_exclude(chdir_tmp: Path) -> None:
+    """A force-included file overrides a matching wheel.exclude pattern."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'wheel.exclude = ["pkg/data.txt"]\n'
+            'wheel.force-include = {"data.txt" = "pkg/data.txt"}'
+        ),
+    )
+    (chdir_tmp / "data.txt").write_text("forced")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/data.txt" in wheel_names(dist)
+    assert wheel_read(dist, "pkg/data.txt") == b"forced"
+
+
+def test_force_include_pure_wheel_platlib_tree(chdir_tmp: Path) -> None:
+    """A documented /platlib destination resolves to purelib on a pure wheel."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"extra.txt" = "/platlib/pkg/extra.txt"}',
+    )
+    (chdir_tmp / "extra.txt").write_text("x")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/extra.txt" in wheel_names(dist)
+
+
+def test_force_include_sdist_directory_reproducible(chdir_tmp: Path) -> None:
+    """Forced directory entries are ordered deterministically in the SDist tar."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='sdist.force-include = {"assets" = "vendored"}',
+    )
+    assets = chdir_tmp / "assets"
+    (assets / "sub").mkdir(parents=True)
+    for name in ("c.txt", "a.txt", "b.txt"):
+        (assets / name).write_text(name)
+    (assets / "sub" / "z.txt").write_text("z")
+
+    dist = chdir_tmp / "dist"
+    build_sdist(str(dist), {})
+
+    (sdist,) = dist.glob("pkg-0.1.0.tar.gz")
+    with tarfile.open(sdist) as tf:
+        forced = [n for n in tf.getnames() if "/vendored/" in n]
+
+    assert forced == sorted(forced)
+
+
 def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
     """Wheel-target force-includes are baked into the editable wheel (not redirected)."""
     make_pure_pkg(

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import tarfile
+import textwrap
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scikit_build_core.build import build_sdist, build_wheel
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+PYPROJECT = """\
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pkg"
+version = "0.1.0"
+
+[tool.scikit-build]
+wheel.cmake = {cmake}
+sdist.cmake = {cmake}
+experimental = {experimental}
+{extra}
+"""
+
+
+def make_pure_pkg(
+    root: Path,
+    extra: str = "",
+    *,
+    cmake: bool = False,
+    experimental: bool = True,
+) -> None:
+    """Write a minimal package rooted at ``root`` (pure-Python by default)."""
+    pkg = root / "pkg"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("__version__ = '0.1.0'\n")
+    (root / "pyproject.toml").write_text(
+        PYPROJECT.format(
+            extra=extra,
+            cmake=str(cmake).lower(),
+            experimental=str(experimental).lower(),
+        )
+    )
+
+
+def wheel_names(dist: Path) -> set[str]:
+    (wheel,) = dist.glob("pkg-0.1.0-*.whl")
+    with zipfile.ZipFile(wheel) as zf:
+        return set(zf.namelist())
+
+
+def wheel_read(dist: Path, arcname: str) -> bytes:
+    (wheel,) = dist.glob("pkg-0.1.0-*.whl")
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.read(arcname)
+
+
+@pytest.fixture
+def chdir_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    monkeypatch.chdir(root)
+    return root
+
+
+def test_force_include_file_into_wheel(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"extra/data.txt" = "pkg/data.txt"}',
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/data.txt" in wheel_names(dist)
+    assert wheel_read(dist, "pkg/data.txt") == b"hello"
+
+
+def test_force_include_directory_recurses_and_skips_junk(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"assets" = "pkg/assets"}',
+    )
+    assets = chdir_tmp / "assets"
+    (assets / "sub").mkdir(parents=True)
+    (assets / "a.txt").write_text("a")
+    (assets / "sub" / "b.txt").write_text("b")
+    # Junk that must be skipped.
+    (assets / "__pycache__").mkdir()
+    (assets / "__pycache__" / "x.pyc").write_text("junk")
+    (assets / "ignored.pyc").write_text("junk")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    names = wheel_names(dist)
+    assert "pkg/assets/a.txt" in names
+    assert "pkg/assets/sub/b.txt" in names
+    assert not any("__pycache__" in n for n in names)
+    assert not any(n.endswith(".pyc") for n in names)
+
+
+def test_force_include_external_source(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"../outside.txt" = "pkg/outside.txt"}',
+    )
+    (chdir_tmp.parent / "outside.txt").write_text("external")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/outside.txt") == b"external"
+
+
+def test_force_include_leading_slash_targets_scripts(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"run.sh" = {wheel = "/scripts/run.sh"}}',
+    )
+    (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg-0.1.0.data/scripts/run.sh" in wheel_names(dist)
+
+
+def test_force_include_leading_slash_requires_experimental(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"run.sh" = {wheel = "/scripts/run.sh"}}',
+        experimental=False,
+    )
+    (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
+
+    dist = chdir_tmp / "dist"
+    with pytest.raises(AssertionError, match=r"[Ee]xperimental"):
+        build_wheel(str(dist), {})
+
+
+def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"override.py" = "pkg/__init__.py"}',
+    )
+    (chdir_tmp / "override.py").write_text("FORCED = True\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert wheel_read(dist, "pkg/__init__.py") == b"FORCED = True\n"
+
+
+def test_force_include_missing_source_skipped(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"does-not-exist.txt" = "pkg/missing.txt"}',
+    )
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/missing.txt" not in wheel_names(dist)
+
+
+def test_force_include_sdist_target(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            "force-include = {"
+            '"vendor/blob.txt" = {sdist = "vendored/blob.txt"}, '
+            '"wheel-only.txt" = "pkg/wheel_only.txt"}'
+        ),
+    )
+    (chdir_tmp / "vendor").mkdir()
+    (chdir_tmp / "vendor" / "blob.txt").write_text("vendored")
+    (chdir_tmp / "wheel-only.txt").write_text("w")
+
+    dist = chdir_tmp / "dist"
+    build_sdist(str(dist), {})
+
+    (sdist,) = dist.glob("pkg-0.1.0.tar.gz")
+    with tarfile.open(sdist) as tf:
+        names = set(tf.getnames())
+
+    assert "pkg-0.1.0/vendored/blob.txt" in names
+    # A bare string is wheel-only, so it must not appear in the SDist.
+    assert not any("wheel_only" in n for n in names)
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+def test_force_include_build_target_visible_to_cmake(chdir_tmp: Path) -> None:
+    """A {build=...} entry lands in the CMake build dir before configure."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='force-include = {"injected.cmake" = {build = "injected.cmake"}}',
+        cmake=True,
+    )
+    (chdir_tmp / "injected.cmake").write_text("set(INJECTED_OK TRUE)\n")
+    (chdir_tmp / "CMakeLists.txt").write_text(
+        textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.15)
+        project(pkg LANGUAGES NONE)
+        if(NOT EXISTS "${CMAKE_BINARY_DIR}/injected.cmake")
+          message(FATAL_ERROR "force-include build target missing")
+        endif()
+        include("${CMAKE_BINARY_DIR}/injected.cmake")
+        if(NOT INJECTED_OK)
+          message(FATAL_ERROR "injected.cmake did not run")
+        endif()
+        install(CODE "message(STATUS configured)")
+        """)
+    )
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+    # Build succeeds only if the injected file was present at configure time.
+    assert list(dist.glob("pkg-0.1.0-*.whl"))
+
+
+def _read_force_include(
+    tmp_path: Path,
+    toml: str = "",
+    config_settings: dict[str, str] | None = None,
+    env: dict[str, str] | None = None,
+) -> Mapping[str, object]:
+    import scikit_build_core.settings.skbuild_read_settings as rs
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(toml, encoding="utf-8")
+    reader = rs.SettingsReader.from_file(
+        pyproject_toml, config_settings or {}, env=env or {}
+    )
+    assert list(reader.unrecognized_options()) == []
+    return reader.settings.force_include
+
+
+def test_settings_force_include_toml_forms(tmp_path: Path) -> None:
+    from scikit_build_core.settings.skbuild_model import ForceIncludeTargets
+
+    fi = _read_force_include(
+        tmp_path,
+        toml=textwrap.dedent("""\
+            [tool.scikit-build.force-include]
+            "vendor/lib.so" = "pkg/_lib.so"
+            "../data" = {sdist = "data", wheel = "pkg/data"}
+            "toolchain.cmake" = {build = "toolchain.cmake"}
+            """),
+    )
+    assert fi["vendor/lib.so"] == "pkg/_lib.so"
+    assert fi["../data"] == ForceIncludeTargets(sdist="data", wheel="pkg/data")
+    assert fi["toolchain.cmake"] == ForceIncludeTargets(build="toolchain.cmake")
+
+
+def test_settings_force_include_envvar_bare_string(tmp_path: Path) -> None:
+    fi = _read_force_include(
+        tmp_path, env={"SKBUILD_FORCE_INCLUDE": "a.txt=pkg/a.txt;b.txt=pkg/b.txt"}
+    )
+    assert fi == {"a.txt": "pkg/a.txt", "b.txt": "pkg/b.txt"}
+
+
+def test_settings_force_include_config_settings_bare_string(tmp_path: Path) -> None:
+    fi = _read_force_include(
+        tmp_path, config_settings={"force-include.c.txt": "pkg/c.txt"}
+    )
+    assert fi == {"c.txt": "pkg/c.txt"}

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -306,6 +306,29 @@ def test_force_include_survives_wheel_exclude(chdir_tmp: Path) -> None:
     assert wheel_read(dist, "pkg/data.txt") == b"forced"
 
 
+def test_force_include_directory_respects_wheel_exclude(chdir_tmp: Path) -> None:
+    """A force-included directory's members are still filtered by wheel.exclude."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'wheel.exclude = ["pkg/assets/*.tmp"]\n'
+            'wheel.force-include = {"assets" = "pkg/assets"}'
+        ),
+    )
+    assets = chdir_tmp / "assets"
+    assets.mkdir()
+    (assets / "keep.txt").write_text("keep")
+    (assets / "drop.tmp").write_text("drop")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    names = wheel_names(dist)
+    assert "pkg/assets/keep.txt" in names
+    # A directory copy is bulk, so exclude still trims it.
+    assert "pkg/assets/drop.tmp" not in names
+
+
 def test_force_include_pure_wheel_platlib_tree(chdir_tmp: Path) -> None:
     """A documented /platlib destination resolves to purelib on a pure wheel."""
     make_pure_pkg(

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -224,6 +224,26 @@ def test_force_include_rejects_escaping_wheel_dest(chdir_tmp: Path) -> None:
         build_wheel(str(dist), {})
 
 
+def test_force_include_dotted_filename_allowed(chdir_tmp: Path) -> None:
+    """Adjacent dots in a destination filename are not a '..' traversal."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'wheel.force-include = {"data..txt" = "pkg/data..json", '
+            '"run..py" = "/scripts/run..py"}'
+        ),
+    )
+    (chdir_tmp / "data..txt").write_text("x")
+    (chdir_tmp / "run..py").write_text("y\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    names = wheel_names(dist)
+    assert "pkg/data..json" in names
+    assert "pkg-0.1.0.data/scripts/run..py" in names
+
+
 def test_force_include_overrides_package_file(chdir_tmp: Path) -> None:
     make_pure_pkg(
         chdir_tmp,

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -36,7 +36,7 @@ def test_hatchling_sdist_cmake_error_message() -> None:
 def test_hatchling_force_include_rejected() -> None:
     pyproject = {
         "project": {"name": "x", "version": "0.1.0"},
-        "tool": {"scikit-build": {"force-include": {"a.txt": "pkg/a.txt"}}},
+        "tool": {"scikit-build": {"wheel": {"force-include": {"a.txt": "pkg/a.txt"}}}},
     }
     with pytest.raises(ValueError, match="Force-include is not supported"):
         _validate_settings(pyproject)

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -33,6 +33,15 @@ def test_hatchling_sdist_cmake_error_message() -> None:
         _validate_settings(pyproject)
 
 
+def test_hatchling_force_include_rejected() -> None:
+    pyproject = {
+        "project": {"name": "x", "version": "0.1.0"},
+        "tool": {"scikit-build": {"force-include": {"a.txt": "pkg/a.txt"}}},
+    }
+    with pytest.raises(ValueError, match="Force-include is not supported"):
+        _validate_settings(pyproject)
+
+
 def set_hatchling_editable_mode(mode: str) -> None:
     pyproject = Path("pyproject.toml")
     pyproject.write_text(

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -38,7 +38,9 @@ def test_hatchling_force_include_rejected() -> None:
         "project": {"name": "x", "version": "0.1.0"},
         "tool": {"scikit-build": {"wheel": {"force-include": {"a.txt": "pkg/a.txt"}}}},
     }
-    with pytest.raises(ValueError, match="Force-include is not supported"):
+    with pytest.raises(
+        ValueError, match=r"force-include is not supported, use hatch's force-include"
+    ):
         _validate_settings(pyproject)
 
 

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -687,6 +687,75 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.define == {"a": "A", "b": "B", "c": "C"}
 
 
+@pytest.mark.parametrize("inherit", ["none", "append", "prepend"])
+def test_skbuild_overrides_inherit_force_include(inherit: str, tmp_path: Path):
+    """Free-form dicts (force-include, whose keys are file paths with dots and
+    slashes) follow the same inherit rules as cmake.define: append/prepend merge
+    the base and override tables, while none replaces the base outright."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            f"""\
+            [tool.scikit-build.sdist.force-include]
+            "a/b.txt" = "A"
+            "c.d.txt" = "B"
+
+            [tool.scikit-build.wheel.force-include]
+            "a/b.txt" = "A"
+            "c.d.txt" = "B"
+
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            inherit.sdist.force-include = "{inherit}"
+            inherit.wheel.force-include = "{inherit}"
+            sdist.force-include."c.d.txt" = "X"
+            sdist.force-include."e/f.txt" = "C"
+            wheel.force-include."c.d.txt" = "X"
+            wheel.force-include."e/f.txt" = "C"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings = SettingsReader.from_file(pyproject_toml, state="wheel").settings
+
+    if inherit == "none":
+        # The whole table is replaced; the base "a/b.txt" entry is dropped.
+        expected = {"c.d.txt": "X", "e/f.txt": "C"}
+    elif inherit == "append":
+        # Merged, with the override winning the "c.d.txt" conflict.
+        expected = {"a/b.txt": "A", "c.d.txt": "X", "e/f.txt": "C"}
+    else:  # prepend
+        # Merged, with the base winning the "c.d.txt" conflict.
+        expected = {"a/b.txt": "A", "c.d.txt": "B", "e/f.txt": "C"}
+
+    assert settings.sdist.force_include == expected
+    assert settings.wheel.force_include == expected
+
+
+def test_skbuild_overrides_force_include_default_replaces(tmp_path: Path):
+    """Without an inherit entry the override replaces the whole force-include
+    table rather than merging into it (the default mode is "none")."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build.wheel.force-include]
+            "a/b.txt" = "A"
+            "c.d.txt" = "B"
+
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            wheel.force-include."e/f.txt" = "C"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings = SettingsReader.from_file(pyproject_toml, state="wheel").settings
+    assert settings.wheel.force_include == {"e/f.txt": "C"}
+
+
 def test_skbuild_overrides_inherit_with_scalar_key(tmp_path: Path):
     """An override mixing inherit.<table>.<key> with a top-level scalar key
     must not crash (previously asserted the whole inherit table was empty)."""

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -1069,3 +1069,36 @@ def test_skbuild_overrides_matched_version_if_any_match(
 
     with pytest.raises(TypeError, match="not_real"):
         SettingsReader.from_file(pyproject_toml)
+
+
+@pytest.mark.parametrize("from_sdist", [True, False])
+def test_skbuild_overrides_force_include_from_sdist(
+    from_sdist: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """wheel.force-include entries merge across a from-sdist override (the
+    documented recipe for redirecting an external source to its vendored copy)."""
+    monkeypatch.chdir(tmp_path)
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.from-sdist = false
+            wheel.force-include."../outside.txt" = "pkg/blob.txt"
+
+            [[tool.scikit-build.overrides]]
+            if.from-sdist = true
+            wheel.force-include."vendored/blob.txt" = "pkg/blob.txt"
+            """
+        ),
+        encoding="utf-8",
+    )
+    if from_sdist:
+        (tmp_path / "PKG-INFO").write_text("Metadata-Version: 2.1\nName: pkg\n")
+
+    settings = SettingsReader.from_file(pyproject_toml, state="wheel").settings
+
+    if from_sdist:
+        assert settings.wheel.force_include == {"vendored/blob.txt": "pkg/blob.txt"}
+    else:
+        assert settings.wheel.force_include == {"../outside.txt": "pkg/blob.txt"}

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -60,7 +60,8 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.minimum_version is None
     assert settings.build_dir == ""
     assert settings.metadata == {}
-    assert settings.force_include == {}
+    assert settings.sdist.force_include == {}
+    assert settings.wheel.force_include == {}
     assert settings.editable.mode == "redirect"
     assert not settings.editable.rebuild
     assert settings.editable.verbose
@@ -195,7 +196,8 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.minimum_version == Version("0.12")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
-    assert settings.force_include == {}
+    assert settings.sdist.force_include == {}
+    assert settings.wheel.force_include == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
     assert not settings.editable.verbose
@@ -301,7 +303,8 @@ def test_skbuild_settings_config_settings(
     assert settings.minimum_version == Version("0.10")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
-    assert settings.force_include == {}
+    assert settings.sdist.force_include == {}
+    assert settings.wheel.force_include == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
     assert not settings.editable.verbose

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -60,6 +60,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.minimum_version is None
     assert settings.build_dir == ""
     assert settings.metadata == {}
+    assert settings.force_include == {}
     assert settings.editable.mode == "redirect"
     assert not settings.editable.rebuild
     assert settings.editable.verbose
@@ -194,6 +195,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.minimum_version == Version("0.12")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
+    assert settings.force_include == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
     assert not settings.editable.verbose
@@ -299,6 +301,7 @@ def test_skbuild_settings_config_settings(
     assert settings.minimum_version == Version("0.10")
     assert settings.build_dir == "a/b/c"
     assert settings.metadata == {}
+    assert settings.force_include == {}
     assert settings.editable.mode == "redirect"
     assert settings.editable.rebuild
     assert not settings.editable.verbose


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a top-level `[tool.scikit-build.force-include]` table that maps source paths to destinations, modeled on hatchling's `force-include` but extended for scikit-build-core's multi-tree wheel layout and CMake build directory.

```toml
[tool.scikit-build.force-include]
"vendor/lib.so"   = "pkg/_lib.so"                          # bare string -> wheel (platlib)
"tools/run.sh"    = {wheel = "/scripts/run.sh"}            # leading-slash -> wheel tree (experimental)
"../shared/data"  = {sdist = "data", wheel = "pkg/data"}   # per-target; dirs recurse
"toolchain.cmake" = {build = "toolchain.cmake"}            # into CMake build dir, before configure
```

### Semantics
- **Key = source**, relative to the project root; may point outside it (`../shared`), `~` is expanded. File or directory (directories recurse, skipping VCS/`__pycache__` junk via the existing `EXCLUDE_LINES`).
- **Bare string value = wheel destination** (the common case), relative to platlib. A leading `/data`, `/scripts`, `/headers`, `/platlib`, or `/metadata` targets that wheel tree instead (requires `experimental = true`, like `wheel.install-dir`).
- **Inline table** gives per-target control over any subset of `sdist`, `wheel`, and `build`. This form is TOML-only (force-include keys are file paths with dots/slashes that don't round-trip through config-settings dotted keys); the bare-string/wheel form also works via config-settings and `SKBUILD_FORCE_INCLUDE`.
- Force-included files are copied **last**, so they override discovered package files and CMake output at the same destination.
- **A missing source is silently skipped, not an error** (matches hatchling): when building a wheel from an SDist an external source may be gone but is assumed already present at the destination. Use the `sdist` target to vendor it into the tarball so it is.

### Implementation notes
- Taught the settings machinery to route a TOML table to a dataclass member of a union (`Dict[str, Union[str, ForceIncludeTargets]]`) — previously `TOMLSource.convert()` rejected a `dict` value in a union. `json_schema.py` already produced the right `oneOf`; `documentation.py` learned to render a non-optional `Union`, and a one-line guard in `skbuild_schema.py` tolerates the `patternProperties` shape (like `metadata`).
- The leading-slash wheel-tree resolution is factored into `resolve_wheel_tree` and reused by `wheel.install-dir`, the force-include wheel path, and the Hatch plugin (removed a triplicated block).
- Non-wheel destinations are validated to reject absolute or `..`-containing paths so `sdist`/`build` targets can't escape their root.
- The experimental **Hatch** plugin rejects `force-include` in `_validate` (it cannot honor the `sdist` target, which Hatch builds separately), consistent with how `generate`/`metadata` are rejected.

### Tests / docs
- New `tests/test_force_include.py` covers file / directory-recursion / external (`../`) / leading-slash wheel tree / override / missing-source / sdist / build-into-CMake, escape-rejection, plus settings parsing across TOML / env / config-settings.
- A Hatch `_validate` rejection test.
- Generated schema + `docs/reference/configs.md` (`nox -t gen`) and a narrative "Force-including files" docs section.

### Open question
The inline-table form is intentionally TOML-only (see above). Flagging in case you'd prefer a config-settings encoding too.
