### PR TITLE
feat: honor CMAKE_BUILD_TYPE from the environment

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -428,6 +428,12 @@ You can select a different build type, such as `Debug`:
 
 ```
 
+If `cmake.build-type` is left at its default and `CMAKE_BUILD_TYPE` is set in
+the environment, that value is used instead. This lets you override the build
+type without editing `pyproject.toml` (for example
+`CMAKE_BUILD_TYPE=RelWithDebInfo`), mirroring CMake's own handling of the
+variable.
+
 You can specify CMake defines as strings or bools:
 
 ````{tab} pyproject.toml

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import difflib
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
@@ -24,7 +25,6 @@ from .skbuild_overrides import process_overrides
 from .sources import ConfSource, EnvSource, Source, SourceChain, TOMLSource
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import Generator, Mapping
 
     from .skbuild_overrides import OverrideRecord
@@ -245,6 +245,7 @@ class SettingsReader:
         retry: bool = False,
     ) -> None:
         self.state = state
+        environ = os.environ if env is None else env
 
         # Handle overrides
         pyproject = copy.deepcopy(pyproject)
@@ -314,6 +315,16 @@ class SettingsReader:
             prefixes=["tool", "scikit-build"],
         )
         self.settings = self.sources.convert_target(ScikitBuildSettings)
+
+        # CMake 3.22+ reads CMAKE_BUILD_TYPE from the environment, but only as a
+        # default for the first configure; the -DCMAKE_BUILD_TYPE we always pass
+        # (default "Release") would override it. Honor the environment value when
+        # build-type wasn't configured, which also works on older CMake.
+        if "CMAKE_BUILD_TYPE" in environ and not self.sources.has_item(
+            "cmake", "build_type", is_dict=False
+        ):
+            self.settings.cmake.build_type = environ["CMAKE_BUILD_TYPE"]
+
         validate_variant_settings(self.settings)
 
         static_settings = SourceChain(

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -71,6 +71,41 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.messages.after_success == ""
 
 
+def test_skbuild_settings_cmake_build_type_envvar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """CMAKE_BUILD_TYPE in the environment is honored when build-type is unset."""
+    monkeypatch.setenv("CMAKE_BUILD_TYPE", "RelWithAssert")
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.cmake.build_type == "RelWithAssert"
+
+
+def test_skbuild_settings_cmake_build_type_explicit_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An explicitly configured cmake.build-type beats CMAKE_BUILD_TYPE."""
+    monkeypatch.setenv("CMAKE_BUILD_TYPE", "RelWithAssert")
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            cmake.build-type = "Debug"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert settings_reader.settings.cmake.build_type == "Debug"
+
+
 def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         scikit_build_core.settings.skbuild_read_settings, "__version__", "0.12.0"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1367.

## Problem

CMake 3.22+ reads `CMAKE_BUILD_TYPE` from the environment, but only as a *default* for the first configure — an explicit `-DCMAKE_BUILD_TYPE` on the command line overrides it. Since scikit-build-core's `cmake.build-type` defaults to `"Release"`, it **always** passes `-DCMAKE_BUILD_TYPE=Release`, so an env-set `CMAKE_BUILD_TYPE=RelWithAssert` is silently ignored. (This is one of the pain points in #1367 — pytorch needed extra override blocks to work around it.)

## Fix

After settings are resolved, if `CMAKE_BUILD_TYPE` is set in the environment **and** `cmake.build-type` was not explicitly configured (via TOML, `SKBUILD_CMAKE_BUILD_TYPE`, config-settings, or an override), use the environment value.

Resulting precedence:
1. Explicit `cmake.build-type` — wins
2. `CMAKE_BUILD_TYPE` environment variable
3. `"Release"` default

This is done in Python rather than relying on CMake's native env support, so it works on CMake versions older than 3.22 (scikit-build-core supports down to 3.15) and uses the same `env` mapping the rest of the settings reader uses.

## Tests

- Added a regression test confirming `CMAKE_BUILD_TYPE` is honored when `build-type` is unset (verified it fails without the fix).
- Added a test confirming an explicit `cmake.build-type` still beats `CMAKE_BUILD_TYPE`.
- Docs note added under "Configuring CMake arguments and defines".