### PR TITLE
feat: add env table for build environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ search.site-packages = true
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
 
-# A table of environment variables to set for the CMake subprocesses. Additive.
+# A table of environment variables to set for the CMake subprocesses.
 env = {}
 
 # Strictly check all config options.

--- a/README.md
+++ b/README.md
@@ -177,9 +177,6 @@ cmake.source-dir = "."
 # Do not pass the current environment's python hints such as ``Python_EXECUTABLE``.
 cmake.python-hints = true
 
-# Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
-cmake.use-sysconfig-compiler = true
-
 # The versions of Ninja to allow.
 ninja.version = ">=1.5"
 
@@ -293,6 +290,9 @@ search.site-packages = true
 
 # List dynamic metadata fields and hook locations in this table.
 metadata = {}
+
+# A table of environment variables to set for the CMake subprocesses. Additive.
+env = {}
 
 # Strictly check all config options.
 strict-config = true

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -638,6 +638,86 @@ You can pass raw arguments directly to the build tool, as well:
 
 ```
 
+## Environment variables for the build
+
+The `[tool.scikit-build.env]` table sets environment variables for the CMake
+configure, build, and install subprocesses. Use it for things CMake or the
+generator read _from the environment_ — `CC`/`CXX`, `CFLAGS`,
+`CMAKE_PREFIX_PATH`, compiler launchers, parallel-build level, and so on. For
+CMake `-D` cache entries, use `cmake.define` instead.
+
+Each value is a literal string, or a table that reads from another environment
+variable (`{ env = "OTHER", default = "..." }`). By default a variable is only
+set if it is not already present (`setdefault`); add `force = true` to overwrite
+an existing value. If a value resolves to nothing (its `env` source is unset and
+there is no `default`), the key is skipped. This pairs well with
+`[[tool.scikit-build.overrides]]` for platform- or state-specific values.
+
+```toml
+[tool.scikit-build.env]
+SOME_VAR = "some-value"
+CMAKE_PREFIX_PATH = { env = "CMAKE_PREFIX_PATH", default = "/opt/mydeps" }
+```
+
+A common use is forwarding a project's historical parallelism variable (such as
+`MAX_JOBS`) to `CMAKE_BUILD_PARALLEL_LEVEL`:
+
+```toml
+[tool.scikit-build.env]
+CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
+```
+
+A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
+`setdefault` semantics unless `force = true` is given.
+
+```{note}
+This table is independent of the `if.env` override _condition_. `if.env` only
+matches against the ambient process environment and does not see variables you
+define here.
+```
+
+The table form (`{ env = ..., default = ..., force = ... }`) is `pyproject.toml`
+only; via config-settings or `SKBUILD_ENV_*` you can only set a literal value.
+
+### Selecting a compiler
+
+To pick a specific compiler — for example, to use GCC instead of MSVC on a
+Windows runner — set `CC`/`CXX`, optionally scoped to a platform with an
+override:
+
+```toml
+[[tool.scikit-build.overrides]]
+if.platform-system = "win32"
+env.CC = "gcc"
+env.CXX = "g++"
+```
+
+These take precedence over the compiler scikit-build-core would otherwise pull
+from Python's `sysconfig`, even without `force`.
+
+By default, scikit-build-core sets `CC`/`CXX` from Python's `sysconfig` compiler
+when they are not already set. If a project's compiler probes break on that
+compiler (a conda narrow sysroot, a stale venv gcc, a cross or oneAPI
+toolchain), list the variable in the `env` table to suppress that default and
+let CMake detect the compiler from `PATH` — an entry that reads from the same
+name does this without pinning a value:
+
+```toml
+[tool.scikit-build.env]
+CC = { env = "CC" }
+CXX = { env = "CXX" }
+```
+
+### Search paths for dependencies
+
+To point CMake at extra prefixes (vcpkg, Homebrew, a custom install tree) when
+locating dependencies, set `CMAKE_PREFIX_PATH`:
+
+```toml
+[tool.scikit-build.env]
+CMAKE_PREFIX_PATH = "/opt/mydeps;/usr/local"
+```
+
 ## Editable installs
 
 Support for editable installs is provided, with some caveats and configuration.

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -33,7 +33,7 @@ to run in parallel with the number of cores on your machine.
 
 If your project has historically used a different environment variable (such as
 `MAX_JOBS`) to control this, you can forward it to `CMAKE_BUILD_PARALLEL_LEVEL`
-with the `[tool.scikit-build.env]` table instead of wrapping the build backend:
+with the `[tool.scikit-build.env]` table:
 
 ```toml
 [tool.scikit-build.env]
@@ -41,66 +41,9 @@ CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
 ```
 
 A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
-`setdefault` semantics unless `force = true` is given.
-
-## Setting environment variables for the build
-
-The `[tool.scikit-build.env]` table sets environment variables for the CMake
-configure, build, and install subprocesses. Use it for things CMake or the
-generator read _from the environment_ — `CC`/`CXX`, `CFLAGS`,
-`CMAKE_PREFIX_PATH`, compiler launchers, parallel-build level, and so on. For
-CMake `-D` cache entries, use `cmake.define` instead.
-
-Each value is a literal string, or a table that reads from another environment
-variable (`{ env = "OTHER", default = "..." }`). By default a variable is only
-set if it is not already present (`setdefault`); add `force = true` to overwrite
-an existing value. This pairs well with `[[tool.scikit-build.overrides]]` for
-platform- or state-specific values.
-
-```{note}
-This table is independent of the `if.env` override _condition_. `if.env` only
-matches against the ambient process environment and does not see variables you
-define here.
-```
-
-### Selecting a compiler
-
-To pick a specific compiler — for example, to use GCC instead of MSVC on a
-Windows runner — set `CC`/`CXX`, optionally scoped to a platform with an
-override:
-
-```toml
-[[tool.scikit-build.overrides]]
-if.platform-system = "win32"
-env.CC = "gcc"
-env.CXX = "g++"
-```
-
-These take precedence over the compiler scikit-build-core would otherwise pull
-from Python's `sysconfig`, even without `force`.
-
-By default, scikit-build-core sets `CC`/`CXX` from Python's `sysconfig` compiler
-when they are not already set. If a project's compiler probes break on that
-compiler (a conda narrow sysroot, a stale venv gcc, a cross or oneAPI
-toolchain), list the variable in the `env` table to suppress that default and
-let CMake detect the compiler from `PATH` — an entry that reads from the same
-name does this without pinning a value:
-
-```toml
-[tool.scikit-build.env]
-CC = { env = "CC" }
-CXX = { env = "CXX" }
-```
-
-### Search paths for dependencies
-
-To point CMake at extra prefixes (vcpkg, Homebrew, a custom install tree) when
-locating dependencies, set `CMAKE_PREFIX_PATH`:
-
-```toml
-[tool.scikit-build.env]
-CMAKE_PREFIX_PATH = "/opt/mydeps;/usr/local"
-```
+`setdefault` semantics unless `force = true` is given. See
+[](../configuration/index.md#environment-variables-for-the-build) for the full
+`env` table reference, including selecting a compiler and setting search paths.
 
 ## Dynamic setup.py options
 

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -31,6 +31,77 @@ CMAKE_BUILD_PARALLEL_LEVEL=8 pip install .
 The default generator on Unix-like platforms is Ninja, which automatically tries
 to run in parallel with the number of cores on your machine.
 
+If your project has historically used a different environment variable (such as
+`MAX_JOBS`) to control this, you can forward it to `CMAKE_BUILD_PARALLEL_LEVEL`
+with the `[tool.scikit-build.env]` table instead of wrapping the build backend:
+
+```toml
+[tool.scikit-build.env]
+CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
+```
+
+A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
+`setdefault` semantics unless `force = true` is given.
+
+## Setting environment variables for the build
+
+The `[tool.scikit-build.env]` table sets environment variables for the CMake
+configure, build, and install subprocesses. Use it for things CMake or the
+generator read _from the environment_ — `CC`/`CXX`, `CFLAGS`,
+`CMAKE_PREFIX_PATH`, compiler launchers, parallel-build level, and so on. For
+CMake `-D` cache entries, use `cmake.define` instead.
+
+Each value is a literal string, or a table that reads from another environment
+variable (`{ env = "OTHER", default = "..." }`). By default a variable is only
+set if it is not already present (`setdefault`); add `force = true` to overwrite
+an existing value. This pairs well with `[[tool.scikit-build.overrides]]` for
+platform- or state-specific values.
+
+```{note}
+This table is independent of the `if.env` override _condition_. `if.env` only
+matches against the ambient process environment and does not see variables you
+define here.
+```
+
+### Selecting a compiler
+
+To pick a specific compiler — for example, to use GCC instead of MSVC on a
+Windows runner — set `CC`/`CXX`, optionally scoped to a platform with an
+override:
+
+```toml
+[[tool.scikit-build.overrides]]
+if.platform-system = "win32"
+env.CC = "gcc"
+env.CXX = "g++"
+```
+
+These take precedence over the compiler scikit-build-core would otherwise pull
+from Python's `sysconfig`, even without `force`.
+
+By default, scikit-build-core sets `CC`/`CXX` from Python's `sysconfig` compiler
+when they are not already set. If a project's compiler probes break on that
+compiler (a conda narrow sysroot, a stale venv gcc, a cross or oneAPI
+toolchain), list the variable in the `env` table to suppress that default and
+let CMake detect the compiler from `PATH` — an entry that reads from the same
+name does this without pinning a value:
+
+```toml
+[tool.scikit-build.env]
+CC = { env = "CC" }
+CXX = { env = "CXX" }
+```
+
+### Search paths for dependencies
+
+To point CMake at extra prefixes (vcpkg, Homebrew, a custom install tree) when
+locating dependencies, set `CMAKE_PREFIX_PATH`:
+
+```toml
+[tool.scikit-build.env]
+CMAKE_PREFIX_PATH = "/opt/mydeps;/usr/local"
+```
+
 ## Dynamic setup.py options
 
 While we will eventually have some dynamic options, most common needs can be

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -71,6 +71,41 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: env
+
+  :Type: ``dict[str,EnvValue]``
+  :Config-settings: ``env`` or ``skbuild.env``
+  :Environment variable: ``SKBUILD_ENV``
+
+  A table of environment variables to set for the CMake subprocesses. Additive.
+
+  These are applied to the CMake configure, build, and install steps. By
+  default a variable is only set if it is not already present in the
+  environment (like a ``setdefault``); pass ``force = true`` to overwrite an
+  existing value. Each value is either a literal string or a table with
+  ``env`` (read the value from another environment variable), ``default`` (the
+  value to use, or the fallback when ``env`` is unset), and ``force``. An entry
+  that resolves to nothing (an unset source ``env`` with no ``default``) is
+  skipped.
+
+  This is independent of the ``if.env`` override condition: ``if.env`` only
+  matches against the ambient process environment and never sees variables
+  defined here.
+
+  For example, to forward a ``MAX_JOBS``-style variable to the
+  generator-agnostic parallel-build control::
+
+      [tool.scikit-build.env]
+      CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
+
+  By default scikit-build-core sets ``CC``/``CXX`` from Python's ``sysconfig``
+  compiler when they are not already set. Listing ``CC`` or ``CXX`` here
+  suppresses that default for the listed variable, even when the entry resolves
+  to nothing -- so ``CC = { env = "CC" }`` lets CMake pick the compiler from
+  ``PATH`` instead.
+```
+
+```{eval-rst}
 .. confval:: experimental
 
   :Type: ``bool``
@@ -336,24 +371,6 @@ print(mk_skbuild_docs())
   The CMAKE_TOOLCHAIN_FILE / --toolchain used for cross-compilation.
 
   This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
-```
-
-```{eval-rst}
-.. confval:: cmake.use-sysconfig-compiler
-
-  :Type: ``bool``
-  :Default: true
-  :Config-settings: ``cmake.use-sysconfig-compiler`` or ``skbuild.cmake.use-sysconfig-compiler``
-  :Environment variable: ``SKBUILD_CMAKE_USE_SYSCONFIG_COMPILER``
-
-  Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
-  environment.
-
-  When ``false``, scikit-build-core will not set these, letting CMake pick the
-  compiler from ``PATH``. This is useful for projects whose compiler probes
-  (e.g. ``FindBLAS``, ``FindOpenMP``) break on the sysconfig compiler, such as a
-  conda narrow sysroot or a stale venv gcc. A user-set ``CC``/``CXX`` in the
-  environment is always respected regardless of this setting.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -77,32 +77,14 @@ print(mk_skbuild_docs())
   :Config-settings: ``env`` or ``skbuild.env``
   :Environment variable: ``SKBUILD_ENV``
 
-  A table of environment variables to set for the CMake subprocesses. Additive.
+  A table of environment variables to set for the CMake subprocesses.
 
-  These are applied to the CMake configure, build, and install steps. By
-  default a variable is only set if it is not already present in the
-  environment (like a ``setdefault``); pass ``force = true`` to overwrite an
-  existing value. Each value is either a literal string or a table with
-  ``env`` (read the value from another environment variable), ``default`` (the
-  value to use, or the fallback when ``env`` is unset), and ``force``. An entry
-  that resolves to nothing (an unset source ``env`` with no ``default``) is
-  skipped.
-
-  This is independent of the ``if.env`` override condition: ``if.env`` only
-  matches against the ambient process environment and never sees variables
-  defined here.
-
-  For example, to forward a ``MAX_JOBS``-style variable to the
-  generator-agnostic parallel-build control::
-
-      [tool.scikit-build.env]
-      CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
-
-  By default scikit-build-core sets ``CC``/``CXX`` from Python's ``sysconfig``
-  compiler when they are not already set. Listing ``CC`` or ``CXX`` here
-  suppresses that default for the listed variable, even when the entry resolves
-  to nothing -- so ``CC = { env = "CC" }`` lets CMake pick the compiler from
-  ``PATH`` instead.
+  Applied to the configure, build, and install steps. A variable is only set if
+  not already present (like a ``setdefault``); pass ``force = true`` to
+  overwrite. Each value is a literal string or a table with ``env`` (read from
+  another environment variable), ``default``, and ``force``; an entry that
+  resolves to nothing is skipped. Independent of the ``if.env`` override
+  condition.
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -36,6 +36,7 @@ __all__ = [
     "archs_to_tags",
     "get_archs",
     "get_cmake_args_from_settings",
+    "set_environment_from_settings",
 ]
 
 DIR = Path(__file__).parent.resolve()
@@ -116,6 +117,24 @@ def get_cmake_args_from_settings(
     return [*settings.cmake.args, *_filter_env_cmake_args(env_cmake_args)]
 
 
+def set_environment_from_settings(
+    env: dict[str, str], settings: ScikitBuildSettings
+) -> None:
+    """
+    Apply the ``tool.scikit-build.env`` table to ``env`` (mutated in place).
+
+    Each entry is resolved against ``env`` and written back unless it is already
+    set (``setdefault`` semantics), with ``force = true`` overriding. Entries
+    that resolve to nothing are skipped.
+    """
+    for name, value in settings.env.items():
+        resolved = value.resolve(env)
+        if resolved is None:
+            continue
+        if value.force or name not in env:
+            env[name] = resolved
+
+
 def _sanitize_path(path: Any) -> list[Path]:
     # This handles classes like:
     # MultiplexedPath from importlib.resources.readers (3.11+)
@@ -132,6 +151,12 @@ def _sanitize_path(path: Any) -> list[Path]:
 class Builder:
     settings: ScikitBuildSettings
     config: CMaker
+
+    def __post_init__(self) -> None:
+        # Apply the user's env table before configure/build/install so it is
+        # visible to all CMake subprocesses (which share ``config.env``).
+        if self.settings.env:
+            set_environment_from_settings(self.config.env, self.settings)
 
     def get_cmake_args(self) -> list[str]:
         """
@@ -217,7 +242,7 @@ class Builder:
             self.config.cmake,
             self.config.env,
             self.settings.ninja,
-            use_sysconfig_compiler=self.settings.cmake.use_sysconfig_compiler,
+            env_managed_keys=self.settings.env.keys(),
         )
         cmake_defines.update(local_def)
 

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -13,7 +13,7 @@ from ..program_search import best_program, get_make_programs, get_ninja_programs
 from .sysconfig import get_cmake_platform
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, MutableMapping
+    from collections.abc import Collection, Iterable, Mapping, MutableMapping
 
     from ..cmake import CMake
     from ..settings.skbuild_model import NinjaSettings
@@ -100,7 +100,7 @@ def set_environment_for_gen(
     env: MutableMapping[str, str],
     ninja_settings: NinjaSettings,
     *,
-    use_sysconfig_compiler: bool = True,
+    env_managed_keys: Collection[str] = (),
 ) -> Mapping[str, str]:
     """
     This function modifies the environment as needed to safely set a generator.
@@ -134,19 +134,19 @@ def set_environment_for_gen(
     # Set Python's recommended CC and CXX if not already set by the user. Only
     # the executable is kept; sysconfig may append flags (e.g. "c++ -pthread"),
     # which would otherwise leak into tools like autotools sub-builds. CMake adds
-    # any flags it needs itself. See #1330. This can be disabled with
-    # cmake.use-sysconfig-compiler for projects whose compiler probes break on
-    # the sysconfig compiler. See #1367.
-    if use_sysconfig_compiler:
-        if "CC" not in env:
-            cc = sysconfig.get_config_var("CC")
-            if cc:
-                env["CC"] = shlex.split(cc)[0]
+    # any flags it needs itself. See #1330. A key the user manages via the
+    # ``env`` table is left alone (even when it resolves to nothing), letting
+    # CMake pick the compiler from ``PATH`` for projects whose compiler probes
+    # break on the sysconfig compiler. See #1367.
+    if "CC" not in env and "CC" not in env_managed_keys:
+        cc = sysconfig.get_config_var("CC")
+        if cc:
+            env["CC"] = shlex.split(cc)[0]
 
-        if "CXX" not in env:
-            cxx = sysconfig.get_config_var("CXX")
-            if cxx:
-                env["CXX"] = shlex.split(cxx)[0]
+    if "CXX" not in env and "CXX" not in env_managed_keys:
+        cxx = sysconfig.get_config_var("CXX")
+        if cxx:
+            env["CXX"] = shlex.split(cxx)[0]
 
     if "Ninja" in (generator or "Ninja"):
         ninja = best_program(get_ninja_programs(), version=ninja_settings.version)

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -108,11 +108,6 @@
           "type": "boolean",
           "default": true,
           "description": "Do not pass the current environment's python hints such as ``Python_EXECUTABLE``."
-        },
-        "use-sysconfig-compiler": {
-          "type": "boolean",
-          "default": true,
-          "description": "Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the"
         }
       }
     },
@@ -522,6 +517,36 @@
         }
       }
     },
+    "env": {
+      "type": "object",
+      "patternProperties": {
+        ".+": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "default": {
+                  "type": "string"
+                },
+                "force": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      },
+      "description": "A table of environment variables to set for the CMake subprocesses. Additive."
+    },
     "strict-config": {
       "type": "boolean",
       "default": true,
@@ -693,6 +718,9 @@
           },
           "metadata": {
             "$ref": "#/properties/metadata"
+          },
+          "env": {
+            "$ref": "#/properties/env"
           },
           "strict-config": {
             "$ref": "#/properties/strict-config"

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -545,7 +545,7 @@
           ]
         }
       },
-      "description": "A table of environment variables to set for the CMake subprocesses. Additive."
+      "description": "A table of environment variables to set for the CMake subprocesses."
     },
     "strict-config": {
       "type": "boolean",

--- a/src/scikit_build_core/settings/json_schema.py
+++ b/src/scikit_build_core/settings/json_schema.py
@@ -67,6 +67,25 @@ def to_json_schema(dclass: type[Any], *, normalize_keys: bool) -> dict[str, Any]
                 }
                 props[field.name] = full
                 continue
+            if get_args(field.type)[1] == "EnvTable":
+                # Each value is a literal string or a table reading from another
+                # environment variable, with an optional ``force`` overwrite.
+                table_branch = {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "env": {"type": "string", "minLength": 1},
+                        "default": {"type": "string"},
+                        "force": {"type": "boolean", "default": False},
+                    },
+                }
+                props[field.name] = {
+                    "type": "object",
+                    "patternProperties": {
+                        ".+": {"oneOf": [{"type": "string"}, table_branch]}
+                    },
+                }
+                continue
             msg = "Only EnvVar is supported for Annotated"
             raise FailedConversionError(msg)
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -678,32 +678,14 @@ class ScikitBuildSettings:
         default_factory=dict
     )
     """
-    A table of environment variables to set for the CMake subprocesses. Additive.
+    A table of environment variables to set for the CMake subprocesses.
 
-    These are applied to the CMake configure, build, and install steps. By
-    default a variable is only set if it is not already present in the
-    environment (like a ``setdefault``); pass ``force = true`` to overwrite an
-    existing value. Each value is either a literal string or a table with
-    ``env`` (read the value from another environment variable), ``default`` (the
-    value to use, or the fallback when ``env`` is unset), and ``force``. An entry
-    that resolves to nothing (an unset source ``env`` with no ``default``) is
-    skipped.
-
-    This is independent of the ``if.env`` override condition: ``if.env`` only
-    matches against the ambient process environment and never sees variables
-    defined here.
-
-    For example, to forward a ``MAX_JOBS``-style variable to the
-    generator-agnostic parallel-build control::
-
-        [tool.scikit-build.env]
-        CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
-
-    By default scikit-build-core sets ``CC``/``CXX`` from Python's ``sysconfig``
-    compiler when they are not already set. Listing ``CC`` or ``CXX`` here
-    suppresses that default for the listed variable, even when the entry resolves
-    to nothing -- so ``CC = { env = "CC" }`` lets CMake pick the compiler from
-    ``PATH`` instead.
+    Applied to the configure, build, and install steps. A variable is only set if
+    not already present (like a ``setdefault``); pass ``force = true`` to
+    overwrite. Each value is a literal string or a table with ``env`` (read from
+    another environment variable), ``default``, and ``force``; an entry that
+    resolves to nothing is skipped. Independent of the ``if.env`` override
+    condition.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -13,6 +13,7 @@ __all__ = [
     "CMakeSettings",
     "CMakeSettingsDefine",
     "EditableSettings",
+    "EnvValue",
     "GenerateSettings",
     "InstallSettings",
     "LoggingSettings",
@@ -59,6 +60,68 @@ class CMakeSettingsDefine(str):
             value = raw
 
         return super().__new__(cls, value)
+
+
+class EnvValue:
+    """
+    A single entry in the top-level ``env`` table.
+
+    Accepts either a literal string or a table with ``env`` / ``default`` /
+    ``force`` keys. Resolution against the build environment is deferred to
+    :meth:`resolve` so that the ``force`` flag survives parsing (unlike the
+    ``cmake.define`` ``EnvVar`` form, which resolves at parse time). A bare
+    string is shorthand for ``{ default = "<string>" }``.
+    """
+
+    __slots__ = ("default", "env", "force")
+
+    def __init__(self, raw: Union[str, Dict[str, Any]]) -> None:
+        self.env: Optional[str] = None
+        self.default: Optional[str] = None
+        self.force: bool = False
+
+        if isinstance(raw, str):
+            self.default = raw
+            return
+        if not isinstance(raw, dict):
+            msg = f"Expected str or table for an env value, got {type(raw).__name__}"
+            raise TypeError(msg)
+
+        extra = set(raw) - {"env", "default", "force"}
+        if extra:
+            msg = f"Unrecognized env table keys: {sorted(extra)}"
+            raise TypeError(msg)
+        self.env = raw.get("env")
+        self.default = raw.get("default")
+        self.force = bool(raw.get("force", False))
+
+    def resolve(self, env: Dict[str, str]) -> Optional[str]:
+        """
+        Resolve to the final string value (or ``None`` if unset) against ``env``.
+
+        ``env`` (if set) is looked up in the environment with ``default`` as the
+        fallback. ``None`` means "leave the variable unset".
+        """
+        got = env.get(self.env, self.default) if self.env is not None else self.default
+        return None if got is None else str(got)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, EnvValue):
+            return NotImplemented
+        return (self.env, self.default, self.force) == (
+            other.env,
+            other.default,
+            other.force,
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.env, self.default, self.force))
+
+    def __repr__(self) -> str:
+        return (
+            f"EnvValue(env={self.env!r}, default={self.default!r}, "
+            f"force={self.force!r})"
+        )
 
 
 @dataclasses.dataclass
@@ -151,18 +214,6 @@ class CMakeSettings:
     Do not pass the current environment's python hints such as ``Python_EXECUTABLE``.
     Primarily used for cross-compilation where the CMAKE_TOOLCHAIN_FILE should handle it
     instead.
-    """
-
-    use_sysconfig_compiler: bool = True
-    """
-    Set ``CC``/``CXX`` from Python's sysconfig compiler when not already set in the
-    environment.
-
-    When ``false``, scikit-build-core will not set these, letting CMake pick the
-    compiler from ``PATH``. This is useful for projects whose compiler probes
-    (e.g. ``FindBLAS``, ``FindOpenMP``) break on the sysconfig compiler, such as a
-    conda narrow sysroot or a stale venv gcc. A user-set ``CC``/``CXX`` in the
-    environment is always respected regardless of this setting.
     """
 
 
@@ -605,6 +656,38 @@ class ScikitBuildSettings:
     metadata: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
     """
     List dynamic metadata fields and hook locations in this table.
+    """
+
+    env: Annotated[Dict[str, EnvValue], "EnvTable"] = dataclasses.field(
+        default_factory=dict
+    )
+    """
+    A table of environment variables to set for the CMake subprocesses. Additive.
+
+    These are applied to the CMake configure, build, and install steps. By
+    default a variable is only set if it is not already present in the
+    environment (like a ``setdefault``); pass ``force = true`` to overwrite an
+    existing value. Each value is either a literal string or a table with
+    ``env`` (read the value from another environment variable), ``default`` (the
+    value to use, or the fallback when ``env`` is unset), and ``force``. An entry
+    that resolves to nothing (an unset source ``env`` with no ``default``) is
+    skipped.
+
+    This is independent of the ``if.env`` override condition: ``if.env`` only
+    matches against the ambient process environment and never sees variables
+    defined here.
+
+    For example, to forward a ``MAX_JOBS``-style variable to the
+    generator-agnostic parallel-build control::
+
+        [tool.scikit-build.env]
+        CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
+
+    By default scikit-build-core sets ``CC``/``CXX`` from Python's ``sysconfig``
+    compiler when they are not already set. Listing ``CC`` or ``CXX`` here
+    suppresses that default for the listed variable, even when the entry resolves
+    to nothing -- so ``CC = { env = "CC" }`` lets CMake pick the compiler from
+    ``PATH`` instead.
     """
 
     strict_config: bool = True

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -91,9 +91,25 @@ class EnvValue:
         if extra:
             msg = f"Unrecognized env table keys: {sorted(extra)}"
             raise TypeError(msg)
-        self.env = raw.get("env")
-        self.default = raw.get("default")
-        self.force = bool(raw.get("force", False))
+
+        env = raw.get("env")
+        if env is not None and not isinstance(env, str):
+            msg = f"env table 'env' must be a string, got {type(env).__name__}"
+            raise TypeError(msg)
+        default = raw.get("default")
+        if default is not None and not isinstance(default, str):
+            msg = f"env table 'default' must be a string, got {type(default).__name__}"
+            raise TypeError(msg)
+        # Note: bool is an int subclass, so this rejects 0/1 as well as strings;
+        # the value must be a real TOML boolean (not coerced like ``bool("false")``).
+        force = raw.get("force", False)
+        if not isinstance(force, bool):
+            msg = f"env table 'force' must be a boolean, got {type(force).__name__}"
+            raise TypeError(msg)
+
+        self.env = env
+        self.default = default
+        self.force = force
 
     def resolve(self, env: Dict[str, str]) -> Optional[str]:
         """

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -771,11 +771,11 @@ def test_set_environment_for_gen_strips_cc_cxx_flags(
     assert env["CXX"] == "c++"
 
 
-def test_set_environment_for_gen_use_sysconfig_compiler(
+def test_set_environment_for_gen_sysconfig_compiler(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    # With use_sysconfig_compiler=True (default), CC/CXX from sysconfig are
-    # injected; with False they are left untouched. See #1367.
+    # By default CC/CXX from sysconfig are injected; a key managed via the env
+    # table suppresses that default, letting CMake detect the compiler. See #1367.
     from scikit_build_core.builder import generator as gen_mod
     from scikit_build_core.program_search import Program
     from scikit_build_core.settings.skbuild_model import NinjaSettings
@@ -791,7 +791,6 @@ def test_set_environment_for_gen_use_sysconfig_compiler(
         CMake(Version("3.30"), Path("cmake")),
         env_default,
         NinjaSettings(),
-        use_sysconfig_compiler=True,
     )
     assert env_default["CC"] == "gcc"
     assert env_default["CXX"] == "c++"
@@ -802,7 +801,7 @@ def test_set_environment_for_gen_use_sysconfig_compiler(
         CMake(Version("3.30"), Path("cmake")),
         env_off,
         NinjaSettings(),
-        use_sysconfig_compiler=False,
+        env_managed_keys={"CC", "CXX"},
     )
     assert "CC" not in env_off
     assert "CXX" not in env_off
@@ -826,3 +825,77 @@ def test_set_environment_for_gen_ninja_multi_config_missing(
             {},
             NinjaSettings(),
         )
+
+
+def _settings_with_env(env: dict[str, typing.Any]) -> ScikitBuildSettings:
+    from scikit_build_core.settings.skbuild_model import EnvValue
+
+    return ScikitBuildSettings(env={k: EnvValue(v) for k, v in env.items()})
+
+
+def test_set_environment_from_settings_setdefault():
+    from scikit_build_core.builder.builder import set_environment_from_settings
+
+    settings = _settings_with_env(
+        {
+            "LITERAL": "hello",
+            "CMAKE_BUILD_PARALLEL_LEVEL": {"env": "MAX_JOBS"},
+            "WITH_DEFAULT": {"env": "NOT_SET", "default": "fallback"},
+        }
+    )
+    # MAX_JOBS provides the value; an already-set target var is preserved.
+    env = {"MAX_JOBS": "7", "CMAKE_BUILD_PARALLEL_LEVEL": "keep"}
+    set_environment_from_settings(env, settings)
+
+    assert env["LITERAL"] == "hello"
+    assert env["CMAKE_BUILD_PARALLEL_LEVEL"] == "keep"
+    assert env["WITH_DEFAULT"] == "fallback"
+
+
+def test_set_environment_from_settings_max_jobs_alias():
+    """Regression for the PyTorch wrapper: MAX_JOBS -> CMAKE_BUILD_PARALLEL_LEVEL."""
+    from scikit_build_core.builder.builder import set_environment_from_settings
+
+    settings = _settings_with_env({"CMAKE_BUILD_PARALLEL_LEVEL": {"env": "MAX_JOBS"}})
+
+    env = {"MAX_JOBS": "3"}
+    set_environment_from_settings(env, settings)
+    assert env["CMAKE_BUILD_PARALLEL_LEVEL"] == "3"
+
+    # No MAX_JOBS and no default -> the variable is left unset.
+    env_empty: dict[str, str] = {}
+    set_environment_from_settings(env_empty, settings)
+    assert "CMAKE_BUILD_PARALLEL_LEVEL" not in env_empty
+
+
+def test_set_environment_from_settings_force():
+    from scikit_build_core.builder.builder import set_environment_from_settings
+
+    settings = _settings_with_env(
+        {
+            "SOFT": "soft-value",
+            "HARD": {"default": "hard-value", "force": True},
+        }
+    )
+    env = {"SOFT": "existing", "HARD": "existing"}
+    set_environment_from_settings(env, settings)
+
+    assert env["SOFT"] == "existing"
+    assert env["HARD"] == "hard-value"
+
+
+def test_builder_applies_env_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Builder construction applies the env table to the shared CMaker env."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MAX_JOBS", "5")
+    monkeypatch.delenv("CMAKE_BUILD_PARALLEL_LEVEL", raising=False)
+
+    builder = Builder(
+        settings=_settings_with_env(
+            {"CMAKE_BUILD_PARALLEL_LEVEL": {"env": "MAX_JOBS"}}
+        ),
+        config=CMaker(
+            CMake(Version("4.0"), Path("no-cmake")), Path(), Path(), "Release"
+        ),
+    )
+    assert builder.config.env["CMAKE_BUILD_PARALLEL_LEVEL"] == "5"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -67,6 +67,8 @@ def test_valid_schemas_files(filepath: Path) -> None:
         {"metadata": {"invalid": {"provider": "correct"}}},
         {"cmake": {"define": {"FOO": {"env": ""}}}},
         {"cmake": {"define": {"FOO": {"default": False}}}},
+        {"env": {"FOO": {"unknown": "x"}}},
+        {"env": {"FOO": {"force": "not-a-bool"}}},
     ],
 )
 def test_invalid_schemas(addition: dict[str, Any]) -> None:
@@ -109,6 +111,10 @@ def test_invalid_schemas(addition: dict[str, Any]) -> None:
         {"cmake": {"define": {"FOO": "BAR"}}},
         {"cmake": {"define": {"FOO": {"env": "FOO"}}}},
         {"cmake": {"define": {"FOO": {"env": "FOO", "default": False}}}},
+        {"env": {"FOO": "bar"}},
+        {"env": {"CMAKE_BUILD_PARALLEL_LEVEL": {"env": "MAX_JOBS"}}},
+        {"env": {"FOO": {"env": "BAR", "default": "baz"}}},
+        {"env": {"FOO": {"default": "bar", "force": True}}},
     ],
 )
 def test_valid_schemas(addition: dict[str, Any]) -> None:

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -12,6 +12,7 @@ from packaging.version import Version
 
 import scikit_build_core._logging
 import scikit_build_core.settings.skbuild_read_settings
+from scikit_build_core._compat.builtins import ExceptionGroup
 from scikit_build_core.settings.skbuild_model import EnvValue, GenerateSettings
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
@@ -105,6 +106,44 @@ def test_skbuild_settings_env_table(tmp_path: Path):
     }
     assert env["FORCED"].force
     assert not env["LITERAL"].force
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"force": "false"},
+        {"force": 1},
+        {"default": 8},
+        {"env": True},
+        {"unknown": "x"},
+    ],
+)
+def test_env_value_rejects_bad_types(raw: object):
+    """Wrong TOML types are rejected at conversion, not silently coerced.
+
+    Notably ``force = "false"`` must not coerce to ``True`` via ``bool(...)``.
+    """
+    from scikit_build_core.settings.skbuild_model import EnvValue
+
+    with pytest.raises(TypeError):
+        EnvValue(raw)  # type: ignore[arg-type]
+
+
+def test_skbuild_settings_env_table_bad_force_rejected(tmp_path: Path):
+    """A malformed env table in pyproject.toml errors instead of coercing."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build.env]
+            FOO = { default = "x", force = "false" }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExceptionGroup):
+        SettingsReader.from_file(pyproject_toml, {})
 
 
 def test_skbuild_settings_cmake_build_type_envvar(

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 
 import scikit_build_core._logging
 import scikit_build_core.settings.skbuild_read_settings
-from scikit_build_core.settings.skbuild_model import GenerateSettings
+from scikit_build_core.settings.skbuild_model import EnvValue, GenerateSettings
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
 
@@ -36,7 +36,6 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert not settings.build.verbose
     assert settings.cmake.build_type == "Release"
     assert settings.cmake.source_dir == Path()
-    assert settings.cmake.use_sysconfig_compiler
     assert settings.build.targets == []
     assert settings.logging.level == "WARNING"
     assert settings.sdist.include == []
@@ -60,6 +59,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert settings.minimum_version is None
     assert settings.build_dir == ""
     assert settings.metadata == {}
+    assert settings.env == {}
     assert settings.sdist.force_include == {}
     assert settings.wheel.force_include == {}
     assert settings.editable.mode == "redirect"
@@ -73,6 +73,38 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert not settings.fail
     assert settings.messages.after_failure == ""
     assert settings.messages.after_success == ""
+
+
+def test_skbuild_settings_env_table(tmp_path: Path):
+    """The top-level env table parses literal, env-indirection, and force forms."""
+    from scikit_build_core.settings.skbuild_model import EnvValue
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build.env]
+            LITERAL = "hello"
+            CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
+            WITH_DEFAULT = { env = "NOT_SET", default = "fallback" }
+            FORCED = { default = "forced", force = true }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    env = settings_reader.settings.env
+
+    assert env == {
+        "LITERAL": EnvValue("hello"),
+        "CMAKE_BUILD_PARALLEL_LEVEL": EnvValue({"env": "MAX_JOBS"}),
+        "WITH_DEFAULT": EnvValue({"env": "NOT_SET", "default": "fallback"}),
+        "FORCED": EnvValue({"default": "forced", "force": True}),
+    }
+    assert env["FORCED"].force
+    assert not env["LITERAL"].force
 
 
 def test_skbuild_settings_cmake_build_type_envvar(
@@ -232,7 +264,7 @@ def test_skbuild_settings_config_settings(
         "cmake.define.b": "2",
         "cmake.build-type": "Debug",
         "cmake.source-dir": "a/b/c",
-        "cmake.use-sysconfig-compiler": "false",
+        "env.SOME_VAR": "some-value",
         "logging.level": "INFO",
         "sdist.include": ["a", "b", "c"],
         "sdist.exclude": "d;e;f",
@@ -281,7 +313,7 @@ def test_skbuild_settings_config_settings(
     assert settings.build.verbose
     assert settings.cmake.build_type == "Debug"
     assert settings.cmake.source_dir == Path("a/b/c")
-    assert not settings.cmake.use_sysconfig_compiler
+    assert settings.env == {"SOME_VAR": EnvValue("some-value")}
     assert settings.logging.level == "INFO"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]
@@ -481,8 +513,8 @@ def test_skbuild_settings_pyproject_toml_broken(
         "you",
         "mean:",
         "tool.scikit-build.logging,",
-        "tool.scikit-build.generate,",
-        "tool.scikit-build.search?",
+        "tool.scikit-build.env,",
+        "tool.scikit-build.generate?",
     ]
 
 


### PR DESCRIPTION
This is very useful for PyTorch (avoiding a wrapper around us), but also solves several other issues. Also folded in #1370 using this mechanism.

:robot: _AI text below_ :robot:

## Summary

Adds a top-level `[tool.scikit-build.env]` table that sets environment variables for the CMake configure, build, and install subprocesses. This gives a config-native way to control things CMake/the generator read *from the environment* (`CMAKE_BUILD_PARALLEL_LEVEL`, `CC`/`CXX`, `CFLAGS`, `CMAKE_PREFIX_PATH`, compiler launchers, …) — for `-D` cache entries, `cmake.define` is still the tool.

Motivated by pytorch/pytorch#180247, which currently wraps scikit-build-core with a custom PEP 517 backend solely to map `MAX_JOBS` → `CMAKE_BUILD_PARALLEL_LEVEL`. With this table that wrapper can be deleted:

```toml
[tool.scikit-build.env]
CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
```

Also addresses the `CMAKE_PREFIX_PATH`/compiler pieces of #1367, and gives a config-native path for #822 (selecting a compiler).

## Semantics

Each value is a literal string, or a table with `env` (read another variable), `default` (fallback) / explicit literal), and `force`.

- **setdefault by default** — a variable already set in the environment is preserved.
- **`force = true`** — overwrite (CMake `set(... FORCE)` analogue).
- **skip when unresolved** — an unset source `env` with no `default` leaves the variable unset (so no `MAX_JOBS` → no `CMAKE_BUILD_PARALLEL_LEVEL`).

Works in `pyproject.toml`, config-settings (`-Cenv.FOO=bar`), `SKBUILD_ENV`, and `[[tool.scikit-build.overrides]]` bodies (merges per-key). The table form (`{ env = … }`, `force`) is TOML-only, matching `cmake.define`'s `EnvVar` form. It is independent of the `if.env` override *condition*, which only matches the ambient process environment.

## Folds in `cmake.use-sysconfig-compiler`

That setting is unreleased, so rather than ship it, its behavior moves into this table: listing `CC`/`CXX` in `env` suppresses the default sysconfig compiler injection (even when the entry resolves to nothing), so `CC = { env = "CC" }` defers to CMake's own detection. This is strictly more flexible — compiler choice can now be scoped per-platform/state via overrides, and `CC`/`CXX` controlled independently.

## Tests

- Settings parsing across TOML / config-settings / `SKBUILD_ENV`, including literal / `{ env, default }` / `force` forms.
- Builder application: setdefault, force, skip-when-unresolved, and the `MAX_JOBS` → `CMAKE_BUILD_PARALLEL_LEVEL` regression.
- `env_managed_keys` suppression of the sysconfig `CC`/`CXX` injection.
- Schema valid/invalid cases; generated schema/README/config-reference regenerated; docs build is warning-free.

https://claude.ai/code/session_01DRpvaLqeQuYgqoETCKEKiQ