### PR TITLE
fix: cap SKBUILD_PROJECT_VERSION to four components

### DIFF
--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -14,8 +14,9 @@ the version of scikit-build-core with `${SKBUILD_CORE_VERSION}`.
 Scikit-build-core provides several useful variables:
 
 - `${SKBUILD_PROJECT_NAME}`: The name of the project.
-- `${SKBUILD_PROJECT_VERSION}`: The version of the project in a form CMake can
-  use.
+- `${SKBUILD_PROJECT_VERSION}`: The version of the project, the release segment
+  capped to four components (`major.minor.patch.tweak`) so it is always valid
+  for `project(VERSION ...)`.
 - `${SKBUILD_PROJECT_VERSION_FULL}`: The exact version of the project including
   dev & local suffix.
 - `${SKBUILD_STATE}`: The run state, one of `sdist`, `wheel`, `metadata_wheel`,

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -226,9 +226,7 @@ class Builder:
             canonical_name = name.replace("-", "_").replace(".", "_")
             cache_config["SKBUILD_PROJECT_NAME"] = canonical_name
         if version is not None:
-            # Cap to four components so it is valid for project(VERSION ...),
-            # which accepts up to major.minor.patch.tweak. No padding is needed;
-            # SKBUILD_PROJECT_VERSION_FULL retains the full version.
+            # Cap to four components so it is valid for project(VERSION ...)
             cache_config["SKBUILD_PROJECT_VERSION"] = ".".join(
                 str(v) for v in version.release[:4]
             )

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -226,8 +226,11 @@ class Builder:
             canonical_name = name.replace("-", "_").replace(".", "_")
             cache_config["SKBUILD_PROJECT_NAME"] = canonical_name
         if version is not None:
+            # Cap to four components so it is valid for project(VERSION ...),
+            # which accepts up to major.minor.patch.tweak. No padding is needed;
+            # SKBUILD_PROJECT_VERSION_FULL retains the full version.
             cache_config["SKBUILD_PROJECT_VERSION"] = ".".join(
-                str(v) for v in version.release
+                str(v) for v in version.release[:4]
             )
             cache_config["SKBUILD_PROJECT_VERSION_FULL"] = str(version)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -415,6 +415,51 @@ def test_builder_limited_api_auto_free_threaded(tmp_path, monkeypatch):
     assert "set(Py_TARGET_ABI3T [===[1]===] CACHE STRING" in cache
 
 
+def configure_builder_with_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version: Version,
+) -> str:
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+    monkeypatch.setattr(config, "configure", unittest.mock.Mock())
+
+    builder = Builder(
+        settings=ScikitBuildSettings(search=SearchSettings(site_packages=False)),
+        config=config,
+    )
+    monkeypatch.setattr(Builder, "_get_entry_point_search_path", lambda *_: {})
+
+    builder.configure(defines={}, name="example", version=version)
+    return config.init_cache_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("version", "full", "capped"),
+    [
+        ("1.2.3", "1.2.3", "1.2.3"),
+        ("1.2", "1.2", "1.2"),
+        ("2", "2", "2"),
+        ("1.2.3.4", "1.2.3.4", "1.2.3.4"),
+        ("1.2.3.4.5", "1.2.3.4.5", "1.2.3.4"),
+        ("1!2.3.4", "1!2.3.4", "2.3.4"),
+        ("1.0.0a1", "1.0.0a1", "1.0.0"),
+        ("1.2.3.dev4+local", "1.2.3.dev4+local", "1.2.3"),
+    ],
+)
+def test_builder_project_version_cmake(tmp_path, monkeypatch, version, full, capped):
+    cache = configure_builder_with_version(tmp_path, monkeypatch, Version(version))
+    assert f"set(SKBUILD_PROJECT_VERSION [===[{capped}]===] CACHE STRING" in cache
+    assert f"set(SKBUILD_PROJECT_VERSION_FULL [===[{full}]===] CACHE STRING" in cache
+
+
 @pytest.mark.parametrize(
     ("minver", "archs", "answer"),
     [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Caps `SKBUILD_PROJECT_VERSION` to at most four dot-separated release components (`major.minor.patch.tweak`) so it is always valid for CMake's strict `project(VERSION ...)` parser. This addresses #1367, where projects currently hand-strip PEP 440 suffixes.

Previously `SKBUILD_PROJECT_VERSION` was release-only but not guaranteed CMake-valid: `version.release` can have more than four components (`(1,2,3,4,5)` -> invalid). It is now truncated via `version.release[:4]`.

No zero-padding is added. CMake accepts up to four non-negative integer segments and is happy with a bare one- or two-component version, so `2` and `2.6` are left as-is. The `release` segment is already free of epoch/pre/post/dev/local. The full, unmodified version remains available as `SKBUILD_PROJECT_VERSION_FULL`, so no new variable is needed.

Examples:
- `2` -> `2`
- `2.6` -> `2.6`
- `1.2.3.4` -> `1.2.3.4`
- `1.2.3.4.5` -> `1.2.3.4`
- epoch/pre/post/dev/local are already stripped by `version.release`, e.g. `1!2.3.4` -> `2.3.4`, `1.0.0a1` -> `1.0.0`, `1.2.3.dev4+local` -> `1.2.3`

### Compatibility note

This changes the existing variable rather than adding a new one. Only versions with 5+ release components now render differently in `SKBUILD_PROJECT_VERSION`. Anyone needing the exact value should use `SKBUILD_PROJECT_VERSION_FULL`.

## Test plan
- `tests/test_builder.py::test_builder_project_version_cmake` is parametrized over the edge cases, asserting both the capped `SKBUILD_PROJECT_VERSION` and the untouched `SKBUILD_PROJECT_VERSION_FULL` in the generated init cache.
- `prek -a --quiet` clean (ruff + mypy + typos).
- Docs: updated the `SKBUILD_PROJECT_VERSION` entry in `docs/guide/cmakelists.md`.