### PR TITLE
fix: debounce editable rebuild to once per process

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -296,6 +296,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.known_wheel_files = known_wheel_files
         self.path = path
         self.rebuild_flag = rebuild
+        self.rebuilt = False
         self.verbose = verbose
         self.build_options = build_options
         self.install_options = install_options
@@ -352,7 +353,13 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             submodule_search_locations = None
 
         if fullname in self.known_wheel_files:
-            if self.rebuild_flag:
+            # Debounce to once per process: importing a project can resolve many
+            # known wheel files, but a single rebuild covers them all. Set the
+            # flag before rebuilding so a raising build doesn't loop (the import
+            # error propagates normally). The MARKER env var and file lock in
+            # rebuild() handle cross-process recursion, not this case.
+            if self.rebuild_flag and not self.rebuilt:
+                self.rebuilt = True
                 self.rebuild()
             origin = os.path.join(self.dir, self.known_wheel_files[fullname])
             return self._make_spec(fullname, origin, submodule_search_locations)

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -200,6 +200,45 @@ def test_rebuild_success_runs_build_and_install(
     assert calls[1][:2] == ["cmake", "--install"]
 
 
+def test_rebuild_runs_once_per_process(tmp_path: Path):
+    """Regression (#1367): rebuild fires at most once per finder, not per import.
+
+    Importing a project like pytorch resolves many compiled modules at
+    ``import torch``; each known wheel file should not re-trigger an (otherwise
+    no-op) ``cmake --build``/``--install`` cycle.
+    """
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={
+            "pkg._mod_a": "pkg/_mod_a.so",
+            "pkg._mod_b": "pkg/_mod_b.so",
+        },
+        known_directories={},
+        known_packages=[],
+        path=str(tmp_path),
+        rebuild=True,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path),
+        install_dir="",
+    )
+
+    calls = 0
+
+    def fake_rebuild() -> None:
+        nonlocal calls
+        calls += 1
+
+    finder.rebuild = fake_rebuild  # type: ignore[method-assign]
+
+    finder.find_spec("pkg._mod_a")
+    finder.find_spec("pkg._mod_a")
+    finder.find_spec("pkg._mod_b")
+
+    assert calls == 1
+
+
 def test_mapping_to_modules_prefers_py():
     """Test that mapping_to_modules prefers __init__.py over __init__.pxd."""
     from scikit_build_core.build._editable import mapping_to_modules


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

With `editable.rebuild = true`, the meta-path finder in `_editable_redirect.py` ran `cmake --build` + `cmake --install` on **every** import of a known wheel file. A large project (e.g. pytorch) resolves many compiled modules at `import torch`, so the rebuild fired ~7 times (~25s wasted) even with no source change.

This adds a same-process debounce: the rebuild now runs at most once per finder. The flag (`self.rebuilt`) is set **before** calling `rebuild()` so a failing build does not loop — the import error propagates normally. The existing `MARKER` env var and file lock continue to handle cross-process recursion; this only covers the repeated-imports-in-one-process case.

No new config option is added — the once-per-process behavior is unconditional, as requested in #1367.

Closes #1367

## Test plan

- Added `test_rebuild_runs_once_per_process` in `tests/test_editable_redirect.py`: constructs a finder with `rebuild=True` and two known wheel files, patches `rebuild` to count calls, calls `find_spec` three times across both modules, and asserts exactly one rebuild.
- Confirmed the test fails before the fix (3 calls) and passes after (1 call).
- Full `tests/test_editable_redirect.py` passes (8 tests).
- `prek -a --quiet` clean (ruff + mypy + typos).
- `nox -t gen` produces no generated-file changes.