### PR TITLE
feat: support install.targets for install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ build.requires = []
 # The components to install.
 install.components = []
 
+# Build targets to run during the install step via ``cmake --build --target``.
+install.targets = []
+
 # Whether to strip the binaries.
 install.strip = true
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -493,6 +493,26 @@ print(mk_skbuild_docs())
      0.5-0.10.5 also incorrectly set this for debug builds.
 ```
 
+```{eval-rst}
+.. confval:: install.targets
+
+  :Type: ``list[str]``
+  :Config-settings: ``install.targets`` or ``skbuild.install.targets``
+  :Environment variable: ``SKBUILD_INSTALL_TARGETS``
+
+  Build targets to run during the install step via ``cmake --build --target``.
+
+  This is intended for projects that group their install rules under an
+  umbrella "distribution" build target (such as LLVM's ``install-distribution``)
+  rather than using CMake install ``COMPONENT``\ s. Each listed target is built,
+  which triggers its install rules into the staging prefix.
+
+  This relies on the configure-time ``CMAKE_INSTALL_PREFIX`` (set automatically
+  by scikit-build-core to the wheel staging directory); the ``--strip`` and
+  ``--component`` options of ``cmake --install`` do not apply to these targets.
+  ``components`` and ``targets`` may be combined; both will run.
+```
+
 ## logging
 
 ```{eval-rst}

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -373,6 +373,9 @@ class Builder:
         configuring for maximum compatibility.
         """
         components = self.settings.install.components
+        targets = self.settings.install.targets
         strip = self.settings.install.strip
         assert strip is not None
-        self.config.install(install_dir, strip=strip, components=components)
+        self.config.install(
+            install_dir, strip=strip, components=components, targets=targets
+        )

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -329,6 +329,7 @@ class CMaker:
         *,
         strip: bool = False,
         components: Sequence[str] = (),
+        targets: Sequence[str] = (),
     ) -> None:
         opts = ["--prefix", str(prefix)] if prefix else []
         if not self.single_config and self.build_type:
@@ -336,8 +337,20 @@ class CMaker:
         if strip:
             opts.append("--strip")
 
+        # Umbrella install targets (e.g. LLVM's install-distribution) install
+        # via `cmake --build --target`; they rely on the configure-time
+        # CMAKE_INSTALL_PREFIX, so --prefix/--strip/--component do not apply.
+        for target in targets:
+            logger.info("Installing target {}", target)
+            build_args = list(self._compute_build_args(verbose=False))
+            self._build(*build_args, "--target", target)
+
         if not components:
-            self._install(opts)
+            # With no components and no targets, run the default install. If
+            # only targets were requested, the target builds above already
+            # installed, so skip the plain install.
+            if not targets:
+                self._install(opts)
             return
 
         for comp in components:

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -337,18 +337,14 @@ class CMaker:
         if strip:
             opts.append("--strip")
 
-        # Umbrella install targets (e.g. LLVM's install-distribution) install
-        # via `cmake --build --target`; they rely on the configure-time
-        # CMAKE_INSTALL_PREFIX, so --prefix/--strip/--component do not apply.
+        # These are "built", so --prefix/--strip/--component do not apply.
         for target in targets:
             logger.info("Installing target {}", target)
             build_args = list(self._compute_build_args(verbose=False))
             self._build(*build_args, "--target", target)
 
         if not components:
-            # With no components and no targets, run the default install. If
-            # only targets were requested, the target builds above already
-            # installed, so skip the plain install.
+            # With no components and no targets, run the default install.
             if not targets:
                 self._install(opts)
             return

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -342,6 +342,13 @@
           },
           "description": "The components to install."
         },
+        "targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Build targets to run during the install step via ``cmake --build --target``."
+        },
         "strip": {
           "type": "boolean",
           "description": "Whether to strip the binaries."
@@ -609,6 +616,9 @@
                 "additionalProperties": false,
                 "properties": {
                   "components": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "targets": {
                     "$ref": "#/$defs/inherit"
                   }
                 }

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -442,6 +442,21 @@ class InstallSettings:
     If not specified or an empty list, all default components are installed.
     """
 
+    targets: List[str] = dataclasses.field(default_factory=list)
+    """
+    Build targets to run during the install step via ``cmake --build --target``.
+
+    This is intended for projects that group their install rules under an
+    umbrella "distribution" build target (such as LLVM's ``install-distribution``)
+    rather than using CMake install ``COMPONENT``\\ s. Each listed target is built,
+    which triggers its install rules into the staging prefix.
+
+    This relies on the configure-time ``CMAKE_INSTALL_PREFIX`` (set automatically
+    by scikit-build-core to the wheel staging directory); the ``--strip`` and
+    ``--component`` options of ``cmake --install`` do not apply to these targets.
+    ``components`` and ``targets`` may be combined; both will run.
+    """
+
     strip: Optional[bool] = dataclasses.field(
         default=None, metadata=SettingsFieldMetadata(display_default="true")
     )

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -276,6 +276,59 @@ def test_cmake_defines(
     )
 
 
+def test_install_targets(tmp_path: Path, fp):
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    build_dir = tmp_path / "build"
+
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=build_dir,
+        build_type="Release",
+        single_config=True,
+    )
+
+    fp.register([fp.program("cmake"), fp.any()], occurrences=10)
+
+    config.install(tmp_path / "prefix", strip=False, targets=["install-distribution"])
+
+    build_calls = [c for c in fp.calls if "--build" in c]
+    assert len(build_calls) == 1
+    call = [os.fspath(arg) for arg in build_calls[0]]
+    assert "--target" in call
+    assert call[call.index("--target") + 1] == "install-distribution"
+    assert os.fspath(build_dir) in call
+    # Target installs are emitted via `cmake --build`, not `cmake --install`.
+    assert not any("--install" in c for c in fp.calls)
+
+
+def test_install_targets_and_components(tmp_path: Path, fp):
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    build_dir = tmp_path / "build"
+
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=build_dir,
+        build_type="Release",
+        single_config=True,
+    )
+
+    fp.register([fp.program("cmake"), fp.any()], occurrences=10)
+
+    config.install(
+        tmp_path / "prefix",
+        strip=False,
+        components=["runtime"],
+        targets=["install-distribution"],
+    )
+
+    assert any("--install" in c and "--component" in c for c in fp.calls)
+    assert any("--build" in c and "--target" in c for c in fp.calls)
+
+
 def test_get_cmake_via_envvar(monkeypatch: pytest.MonkeyPatch, fp):
     monkeypatch.setattr("shutil.which", lambda x: x)
     cmake_path = Path("some-prog")

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -64,6 +64,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.editable.verbose
     assert settings.build.tool_args == []
     assert settings.install.components == []
+    assert settings.install.targets == []
     assert settings.install.strip
     assert settings.generate == []
     assert not settings.fail
@@ -109,6 +110,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SKBUILD_BUILD_TARGETS", "a;b;c")
     monkeypatch.setenv("SKBUILD_BUILD_TOOL_ARGS", "a;b")
     monkeypatch.setenv("SKBUILD_INSTALL_COMPONENTS", "a;b;c")
+    monkeypatch.setenv("SKBUILD_INSTALL_TARGETS", "x;y;z")
     monkeypatch.setenv("SKBUILD_INSTALL_STRIP", "False")
     monkeypatch.setenv("SKBUILD_FAIL", "1")
     monkeypatch.setenv(
@@ -163,6 +165,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.build.targets == ["a", "b", "c"]
     assert settings.build.tool_args == ["a", "b"]
     assert settings.install.components == ["a", "b", "c"]
+    assert settings.install.targets == ["x", "y", "z"]
     assert not settings.install.strip
     assert settings.fail
     assert settings.messages.after_failure == "This is a test failure message"
@@ -215,6 +218,7 @@ def test_skbuild_settings_config_settings(
         "build.targets": ["a", "b", "c"],
         "build.tool-args": ["a", "b"],
         "install.components": ["a", "b", "c"],
+        "install.targets": ["x", "y", "z"],
         "install.strip": "True",
         "fail": "1",
         "messages.after-failure": "This is a test failure message",
@@ -263,6 +267,7 @@ def test_skbuild_settings_config_settings(
     assert settings.build.targets == ["a", "b", "c"]
     assert settings.build.tool_args == ["a", "b"]
     assert settings.install.components == ["a", "b", "c"]
+    assert settings.install.targets == ["x", "y", "z"]
     assert settings.install.strip
     assert settings.fail
     assert settings.messages.after_failure == "This is a test failure message"
@@ -311,6 +316,7 @@ def test_skbuild_settings_pyproject_toml(
             build.targets = ["a", "b", "c"]
             build.tool-args = ["a", "b"]
             install.components = ["a", "b", "c"]
+            install.targets = ["x", "y", "z"]
             install.strip = true
             fail = true
             messages.after-failure = "This is a test failure message"
@@ -364,6 +370,7 @@ def test_skbuild_settings_pyproject_toml(
     assert settings.build.targets == ["a", "b", "c"]
     assert settings.build.tool_args == ["a", "b"]
     assert settings.install.components == ["a", "b", "c"]
+    assert settings.install.targets == ["x", "y", "z"]
     assert settings.install.strip
     assert settings.generate == [
         GenerateSettings(path=Path("a/b/c"), template="hello", location="install"),


### PR DESCRIPTION
This can also be used for the setuptools plugin.

:robot: _AI text below_ :robot:

## Summary

Adds an `install.targets` setting that runs `cmake --build --target <target>` during the install step, for each listed target.

This supports projects (notably LLVM) that group their install rules under an umbrella *distribution* build target such as `install-distribution`, rather than declaring CMake install `COMPONENT`s. Those need `cmake --build --target` rather than `cmake --install --component`.

Because scikit-build-core already sets `CMAKE_INSTALL_PREFIX` to the wheel staging directory at configure time, building an install target installs into the correct staging prefix automatically. The `--strip`/`--component` options of `cmake --install` do not apply to these targets.

Semantics:
- `install.targets` set: each target is built (which installs).
- `install.components` set: existing per-component `cmake --install` behavior.
- Neither set: plain `cmake --install` (unchanged default).
- Both may be combined; both run.

Closes #970

## Test plan

- New unit tests in `tests/test_cmake_config.py`:
  - `test_install_targets` asserts a single `cmake --build … --target install-distribution` is emitted (and no `cmake --install`) when only `targets` is set.
  - `test_install_targets_and_components` asserts both a target build and a component install are emitted when both are set.
  - Confirmed these fail before the implementation (`CMaker.install() got an unexpected keyword argument 'targets'`) and pass after.
- `tests/test_skbuild_settings.py` updated to assert `install.targets` parses from env, config-settings, and TOML sources (and defaults to `[]`).
- Regenerated `nox -t gen` outputs (README cog, configs.md, JSON schema); `prek -a` clean.