### PR TITLE
feat: support cmake_install_target in setuptools plugin

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -54,11 +54,15 @@ These are the currently supported `setup.py` options:
   installed by CMake, relative to the setuptools build root, and returns the
   subset that should be kept. For editable installs the omitted files are
   removed from the source tree.
+- `cmake_install_target`: The build target that performs the install. The
+  default, `"install"`, runs `cmake --install`. Any other value installs by
+  running `cmake --build --target <value>` (equivalent to setting
+  `install.targets`), for projects with an umbrella install target.
 
 These options from scikit-build (classic) are not currently supported:
-`cmake_with_sdist` and `cmake_install_target`. `cmake_languages` has no effect.
-And `cmake_minimum_required_version` is now specified via `pyproject.toml`
-config, so has no effect here.
+`cmake_with_sdist`. `cmake_languages` has no effect. And
+`cmake_minimum_required_version` is now specified via `pyproject.toml` config,
+so has no effect here.
 
 A compatibility shim, `scikit_build_core.setuptools.wrapper.setup` is provided;
 it will eventually behave as close to scikit-build (classic)'s `skbuild.setup`

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -47,6 +47,18 @@ def __dir__() -> list[str]:
     return __all__
 
 
+def _apply_cmake_install_target(
+    settings: ScikitBuildSettings, dist: Distribution
+) -> None:
+    # Classic scikit-build's cmake_install_target picks the build target that
+    # performs the install; "install" is the default cmake --install path. A
+    # custom target installs via `cmake --build --target`, which is exactly what
+    # install.targets does.
+    target = getattr(dist, "cmake_install_target", None) or "install"
+    if target != "install":
+        settings.install.targets = [*settings.install.targets, target]
+
+
 def _validate_settings(
     settings: ScikitBuildSettings, *, editable_mode: bool = False
 ) -> None:
@@ -524,6 +536,7 @@ class BuildCMake(setuptools.Command):
         # overrides (if.state = "wheel"/"editable") are applied correctly.
         settings = _load_settings(state="editable" if self.editable_mode else "wheel")
         _validate_settings(settings, editable_mode=self.editable_mode)
+        _apply_cmake_install_target(settings, self.distribution)
 
         build_tmp_folder = Path(self.build_temp)
         build_temp = build_tmp_folder / "_skbuild"
@@ -768,10 +781,10 @@ def cmake_install_target(
     dist: Distribution, attr: Literal["cmake_install_target"], value: str
 ) -> None:
     assert attr == "cmake_install_target"
-    assert value is not None
     _cmake_extension(dist)
-    msg = "cmake_install_target is not supported - please use components and build targets instead"
-    raise SetupError(msg)
+    if not isinstance(value, str):
+        msg = "cmake_install_target must be a string"
+        raise SetupError(msg)
 
 
 def cmake_with_sdist(

--- a/src/scikit_build_core/setuptools/wrapper.py
+++ b/src/scikit_build_core/setuptools/wrapper.py
@@ -46,9 +46,6 @@ def setup(
     if cmake_with_sdist:
         msg = "cmake_with_sdist not supported yet"
         raise SetupError(msg)
-    if cmake_install_target != "install":
-        msg = "cmake_install_target not supported yet"
-        raise SetupError(msg)
 
     if cmake_languages is not None:
         warnings.warn("cmake_languages no longer has any effect", stacklevel=2)
@@ -85,6 +82,7 @@ def setup(
         cmake_with_sdist=cmake_with_sdist,
         cmake_args=list(cmake_args),
         cmake_install_dir=cmake_install_dir,
+        cmake_install_target=cmake_install_target,
         cmake_process_manifest_hook=cmake_process_manifest_hook,
         distclass=distribution_class,
         **kw,

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -470,8 +470,34 @@ def test_validate_settings_raises_setup_error():
 def test_wrapper_setup_raises_setup_error():
     with pytest.raises(SetupError, match="cmake_with_sdist not supported"):
         wrapper.setup(cmake_with_sdist=True)
-    with pytest.raises(SetupError, match="cmake_install_target not supported"):
-        wrapper.setup(cmake_install_target="custom")
+
+
+def test_cmake_install_target_keyword_validates_type():
+    with pytest.raises(SetupError, match="cmake_install_target must be a string"):
+        build_cmake.cmake_install_target(
+            setuptools.Distribution(),
+            "cmake_install_target",
+            object(),  # type: ignore[arg-type]
+        )
+
+
+def test_cmake_install_target_maps_to_install_targets():
+    settings = build_cmake._load_settings()
+    settings.install.targets = ["existing"]
+    dist = setuptools.Distribution()
+    dist.cmake_install_target = "install-distribution"  # type: ignore[attr-defined]
+    build_cmake._apply_cmake_install_target(settings, dist)
+    assert settings.install.targets == ["existing", "install-distribution"]
+
+
+@pytest.mark.parametrize("target", [None, "install"])
+def test_cmake_install_target_default_is_noop(target):
+    settings = build_cmake._load_settings()
+    dist = setuptools.Distribution()
+    if target is not None:
+        dist.cmake_install_target = target  # type: ignore[attr-defined]
+    build_cmake._apply_cmake_install_target(settings, dist)
+    assert settings.install.targets == []
 
 
 def test_load_settings_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
Since we added this in core, it's now easier to add. See https://github.com/scikit-build/scikit-build-core/issues/318. Currently this is a hard error.

Tested on an end-to-end project, but only unit tests committed, so it keeps the CI fast.

:robot: _AI text below_ :robot:

## What

Enables the classic scikit-build `cmake_install_target` setup keyword in the setuptools compatibility plugin (previously it raised "not supported yet").

The new `install.targets` setting (#1371 — `cmake --build --target <t>` during install) provides exactly the primitive this needs, so the keyword now maps onto it:

- Default `"install"` → unchanged `cmake --install` path.
- Any custom value → installs via `cmake --build --target <value>`, matching classic semantics where a custom target *replaces* the default install (CMaker skips the plain install when targets are set with no components).

The keyword is also wired through the `scikit_build_core.setuptools.wrapper.setup` shim.

## Changes

- `setuptools/build_cmake.py`: keyword validator now type-checks instead of erroring; mapping extracted to `_apply_cmake_install_target()` and applied in `BuildCMake.run()`.
- `setuptools/wrapper.py`: drop the unsupported error, forward the keyword.
- Docs updated.

## Tests

Covered piecewise without a compiled fixture:
- `install.targets` → `cmake --build --target` is already tested in `test_cmake_config.py::test_install_targets` (fake-process).
- New unit tests cover the keyword→setting mapping (custom appends, default/`install` is a no-op) and the validator type check.