### PR TITLE
fix: link Python::Module in fortran example for CMake 4.x

### DIFF
--- a/docs/examples/getting_started/fortran/CMakeLists.txt
+++ b/docs/examples/getting_started/fortran/CMakeLists.txt
@@ -14,7 +14,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_library(fortranobject OBJECT "${F2PY_INCLUDE_DIR}/fortranobject.c")
-target_link_libraries(fortranobject PUBLIC Python::NumPy)
+target_link_libraries(fortranobject PUBLIC Python::NumPy Python::Module)
 target_include_directories(fortranobject PUBLIC "${F2PY_INCLUDE_DIR}")
 set_property(TARGET fortranobject PROPERTY POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The Fedora `fortran` example test started failing with:

```
fortranobject.h:7:10: fatal error: Python.h: No such file or directory
    7 | #include <Python.h>
```

## Root cause

#1361 raised this example's `cmake_minimum_required` policy ceiling from `...3.29` to `...4.3`. Under CMake 4.x policy behavior, the `Python::NumPy` imported target no longer propagates `Python::Module`'s include directories (the path to `Python.h`) to consumers.

The `fortranobject` object library relied on that transitive propagation:

```cmake
target_link_libraries(fortranobject PUBLIC Python::NumPy)
```

so compiling numpy's `fortranobject.c` no longer found `Python.h`. (The `example` target itself was unaffected because `python_add_library` auto-links `Python::Module`.)

## Fix

Link `Python::Module` explicitly:

```cmake
target_link_libraries(fortranobject PUBLIC Python::NumPy Python::Module)
```

## Verification

Reproduced the exact failure locally with CMake 4.3.4 + gfortran, then confirmed this one-line change builds the example end-to-end.

Notes:
- `docs/guide/getting_started.md` `literalinclude`s this file, so the rendered docs update automatically.
- `tests/packages/fortran_example/CMakeLists.txt` uses the same `Python::NumPy` pattern but is unaffected: it compiles `fortranobject.c` inside the `python_add_library` target and still caps at `...3.29`. Left unchanged.