### PR TITLE
feat: add cmake.use-sysconfig-compiler to opt out of sysconfig CC/CXX

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ cmake.source-dir = "."
 # Do not pass the current environment's python hints such as ``Python_EXECUTABLE``.
 cmake.python-hints = true
 
+# Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
+cmake.use-sysconfig-compiler = true
+
 # The versions of Ninja to allow.
 ninja.version = ">=1.5"
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -339,6 +339,24 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: cmake.use-sysconfig-compiler
+
+  :Type: ``bool``
+  :Default: true
+  :Config-settings: ``cmake.use-sysconfig-compiler`` or ``skbuild.cmake.use-sysconfig-compiler``
+  :Environment variable: ``SKBUILD_CMAKE_USE_SYSCONFIG_COMPILER``
+
+  Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
+  environment.
+
+  When ``false``, scikit-build-core will not set these, letting CMake pick the
+  compiler from ``PATH``. This is useful for projects whose compiler probes
+  (e.g. ``FindBLAS``, ``FindOpenMP``) break on the sysconfig compiler, such as a
+  conda narrow sysroot or a stale venv gcc. A user-set ``CC``/``CXX`` in the
+  environment is always respected regardless of this setting.
+```
+
+```{eval-rst}
 .. confval:: cmake.verbose
 
   :Type: ``bool``

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -213,7 +213,11 @@ class Builder:
 
         current_gen = self.get_generator(*configure_args)
         local_def = set_environment_for_gen(
-            current_gen, self.config.cmake, self.config.env, self.settings.ninja
+            current_gen,
+            self.config.cmake,
+            self.config.env,
+            self.settings.ninja,
+            use_sysconfig_compiler=self.settings.cmake.use_sysconfig_compiler,
         )
         cmake_defines.update(local_def)
 

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -99,6 +99,8 @@ def set_environment_for_gen(
     cmake: CMake,
     env: MutableMapping[str, str],
     ninja_settings: NinjaSettings,
+    *,
+    use_sysconfig_compiler: bool = True,
 ) -> Mapping[str, str]:
     """
     This function modifies the environment as needed to safely set a generator.
@@ -132,16 +134,19 @@ def set_environment_for_gen(
     # Set Python's recommended CC and CXX if not already set by the user. Only
     # the executable is kept; sysconfig may append flags (e.g. "c++ -pthread"),
     # which would otherwise leak into tools like autotools sub-builds. CMake adds
-    # any flags it needs itself. See #1330.
-    if "CC" not in env:
-        cc = sysconfig.get_config_var("CC")
-        if cc:
-            env["CC"] = shlex.split(cc)[0]
+    # any flags it needs itself. See #1330. This can be disabled with
+    # cmake.use-sysconfig-compiler for projects whose compiler probes break on
+    # the sysconfig compiler. See #1367.
+    if use_sysconfig_compiler:
+        if "CC" not in env:
+            cc = sysconfig.get_config_var("CC")
+            if cc:
+                env["CC"] = shlex.split(cc)[0]
 
-    if "CXX" not in env:
-        cxx = sysconfig.get_config_var("CXX")
-        if cxx:
-            env["CXX"] = shlex.split(cxx)[0]
+        if "CXX" not in env:
+            cxx = sysconfig.get_config_var("CXX")
+            if cxx:
+                env["CXX"] = shlex.split(cxx)[0]
 
     if "Ninja" in (generator or "Ninja"):
         ninja = best_program(get_ninja_programs(), version=ninja_settings.version)

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -108,6 +108,11 @@
           "type": "boolean",
           "default": true,
           "description": "Do not pass the current environment's python hints such as ``Python_EXECUTABLE``."
+        },
+        "use-sysconfig-compiler": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the"
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -153,6 +153,18 @@ class CMakeSettings:
     instead.
     """
 
+    use_sysconfig_compiler: bool = True
+    """
+    Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
+    environment.
+
+    When ``false``, scikit-build-core will not set these, letting CMake pick the
+    compiler from ``PATH``. This is useful for projects whose compiler probes
+    (e.g. ``FindBLAS``, ``FindOpenMP``) break on the sysconfig compiler, such as a
+    conda narrow sysroot or a stale venv gcc. A user-set ``CC``/``CXX`` in the
+    environment is always respected regardless of this setting.
+    """
+
 
 @dataclasses.dataclass
 class SearchSettings:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -726,6 +726,43 @@ def test_set_environment_for_gen_strips_cc_cxx_flags(
     assert env["CXX"] == "c++"
 
 
+def test_set_environment_for_gen_use_sysconfig_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # With use_sysconfig_compiler=True (default), CC/CXX from sysconfig are
+    # injected; with False they are left untouched. See #1367.
+    from scikit_build_core.builder import generator as gen_mod
+    from scikit_build_core.program_search import Program
+    from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+    fake_ninja = Program(Path("/usr/bin/ninja"), Version("1.11.0"))
+    monkeypatch.setattr(gen_mod, "get_ninja_programs", lambda: [fake_ninja])
+    config_vars = {"CC": "gcc -pthread", "CXX": "c++ -pthread"}
+    monkeypatch.setattr(sysconfig, "get_config_var", config_vars.get)
+
+    env_default: dict[str, str] = {}
+    gen_mod.set_environment_for_gen(
+        "Ninja",
+        CMake(Version("3.30"), Path("cmake")),
+        env_default,
+        NinjaSettings(),
+        use_sysconfig_compiler=True,
+    )
+    assert env_default["CC"] == "gcc"
+    assert env_default["CXX"] == "c++"
+
+    env_off: dict[str, str] = {}
+    gen_mod.set_environment_for_gen(
+        "Ninja",
+        CMake(Version("3.30"), Path("cmake")),
+        env_off,
+        NinjaSettings(),
+        use_sysconfig_compiler=False,
+    )
+    assert "CC" not in env_off
+    assert "CXX" not in env_off
+
+
 def test_set_environment_for_gen_ninja_multi_config_missing(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -36,6 +36,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert not settings.build.verbose
     assert settings.cmake.build_type == "Release"
     assert settings.cmake.source_dir == Path()
+    assert settings.cmake.use_sysconfig_compiler
     assert settings.build.targets == []
     assert settings.logging.level == "WARNING"
     assert settings.sdist.include == []
@@ -189,6 +190,7 @@ def test_skbuild_settings_config_settings(
         "cmake.define.b": "2",
         "cmake.build-type": "Debug",
         "cmake.source-dir": "a/b/c",
+        "cmake.use-sysconfig-compiler": "false",
         "logging.level": "INFO",
         "sdist.include": ["a", "b", "c"],
         "sdist.exclude": "d;e;f",
@@ -236,6 +238,7 @@ def test_skbuild_settings_config_settings(
     assert settings.build.verbose
     assert settings.cmake.build_type == "Debug"
     assert settings.cmake.source_dir == Path("a/b/c")
+    assert not settings.cmake.use_sysconfig_compiler
     assert settings.logging.level == "INFO"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

scikit-build-core injects Python's `sysconfig` `CC`/`CXX` into the CMake subprocess environment (see #1331, which trimmed it to just the executable token). For projects that run compiler probes (`FindBLAS`, `FindOpenMP`, `FindARM`), this can leak a conda narrow-sysroot compiler, a stale venv gcc, or oneAPI `icx`, breaking `try_compile`. Users have asked for an opt-out.

This adds a new boolean config `cmake.use-sysconfig-compiler` (default `true`, preserving current behavior). When set to `false`, scikit-build-core will not set `CC`/`CXX` from sysconfig, letting CMake pick the compiler from `PATH`. A user-set `CC`/`CXX` in the environment is always respected regardless of this setting.

Refs #1367, #668.

### Changes
- New `use_sysconfig_compiler: bool = True` field on `CMakeSettings` (`cmake.use-sysconfig-compiler`).
- `set_environment_for_gen` gains a keyword-only `use_sysconfig_compiler` parameter guarding the CC/CXX injection block; call site in `builder.py` passes the setting.
- Regenerated `README.md`, `docs/reference/configs.md`, and `scikit-build.schema.json` via `nox -t gen`.

## Test plan
- `tests/test_builder.py::test_set_environment_for_gen_use_sysconfig_compiler` — added first; confirmed failing (`TypeError: unexpected keyword argument`) before the implementation, passing after. Verifies CC/CXX are injected when `True` (default) and absent when `False`.
- `tests/test_skbuild_settings.py` — added default assertion (`use_sysconfig_compiler` is `True`) and a config-settings parse assertion (`cmake.use-sysconfig-compiler = "false"` → field is `False`).
- `prek -a --quiet` clean (ruff, mypy, typos). `nox -t gen` produces no further diff.
