### PR TITLE
fix: correct DynamicMetadataProtocol.dynamic_metadata signature

### DIFF
--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, Union, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Generator
 
     StrMapping = Mapping[str, Any]
 else:
@@ -28,10 +28,10 @@ def __dir__() -> list[str]:
 class DynamicMetadataProtocol(Protocol):
     def dynamic_metadata(
         self,
-        fields: Iterable[str],
+        field: str,
         settings: dict[str, Any],
         project: Mapping[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> Any: ...
 
 
 @runtime_checkable


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`DynamicMetadataProtocol.dynamic_metadata` is annotated as:

```python
def dynamic_metadata(self, fields: Iterable[str], settings, project) -> dict[str, Any]: ...
```

but the actual contract is a single `field: str` returning that field's value, not an iterable of fields returning a dict. This is confirmed by:

- every bundled plugin (`metadata/regex.py`, `template.py`, `setuptools_scm.py`, `fancy_pypi_readme.py`), which all define `dynamic_metadata(field, settings, project)` and return a single value;
- the docs, which document the single-field signature;
- the call site in `DynamicPyProject.__getitem__`, which calls `provider.dynamic_metadata(key, self.settings[key], self)` with a single key — and whose `inspect.signature` backcompat branch only makes sense for the single-field form.

This corrects the annotation to `field: str` / `-> Any` and drops the now-unused `Iterable` import. No runtime behavior changes.

Spotted while reviewing the [dynamic-metadata](https://github.com/scikit-build/dynamic-metadata) spec repo, which inherited the same mismatch.

## Test plan

- `prek run` on the file: ruff + mypy pass.
- `pytest tests/test_dynamic_metadata_unit.py tests/test_dynamic_metadata.py`: 30 passed.