### PR TITLE
feat: point editable rebuilds at a persistent install tree - opt-in (#1135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ editable.verbose = true
 # Rebuild the project when the package is imported.
 editable.rebuild = false
 
+# Install rebuildable editables into this tree (a newer alternative to ``editable.rebuild``).
+editable.rebuild-dir = ""
+
 # Extra args to pass directly to the builder in the build step.
 build.tool-args = []
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -790,6 +790,16 @@ extra reconfigure -- including projects that install to an absolute
 `${SKBUILD_PLATLIB_DIR}/...` destination. Deleting the build directory breaks
 the install, but a rebuildable editable already depends on it.
 
+As a newer, parallel alternative, `editable.rebuild-dir` selects the install
+tree directly and turns on rebuild-on-import by itself (the `editable.rebuild`
+flag is ignored when it is set). It accepts the same template substitutions as
+`build-dir`, and the path must be absolute, or relative to the source directory,
+and stable between build and run time, since it is baked at configure time and
+referenced by absolute path on rebuild. This only moves the install tree;
+`build-dir` is still required and still hosts the CMake build that the rebuild
+re-runs. The classic `editable.rebuild` (which installs into a tree inside
+`build-dir`) is left as-is, so the two approaches can be compared.
+
 The default `editable.mode`, `"redirect"`, uses a custom redirecting finder to
 combine the static CMake install dir with the original source code. Python code
 added via scikit-build-core's package discovery will be found in the original

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -780,6 +780,16 @@ You can disable the verbose rebuild output with `editable.verbose=false` if you
 want. (Also available as the `SKBUILD_EDITABLE_VERBOSE` envvar when importing;
 this will override if non-empty, and `"0"` will disable verbose output).
 
+When `editable.rebuild` is enabled together with a persistent `build-dir`, the
+CMake install targets a tree inside the build directory and the redirecting
+finder loads the compiled artifacts from there directly, rather than from copies
+in site-packages. This means `SKBUILD_PLATLIB_DIR` (or `SKBUILD_PURELIB_DIR`)
+and `CMAKE_INSTALL_PREFIX` are baked at their final location when the editable
+wheel is first built, so import-triggered rebuilds re-install in place with no
+extra reconfigure -- including projects that install to an absolute
+`${SKBUILD_PLATLIB_DIR}/...` destination. Deleting the build directory breaks
+the install, but a rebuildable editable already depends on it.
+
 The default `editable.mode`, `"redirect"`, uses a custom redirecting finder to
 combine the static CMake install dir with the original source code. Python code
 added via scikit-build-core's package discovery will be found in the original

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -427,6 +427,25 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: editable.rebuild-dir
+
+  :Type: ``str``
+  :Config-settings: ``editable.rebuild-dir`` or ``skbuild.editable.rebuild-dir``
+  :Environment variable: ``SKBUILD_EDITABLE_REBUILD_DIR``
+
+  Install rebuildable editables into this tree (a newer alternative to ``editable.rebuild``).
+
+  Setting this turns on rebuild-on-import by itself; the :confval:`editable.rebuild`
+  flag is ignored when it is set. The compiled artifacts are installed here at
+  first build and re-installed in place on every import-triggered rebuild, and
+  the redirect references them by absolute path. Must be an absolute (or
+  source-relative) path that is stable between build and run time, and supports
+  the same template substitutions as :confval:`build-dir`. This relocates only
+  the install tree; :confval:`build-dir` is still required and still hosts the
+  CMake build that the rebuild re-runs.
+```
+
+```{eval-rst}
 .. confval:: editable.verbose
 
   :Type: ``bool``

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -119,6 +119,9 @@ def editable_redirect_files(
     directories, known_packages = collect_search_locations(
         mapping, libdir, absolute=external_install
     )
+    # editable.rebuild-dir turns on rebuild-on-import by itself; the
+    # editable.rebuild flag is ignored when it is set.
+    rebuild = settings.editable.rebuild or bool(settings.editable.rebuild_dir)
     if install_prefix is not None:
         # The persistent install tree lives outside the wheel, so the shim is
         # given an absolute prefix (os.path.join drops DIR for an absolute path)
@@ -126,7 +129,7 @@ def editable_redirect_files(
         install_dir = install_prefix
     else:
         install_dir = settings.wheel.install_dir
-        if settings.editable.rebuild:
+        if rebuild:
             # The shim joins install_dir onto the platlib root; a platlib/purelib
             # selector reduces to its remainder, any other tree is rejected.
             install_dir = editable_rebuild_install_dir(install_dir)
@@ -136,7 +139,7 @@ def editable_redirect_files(
         directories=directories,
         packages=known_packages,
         reload_dir=reload_dir,
-        rebuild=settings.editable.rebuild,
+        rebuild=rebuild,
         verbose=settings.editable.verbose,
         build_options=build_options,
         install_options=install_options,

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -92,6 +92,7 @@ def editable_redirect_files(
     reload_dir: Path | None,
     settings: ScikitBuildSettings,
     use_start: bool | None = None,
+    install_prefix: str | None = None,
 ) -> dict[str, bytes]:
     """
     Build the editable redirect files for a package.
@@ -101,17 +102,34 @@ def editable_redirect_files(
     file, and the ``.pth`` keeps only the ``sys.path`` entries. ``use_start``
     overrides this auto-detection (used by tests); leave it ``None`` to select
     based on the running interpreter.
+
+    ``install_prefix`` selects where the redirect looks for CMake-installed
+    files. When ``None`` (the default), they are recorded relative to the
+    redirect file -- the install tree ships in the wheel and lands in
+    site-packages. When set (a rebuildable editable with a persistent build-dir),
+    the install tree lives outside the wheel: ``installed`` and the install-tree
+    search locations are absolute, and ``install_prefix`` is the
+    ``cmake --install --prefix`` used on rebuild.
     """
     if use_start is None:
         use_start = sys.version_info >= (3, 15)
+    external_install = install_prefix is not None
     modules = mapping_to_modules(mapping, libdir)
-    installed = libdir_to_installed(libdir)
-    directories, known_packages = collect_search_locations(mapping, libdir)
-    install_dir = settings.wheel.install_dir
-    if settings.editable.rebuild:
-        # The shim joins install_dir onto the platlib root; a platlib/purelib
-        # selector reduces to its remainder, any other tree is rejected.
-        install_dir = editable_rebuild_install_dir(install_dir)
+    installed = libdir_to_installed(libdir, absolute=external_install)
+    directories, known_packages = collect_search_locations(
+        mapping, libdir, absolute=external_install
+    )
+    if install_prefix is not None:
+        # The persistent install tree lives outside the wheel, so the shim is
+        # given an absolute prefix (os.path.join drops DIR for an absolute path)
+        # and references the installed files by absolute path.
+        install_dir = install_prefix
+    else:
+        install_dir = settings.wheel.install_dir
+        if settings.editable.rebuild:
+            # The shim joins install_dir onto the platlib root; a platlib/purelib
+            # selector reduces to its remainder, any other tree is rejected.
+            install_dir = editable_rebuild_install_dir(install_dir)
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,
@@ -204,12 +222,16 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     return result
 
 
-def libdir_to_installed(libdir: Path) -> dict[str, str]:
+def libdir_to_installed(libdir: Path, *, absolute: bool = False) -> dict[str, str]:
     """
     Map importable module names to their installed files (relative to ``libdir``).
 
     Only importable files are included; data/resource files are tracked
     separately by :func:`collect_search_locations`.
+
+    With ``absolute``, the paths are emitted absolute rather than relative to
+    ``libdir`` -- used when the install tree lives outside the wheel (a
+    rebuildable editable pointing at a persistent build-dir).
     """
     result: dict[str, str] = {}
     selected: dict[str, Path] = {}
@@ -220,13 +242,13 @@ def libdir_to_installed(libdir: Path) -> dict[str, str]:
         module = path_to_module(pth)
         if module in result and not _prefer_module(pth, selected[module]):
             continue
-        result[module] = str(pth)
+        result[module] = str(v if absolute else pth)
         selected[module] = pth
     return result
 
 
 def collect_search_locations(
-    mapping: dict[str, str], libdir: Path
+    mapping: dict[str, str], libdir: Path, *, absolute: bool = False
 ) -> tuple[dict[str, list[str]], list[str]]:
     """
     Build the package search-location map and the list of regular packages.
@@ -238,8 +260,10 @@ def collect_search_locations(
     module-resolution maps means a non-importable file is never a module's origin.
 
     Source-tree directories are absolute, install-tree ones relative to
-    ``libdir``. Returns ``(directories, packages)`` where ``packages`` are the
-    modules whose directory holds an ``__init__`` (including ``.pxd``/``.pyx``).
+    ``libdir`` (or absolute when ``absolute`` is set, for an install tree that
+    lives outside the wheel). Returns ``(directories, packages)`` where
+    ``packages`` are the modules whose directory holds an ``__init__`` (including
+    ``.pxd``/``.pyx``).
     """
     # Collect (module, directory, is_init) entries. Source tree: the absolute
     # source file's parent. Install tree: the directory relative to libdir.
@@ -252,7 +276,8 @@ def collect_search_locations(
     for v in scantree(libdir):
         rel = v.relative_to(libdir)
         if is_trackable(rel):
-            entries.append((path_to_module(rel), str(rel.parent), _is_init(rel.name)))
+            directory = str(v.parent if absolute else rel.parent)
+            entries.append((path_to_module(rel), directory, _is_init(rel.name)))
 
     directories: dict[str, set[str]] = {}
     packages: set[str] = set()

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -119,9 +119,7 @@ def editable_redirect_files(
     directories, known_packages = collect_search_locations(
         mapping, libdir, absolute=external_install
     )
-    # editable.rebuild-dir turns on rebuild-on-import by itself; the
-    # editable.rebuild flag is ignored when it is set.
-    rebuild = settings.editable.rebuild or bool(settings.editable.rebuild_dir)
+    rebuild = settings.editable.rebuild_enabled
     if install_prefix is not None:
         # The persistent install tree lives outside the wheel, so the shim is
         # given an absolute prefix (os.path.join drops DIR for an absolute path)

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -304,7 +304,7 @@ def build_install_extra_build_types(
         and builder.config.single_config
         and editable
         and settings.editable.mode == "redirect"
-        and (settings.editable.rebuild or bool(settings.editable.rebuild_dir))
+        and settings.editable.rebuild_enabled
     ):
         configure_wheel(
             cmake=builder.config.cmake,

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -42,6 +42,7 @@ __all__ = [
     "configure_wheel",
     "editable_rebuild_options",
     "get_build_dir",
+    "get_editable_rebuild_dir",
     "get_install_dir",
     "get_targetlib",
     "get_wheel_tag",
@@ -108,6 +109,31 @@ def get_build_dir(
         build_dir = fallback
     logger.info("Build directory: {}", build_dir.resolve())
     return build_dir
+
+
+def get_editable_rebuild_dir(
+    settings: ScikitBuildSettings,
+    *,
+    build_dir: Path,
+    targetlib: TargetLib,
+    tags: WheelTag,
+    state: WheelState,
+) -> Path:
+    """
+    Persistent install tree for a rebuildable redirect editable.
+
+    ``editable.rebuild-dir`` (formatted like ``build-dir``) overrides the default
+    ``install/<targetlib>`` tree inside ``build-dir``. The redirect references the
+    compiled artifacts here by absolute path, so it must be stable between build
+    and run time (#1135).
+    """
+    if settings.editable.rebuild_dir:
+        return Path(
+            settings.editable.rebuild_dir.format(
+                **pyproject_format(settings=settings, tags=tags, state=state)
+            )
+        ).resolve()
+    return (build_dir / "install" / targetlib).resolve()
 
 
 def prepare_wheel_dirs(wheel_root: Path, *, targetlib: TargetLib) -> dict[str, Path]:
@@ -278,7 +304,7 @@ def build_install_extra_build_types(
         and builder.config.single_config
         and editable
         and settings.editable.mode == "redirect"
-        and settings.editable.rebuild
+        and (settings.editable.rebuild or bool(settings.editable.rebuild_dir))
     ):
         configure_wheel(
             cmake=builder.config.cmake,

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -312,13 +312,12 @@ def _build_wheel_impl_impl(
         # import-triggered rebuilds need no reconfigure (#1135).
         #
         # Two triggers: the classic editable.rebuild installs into a tree inside
-        # build-dir; setting editable.rebuild-dir is the newer, parallel path that
-        # installs into a user-chosen tree and turns on rebuilds by itself (the
-        # editable.rebuild flag is then ignored). Both still require build-dir.
+        # build-dir; setting editable.rebuild-dir installs into a user-chosen tree
+        # (see EditableSettings.rebuild_enabled). Both still require build-dir.
         editable_rebuild = (
             editable
             and settings.editable.mode == "redirect"
-            and (settings.editable.rebuild or bool(settings.editable.rebuild_dir))
+            and settings.editable.rebuild_enabled
             and bool(settings.build_dir)
         )
         if editable_rebuild:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -69,6 +69,7 @@ def _make_editable(
     settings: ScikitBuildSettings,
     wheel: WheelWriter,
     packages: Iterable[str],
+    install_prefix: str | None = None,
 ) -> None:
     for filename, contents in editable_redirect_files(
         build_options=build_options,
@@ -79,6 +80,7 @@ def _make_editable(
         packages=packages,
         reload_dir=reload_dir,
         settings=settings,
+        install_prefix=install_prefix,
     ).items():
         wheel.writestr(filename, contents)
 
@@ -301,6 +303,26 @@ def _build_wheel_impl_impl(
             settings, wheel_dirs=wheel_dirs, targetlib=targetlib
         )
 
+        # A rebuildable redirect editable (one with a persistent build-dir)
+        # installs the platlib into a persistent tree inside the build directory
+        # instead of the temporary wheel-staging dir, and the redirect references
+        # the compiled artifacts there by absolute path. This bakes
+        # SKBUILD_<targetlib>_DIR / CMAKE_INSTALL_PREFIX at the final location at
+        # configure time, so import-triggered rebuilds need no reconfigure (#1135).
+        editable_rebuild = (
+            editable
+            and settings.editable.mode == "redirect"
+            and settings.editable.rebuild
+            and bool(settings.build_dir)
+        )
+        if editable_rebuild:
+            targetlib_dir = (build_dir / "install" / targetlib).resolve()
+            if targetlib_dir.exists():
+                shutil.rmtree(targetlib_dir)
+            targetlib_dir.mkdir(parents=True)
+        else:
+            targetlib_dir = wheel_dirs[targetlib]
+
         # The metadata-only and full-wheel paths build identical WheelWriters
         # except for the output folder; share a single constructor.
         make_wheel = functools.partial(
@@ -317,6 +339,16 @@ def _build_wheel_impl_impl(
                 wheel_variant.dist_info_contents if wheel_variant else None
             ),
         )
+
+        # A rebuildable editable cannot use an absolute wheel.install-dir (an
+        # AssertionError is raised earlier), so install_dir sits under the target
+        # lib; re-point it into the persistent install tree, and bake the same
+        # SKBUILD_<targetlib>_DIR so an absolute ${SKBUILD_*_DIR}/... destination
+        # also lands there.
+        editable_rebuild_cache: dict[str, str | Path] | None = None
+        if editable_rebuild:
+            install_dir = targetlib_dir / install_dir.relative_to(wheel_dirs[targetlib])
+            editable_rebuild_cache = {f"SKBUILD_{targetlib.upper()}_DIR": targetlib_dir}
 
         # Include the metadata license.file entry if provided
         if metadata.license_files is not None:
@@ -391,7 +423,7 @@ def _build_wheel_impl_impl(
             if gen.location == "build":
                 path = build_dir / gen.path
             elif gen.location == "install":
-                path = wheel_dirs[targetlib] / gen.path
+                path = targetlib_dir / gen.path
             else:
                 assert_never(gen.location)
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -408,6 +440,7 @@ def _build_wheel_impl_impl(
                 install_dir=install_dir,
                 build_dir=build_dir,
                 state=state,
+                extra_cache_entries=editable_rebuild_cache,
                 name=metadata.name,
                 version=metadata.version,
             )
@@ -425,6 +458,7 @@ def _build_wheel_impl_impl(
                 name=metadata.name,
                 version=metadata.version,
                 editable=editable,
+                extra_cache_entries=editable_rebuild_cache,
             )
 
         assert wheel_directory is not None
@@ -437,7 +471,7 @@ def _build_wheel_impl_impl(
         assert settings.sdist.inclusion_mode is not None
         mapping = packages_to_file_mapping(
             packages=packages,
-            platlib_dir=wheel_dirs[targetlib],
+            platlib_dir=targetlib_dir,
             include=settings.sdist.include,
             src_exclude=settings.sdist.exclude,
             target_exclude=settings.wheel.exclude,
@@ -481,13 +515,14 @@ def _build_wheel_impl_impl(
                 _make_editable(
                     build_options=build_options,
                     install_options=install_options,
-                    libdir=wheel_dirs[targetlib],
+                    libdir=targetlib_dir,
                     mapping=mapping,
                     reload_dir=reload_dir,
                     settings=settings,
                     wheel=wheel,
                     name=normalized_name,
                     packages=str_pkgs,
+                    install_prefix=os.fspath(install_dir) if editable_rebuild else None,
                 )
             elif editable and settings.editable.mode == "inplace":
                 if not packages:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -37,6 +37,7 @@ from .common_wheel_helpers import (
     configure_wheel,
     editable_rebuild_options,
     get_build_dir,
+    get_editable_rebuild_dir,
     get_install_dir,
     get_targetlib,
     get_wheel_tag,
@@ -304,19 +305,30 @@ def _build_wheel_impl_impl(
         )
 
         # A rebuildable redirect editable (one with a persistent build-dir)
-        # installs the platlib into a persistent tree inside the build directory
-        # instead of the temporary wheel-staging dir, and the redirect references
-        # the compiled artifacts there by absolute path. This bakes
-        # SKBUILD_<targetlib>_DIR / CMAKE_INSTALL_PREFIX at the final location at
-        # configure time, so import-triggered rebuilds need no reconfigure (#1135).
+        # installs the platlib into a persistent tree instead of the temporary
+        # wheel-staging dir, and the redirect references the compiled artifacts
+        # there by absolute path. This bakes SKBUILD_<targetlib>_DIR /
+        # CMAKE_INSTALL_PREFIX at the final location at configure time, so
+        # import-triggered rebuilds need no reconfigure (#1135).
+        #
+        # Two triggers: the classic editable.rebuild installs into a tree inside
+        # build-dir; setting editable.rebuild-dir is the newer, parallel path that
+        # installs into a user-chosen tree and turns on rebuilds by itself (the
+        # editable.rebuild flag is then ignored). Both still require build-dir.
         editable_rebuild = (
             editable
             and settings.editable.mode == "redirect"
-            and settings.editable.rebuild
+            and (settings.editable.rebuild or bool(settings.editable.rebuild_dir))
             and bool(settings.build_dir)
         )
         if editable_rebuild:
-            targetlib_dir = (build_dir / "install" / targetlib).resolve()
+            targetlib_dir = get_editable_rebuild_dir(
+                settings,
+                build_dir=build_dir,
+                targetlib=targetlib,
+                tags=tags,
+                state=state,
+            )
             if targetlib_dir.exists():
                 shutil.rmtree(targetlib_dir)
             targetlib_dir.mkdir(parents=True)

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -332,6 +332,11 @@
           "type": "boolean",
           "default": false,
           "description": "Rebuild the project when the package is imported."
+        },
+        "rebuild-dir": {
+          "type": "string",
+          "default": "",
+          "description": "Install rebuildable editables into this tree (a newer alternative to ``editable.rebuild``)."
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -597,6 +597,16 @@ class EditableSettings:
     CMake build that the rebuild re-runs.
     """
 
+    @property
+    def rebuild_enabled(self) -> bool:
+        """
+        True when rebuild-on-import is active.
+
+        Setting ``rebuild-dir`` turns this on by itself, so the ``rebuild`` flag
+        is ignored when it is set.
+        """
+        return self.rebuild or bool(self.rebuild_dir)
+
 
 @dataclasses.dataclass
 class BuildSettings:

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -583,6 +583,20 @@ class EditableSettings:
     :confval:`build-dir` must be set.
     """
 
+    rebuild_dir: str = ""
+    """
+    Install rebuildable editables into this tree (a newer alternative to ``editable.rebuild``).
+
+    Setting this turns on rebuild-on-import by itself; the :confval:`editable.rebuild`
+    flag is ignored when it is set. The compiled artifacts are installed here at
+    first build and re-installed in place on every import-triggered rebuild, and
+    the redirect references them by absolute path. Must be an absolute (or
+    source-relative) path that is stable between build and run time, and supports
+    the same template substitutions as :confval:`build-dir`. This relocates only
+    the install tree; :confval:`build-dir` is still required and still hosts the
+    CMake build that the rebuild re-runs.
+    """
+
 
 @dataclasses.dataclass
 class BuildSettings:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -357,7 +357,7 @@ class SettingsReader:
                         "wheel.packages table must match in the last component of the paths"
                     )
 
-        if self.settings.editable.rebuild:
+        if self.settings.editable.rebuild_enabled:
             if self.settings.editable.mode == "inplace":
                 rich_error("editable rebuild is incompatible with inplace mode")
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -80,7 +80,7 @@ def _validate_settings(
         if settings.editable.mode != "inplace":
             msg = "setuptools editable installs require editable.mode = 'inplace'"
             raise SetupError(msg)
-        if settings.editable.rebuild:
+        if settings.editable.rebuild_enabled:
             msg = "editable.rebuild is not supported in setuptools mode"
             raise SetupError(msg)
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -110,21 +110,33 @@ def test_install_dir(isolated, isolate):
         installer="pip",
     )
 
-    # Make sure the package is correctly installed in the subdirectory
-    other_pkg_path = isolated.platlib / "other_pkg"
-    c_module_glob = list(other_pkg_path.glob("simplest/_module*"))
+    # A rebuildable editable installs the platlib into a persistent tree inside
+    # the build-dir; the redirect references it there, so nothing lands in
+    # site-packages and rebuilds need no reconfigure (#1135).
+    assert not list((isolated.platlib / "other_pkg").glob("simplest/_module*"))
+
+    # The compiled module lives under the build tree, honoring wheel.install-dir
+    # (other_pkg/), not at the unprefixed location (simplest/).
+    install_tree = Path("build").glob("*/install/platlib")
+    platlib = next(install_tree)
+    c_module_glob = list(platlib.glob("other_pkg/simplest/_module*"))
     assert len(c_module_glob) == 1
     c_module = c_module_glob[0]
     assert c_module.exists()
-    # If `install-dir` was not taken into account it would install here
-    failed_c_module = other_pkg_path / "../simplest" / c_module.name
+    failed_c_module = platlib / "simplest" / c_module.name
     assert not failed_c_module.exists()
 
-    # Run an import in order to re-trigger the rebuild and check paths again
+    # Run an import in order to re-trigger the rebuild and check paths again. The
+    # module resolves to the build-tree copy, which is refreshed in place.
     out = isolated.execute("import other_pkg.simplest")
     assert "Running cmake" in out
     assert c_module.exists()
     assert not failed_c_module.exists()
+    resolved = isolated.execute(
+        "import other_pkg.simplest._module as m; print(m.__file__)"
+    )
+    assert resolved.splitlines()[-1] == str(c_module.resolve())
+    assert str(isolated.platlib) not in resolved
 
 
 @pytest.mark.compile

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -142,6 +142,47 @@ def test_install_dir(isolated, isolate):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
+@pytest.mark.parametrize("package", ["simplest_c"], indirect=True)
+@pytest.mark.parametrize("isolate", {False}, indirect=True)
+@pytest.mark.usefixtures("package")
+def test_editable_rebuild_dir(isolated, isolate):
+    # editable.rebuild-dir installs into a user-chosen tree (with the same
+    # template substitutions) and turns on rebuild-on-import by itself -- note
+    # editable.rebuild is left unset here.
+    settings_overrides = {
+        "build-dir": "build/{wheel_tag}",
+        "editable.rebuild-dir": "rebuild_tree/{wheel_tag}",
+    }
+
+    isolated.install(
+        "-v",
+        *[f"--config-settings={k}={v}" for k, v in settings_overrides.items()],
+        *isolate.flags,
+        "-e",
+        ".",
+        installer="pip",
+    )
+
+    # The install tree lands under rebuild-dir, not under build-dir/install.
+    assert not list(Path("build").glob("*/install/platlib/simplest/_module*"))
+    rebuild_tree = next(Path("rebuild_tree").glob("*"))
+    c_module_glob = list(rebuild_tree.glob("simplest/_module*"))
+    assert len(c_module_glob) == 1
+    c_module = c_module_glob[0]
+
+    # Nothing compiled lands in site-packages, and imports resolve to the
+    # rebuild-dir copy, which is refreshed in place on rebuild.
+    assert not list((isolated.platlib / "simplest").glob("_module*"))
+    out = isolated.execute("import simplest")
+    assert "Running cmake" in out
+    resolved = isolated.execute("import simplest._module as m; print(m.__file__)")
+    assert resolved.splitlines()[-1] == str(c_module.resolve())
+    assert str(isolated.platlib) not in resolved
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.integration
 @pytest.mark.parametrize("package", ["importlib_editable"], indirect=True)
 @pytest.mark.usefixtures("package")
 def test_direct_import(editable, isolated):

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -255,6 +255,87 @@ def test_mapping_to_modules_prefers_py():
     assert result["pkg"].endswith("__init__.py")
 
 
+def test_libdir_to_installed_absolute(tmp_path: Path):
+    """With absolute=True the install-tree files are recorded as absolute paths.
+
+    Used by rebuildable editables that point at a persistent build-dir install
+    tree (#1135): the redirect references the compiled artifacts there directly,
+    so they need no copy in site-packages and no reconfigure on rebuild.
+    """
+    import importlib.machinery
+
+    from scikit_build_core.build._editable import libdir_to_installed
+
+    ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+    libdir = tmp_path / "install" / "platlib"
+    mod = libdir / "pkg" / f"_module{ext}"
+    mod.parent.mkdir(parents=True)
+    mod.touch()
+
+    relative = libdir_to_installed(libdir)
+    assert relative == {"pkg._module": str(Path(f"pkg/_module{ext}"))}
+
+    absolute = libdir_to_installed(libdir, absolute=True)
+    assert absolute == {"pkg._module": str(mod)}
+    assert Path(absolute["pkg._module"]).is_absolute()
+
+
+def test_collect_search_locations_absolute(tmp_path: Path):
+    """With absolute=True the install-tree __path__ entries are absolute."""
+    import importlib.machinery
+
+    from scikit_build_core.build._editable import collect_search_locations
+
+    ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+    libdir = tmp_path / "install" / "platlib"
+    mod = libdir / "pkg" / f"_module{ext}"
+    mod.parent.mkdir(parents=True)
+    mod.touch()
+
+    directories, packages = collect_search_locations({}, libdir, absolute=True)
+    assert packages == []
+    assert directories == {"pkg": [str(libdir / "pkg")]}
+
+
+def test_editable_redirect_external_install_tree(tmp_path: Path):
+    """An external (absolute) install tree resolves and rebuilds in place (#1135).
+
+    A rebuildable editable bakes the persistent install prefix at build time, so
+    the redirect resolves compiled modules to absolute build-tree paths and the
+    rebuild's ``cmake --install --prefix`` points there -- no reconfigure needed.
+    """
+    import importlib.machinery
+
+    ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+    install_prefix = tmp_path / "build" / "install" / "platlib"
+    mod = install_prefix / "pkg" / f"_module{ext}"
+    mod.parent.mkdir(parents=True)
+    mod.touch()
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={"pkg._module": str(mod)},
+        known_directories={"pkg": [str(install_prefix / "pkg")]},
+        known_packages=[],
+        path=str(tmp_path / "build"),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path / "site-packages"),
+        install_dir=str(install_prefix),
+    )
+
+    # An absolute known_wheel_file is used verbatim, not joined under site-packages.
+    spec = finder.find_spec("pkg._module")
+    assert spec is not None
+    assert spec.origin == str(mod)
+
+    # The rebuild --prefix is the absolute install tree, so the cached
+    # SKBUILD_<targetlib>_DIR / CMAKE_INSTALL_PREFIX stay valid without a redo.
+    assert finder.install_dir == str(install_prefix)
+
+
 def test_mapping_to_modules_keeps_symlink_in_package_dir(tmp_path: Path):
     """A symlinked-in module keeps its in-package directory, not the link target (#647)."""
     from scikit_build_core.build._editable import mapping_to_modules

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -633,6 +633,28 @@ def test_editable_redirect_files_platlib_var_install_dir_with_rebuild(
     assert "SKBUILD_PURELIB_DIR" not in shim
 
 
+def test_editable_redirect_files_rebuild_dir_implies_rebuild(tmp_path: Path):
+    # editable.rebuild-dir turns on rebuild-on-import by itself, so the
+    # non-platlib install-dir guard fires even with editable.rebuild left False.
+    from scikit_build_core.settings.skbuild_model import EditableSettings, WheelSettings
+
+    settings = ScikitBuildSettings(
+        wheel=WheelSettings(install_dir="/data"),
+        editable=EditableSettings(rebuild=False, rebuild_dir=str(tmp_path / "tree")),
+    )
+
+    with pytest.raises(AssertionError, match=r"non-platlib wheel\.install-dir"):
+        editable_redirect_files(
+            libdir=tmp_path,
+            mapping={},
+            name="pkg",
+            packages=[],
+            reload_dir=None,
+            settings=settings,
+            use_start=False,
+        )
+
+
 def test_is_trackable():
     # Importable modules and data/resource files are both tracked, so the
     # redirect registers their directories for importlib.resources.

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -373,6 +373,40 @@ def test_packages_to_file_mapping_missing_source(
         )
 
 
+def test_editable_redirect_files_external_install_prefix(tmp_path: Path):
+    # A rebuildable editable (#1135) records the install tree as absolute paths
+    # and bakes the install prefix as the rebuild --prefix, so imports resolve to
+    # the persistent build tree and rebuilds skip the reconfigure.
+    import importlib.machinery
+
+    from scikit_build_core.settings.skbuild_model import EditableSettings
+
+    ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+    libdir = tmp_path / "build" / "install" / "platlib"
+    mod = libdir / "pkg" / f"_module{ext}"
+    mod.parent.mkdir(parents=True)
+    mod.touch()
+    install_prefix = str(libdir)
+
+    files = editable_redirect_files(
+        libdir=libdir,
+        mapping={},
+        name="pkg",
+        packages=[],
+        reload_dir=tmp_path / "build",
+        settings=ScikitBuildSettings(editable=EditableSettings(rebuild=True)),
+        use_start=False,
+        install_prefix=install_prefix,
+    )
+
+    redirect = files["_editable_skbc_pkg.py"].decode()
+    # The compiled module is referenced by its absolute build-tree path ...
+    assert repr(str(mod)) in redirect
+    # ... and the install prefix passed to the redirect is the build tree, not a
+    # site-packages-relative value.
+    assert repr(install_prefix) in redirect
+
+
 def test_editable_redirect_files_legacy_pth(tmp_path: Path):
     files = editable_redirect_files(
         libdir=tmp_path,

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -1129,6 +1129,27 @@ def test_skbuild_override_renamed_fail(
         SettingsReader.from_file(pyproject_toml)
 
 
+@pytest.mark.parametrize(
+    "trigger", ["editable.rebuild = true", 'editable.rebuild-dir = "tree"']
+)
+def test_editable_rebuild_requires_build_dir(tmp_path: Path, trigger: str):
+    # Both rebuild triggers require build-dir; rebuild-dir alone activates the
+    # rebuild path, so it must be validated like rebuild (PR #1375 review).
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            f"""\
+            [tool.scikit-build]
+            {trigger}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml)
+
+
 def test_skbuild_override_static(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Alternative to #1342. Instead of reconfiguring CMake on every editable rebuild, this bakes the install variables at their final location when the editable wheel is first built, so rebuilds need no reconfigure at all.

## Problem

With `editable.rebuild = true`, importing the package rebuilds and re-installs via the redirect shim, which runs `cmake --install . --prefix <site-packages>`. But CMake **silently ignores `--prefix`** for install rules whose `DESTINATION` is absolute, e.g. `install(TARGETS ... DESTINATION ${SKBUILD_PLATLIB_DIR}/...)`.

scikit-build-core baked `SKBUILD_PLATLIB_DIR` (and the other `SKBUILD_*_DIR` cache variables) into the CMake cache pointing at the *temporary* wheel-staging directory used during the initial build. That directory is deleted afterwards, so on rebuild the install writes back to the (now nonexistent / stale) temp path and the refreshed `.so` never reaches its target. The running process keeps using the old shared object, so source changes don't take effect.

## Approach (Option B)

#1342 fixed this by doing an in-place reconfigure on **every** rebuild to re-point the destinations. That's correct but pays a reconfigure cost on each import-triggered rebuild.

This PR instead uses the fact that `editable.rebuild = true` already requires a persistent `build-dir` (pip deletes the isolated one). That persistent directory *is* the non-removable spot:

- A rebuildable redirect editable installs the platlib into a persistent tree inside the build directory (`build-dir/install/<targetlib>`) instead of the temporary wheel-staging dir.
- `SKBUILD_<targetlib>_DIR` and `CMAKE_INSTALL_PREFIX` are baked at that final location **at first configure**.
- The redirecting finder references the compiled artifacts there by **absolute path**, so nothing is copied into site-packages.
- On rebuild, the shim runs `cmake --build` + `cmake --install` with the cached prefix already correct — **no reconfigure**, including for projects that install to an absolute `${SKBUILD_PLATLIB_DIR}/...` destination.

The redirect shim (`resources/_editable_redirect.py`) needed no changes: it already resolves absolute `known_wheel_files` / `known_directories` / `install_dir` correctly.

The other wheel schemes (`data`, `headers`, `scripts`, `metadata`) still stage into the wheel as before, so pip places them into the environment.

## `editable.rebuild-dir` — a parallel trigger for comparison

To evaluate this "persistent tree" idea against the original system on equal footing, this PR also adds an opt-in `editable.rebuild-dir` setting:

- Setting it installs the rebuildable editable into a **user-chosen** tree and **turns on rebuild-on-import by itself** — the `editable.rebuild` flag is ignored when it is set.
- It accepts the same template substitutions as `build-dir` (e.g. `rebuild_tree/{wheel_tag}`) and must be an absolute (or source-relative) path that is stable between build and run time, since it is baked into the CMake cache at configure time and referenced by absolute path on rebuild.
- It relocates **only** the install tree; `build-dir` is still required and still hosts the CMake build the rebuild re-runs.

This is a *parallel* path: the classic `editable.rebuild` (install tree inside `build-dir`) is left untouched, so the previous and new layouts can be compared directly. This is why we can't simply auto-detect site-packages here — it isn't known at configure time (the build runs in an isolated env producing a relocatable wheel; pip chooses the install location only afterward). A user-named path sidesteps that by being known at configure time and stable at runtime.

## Behavior change

For a rebuildable editable, compiled artifacts are now loaded from the persistent tree rather than from copies in site-packages. Deleting that tree (or `build-dir`) breaks the install — but a rebuildable editable already depended on `build-dir`. Non-rebuild editables and all other builds are unchanged (the gate keeps the platlib target at the staging dir).

## Testing

- New unit tests for the absolute-path variants of `libdir_to_installed` / `collect_search_locations`, a finder test resolving an external install tree, and an `editable_redirect_files` test asserting absolute paths and the baked rebuild prefix.
- `editable.rebuild-dir`: a unit test asserting it activates the rebuild path on its own (trips the absolute-`install-dir` guard with `rebuild = false`), and an integration test (`test_editable_rebuild_dir`) asserting it relocates the install tree, keeps site-packages clean, and triggers a rebuild that resolves to the rebuild-dir copy.
- Rewrote `tests/test_editable.py::test_install_dir` to the new contract: the compiled module lives in the build tree (honoring `wheel.install-dir`), resolves there on import, refreshes in place, and nothing lands in site-packages.
- Full editable suites pass; ruff + mypy clean.

Fixes #1135
