### PR TITLE
feat: add ${SKBUILD_<TREE>_DIR} prefix for wheel-tree targeting

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -333,10 +333,10 @@ This matches the cache variables available from within CMake.
 
 When passing this through PEP 517 `config-settings` on a command line, quote it
 so the shell does not expand `${SKBUILD_DATA_DIR}` as an environment variable
-(e.g. `--config-settings='wheel.install-dir=${SKBUILD_DATA_DIR}/mypackage'`).
+(e.g. `-C 'wheel.install-dir=${SKBUILD_DATA_DIR}/mypackage'`).
 
 The older leading-slash spelling (`/data`, `/scripts`, ...) selects the same
-trees but is still gated behind `experimental = true`.
+trees but is gated behind `experimental = true`, and deprecated.
 
 :::
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -316,11 +316,27 @@ For example, to mimic scikit-build classic:
 wheel.install-dir = "mypackage"
 ```
 
+You can target a different wheel tree by prefixing the install dir with the
+matching `SKBUILD_*_DIR` CMake variable name:
+
+```toml
+[tool.scikit-build]
+wheel.install-dir = "${SKBUILD_DATA_DIR}/mypackage"
+```
+
+The available trees are `${SKBUILD_PLATLIB_DIR}` (the default),
+`${SKBUILD_PURELIB_DIR}`, `${SKBUILD_DATA_DIR}`, `${SKBUILD_HEADERS_DIR}`,
+`${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_METADATA_DIR}`, and `${SKBUILD_NULL_DIR}`.
+This matches the cache variables available from within CMake.
+
 :::{warning}
 
-You can select a different wheel target directory, as well, but that syntax is
-experimental; install to `${SKBUILD_DATA_DIR}`, etc. from within CMake instead
-for now.
+When passing this through PEP 517 `config-settings` on a command line, quote it
+so the shell does not expand `${SKBUILD_DATA_DIR}` as an environment variable
+(e.g. `--config-settings='wheel.install-dir=${SKBUILD_DATA_DIR}/mypackage'`).
+
+The older leading-slash spelling (`/data`, `/scripts`, ...) selects the same
+trees but is still gated behind `experimental = true`.
 
 :::
 
@@ -372,7 +388,7 @@ paths to destinations:
 
 [tool.scikit-build.wheel.force-include]
 "vendor/lib.so" = "mypackage/_lib.so"
-"tools/run.sh"  = "/scripts/run.sh"
+"tools/run.sh"  = "${SKBUILD_SCRIPTS_DIR}/run.sh"
 ```
 
 The keys are source paths relative to the project root; they may point outside
@@ -382,10 +398,13 @@ file or a directory, and directories are copied recursively (skipping VCS and
 
 `sdist.force-include` destinations are relative to the SDist root.
 `wheel.force-include` destinations are relative to the platlib (the package
-area), and also accept a leading `/data`, `/scripts`, `/headers`, or `/metadata`
-to target that wheel tree instead (this requires `experimental = true`, like
-`wheel.install-dir`). Force-included wheel files are placed last, so they
-override discovered package files and CMake output at the same destination.
+area), and also accept a `${SKBUILD_<TREE>_DIR}` prefix (e.g.
+`${SKBUILD_DATA_DIR}`, `${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_HEADERS_DIR}`,
+`${SKBUILD_METADATA_DIR}`) to target that wheel tree instead, matching the
+`SKBUILD_*_DIR` CMake cache variables. The older leading-slash spelling
+(`/data`, `/scripts`, ...) does the same but requires `experimental = true`.
+Force-included wheel files are placed last, so they override discovered package
+files and CMake output at the same destination.
 
 A force-included _file_ also overrides the matching exclude list
 (`wheel.exclude` for wheels, `sdist.exclude` for SDists): naming an exact source
@@ -872,9 +891,10 @@ The following features currently require this flag:
 - **Third-party dynamic-metadata plugins**: dynamic metadata providers not
   shipped with scikit-build-core (anything using `provider-path` or a provider
   outside the `scikit_build_core.*` namespace). See [](./dynamic.md).
-- **Absolute `wheel.install-dir`**: an absolute install dir is placed one level
-  above the platlib root, giving access to `/platlib`, `/data`, `/headers`,
-  `/scripts`, and `/metadata`. See
+- **Leading-slash wheel trees**: the deprecated absolute spelling (`/platlib`,
+  `/data`, `/headers`, `/scripts`, `/metadata`) for `wheel.install-dir` and
+  `wheel.force-include`, placed one level above the platlib root. The
+  `${SKBUILD_<TREE>_DIR}` prefix is the non-experimental replacement. See
   [`wheel.install-dir`](../reference/configs.md).
 
 The [rebuild-on-import feature](#editable-installs) for editable installs is

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -828,9 +828,11 @@ print(mk_skbuild_docs())
   file or a directory; directories are copied recursively, skipping VCS and
   ``__pycache__`` junk.
 
-  A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
-  ``/metadata`` destination targets that wheel tree instead of the platlib
-  (this requires :confval:`experimental`).
+  A ``${SKBUILD_<TREE>_DIR}`` prefix (e.g. ``${SKBUILD_DATA_DIR}/foo``) targets
+  that wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake
+  cache variables (``DATA``, ``SCRIPTS``, ``HEADERS``, ``PLATLIB``,
+  ``METADATA``, ...). The deprecated leading-slash form (``/data``, ``/scripts``,
+  ...) selects the same trees but requires :confval:`experimental`.
 
   Force-included files are placed last, so they override discovered package
   files and CMake output at the same destination. A missing source is an error.
@@ -862,9 +864,15 @@ print(mk_skbuild_docs())
   The original dir is still at ``SKBUILD_PLATLIB_DIR`` (also ``SKBUILD_DATA_DIR``, etc.
   are available).
 
+  A ``${SKBUILD_<TREE>_DIR}`` prefix (e.g. ``${SKBUILD_DATA_DIR}/foo``) targets that
+  wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake cache
+  variables. Available trees: ``PLATLIB``/``PURELIB``, ``DATA``, ``HEADERS``,
+  ``SCRIPTS``, ``METADATA``, ``NULL``.
+
   .. warning::
-     EXPERIMENTAL An absolute path will be one level higher than the platlib
-     root, giving access to "/platlib", "/data", "/headers", and "/scripts".
+     EXPERIMENTAL A leading-slash absolute path (``/platlib``, ``/data``,
+     ``/headers``, ``/scripts``, ...) is the deprecated spelling of the
+     ``${SKBUILD_<TREE>_DIR}`` form and is one level higher than the platlib root.
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from ..resources import resources
 from ._pathutil import (
+    editable_rebuild_install_dir,
     is_module,
     is_trackable,
     module_loader_rank,
@@ -106,11 +107,11 @@ def editable_redirect_files(
     modules = mapping_to_modules(mapping, libdir)
     installed = libdir_to_installed(libdir)
     directories, known_packages = collect_search_locations(mapping, libdir)
-    if settings.editable.rebuild and settings.wheel.install_dir.startswith(
-        ("/", "${SKBUILD_")
-    ):
-        msg = "Editable installs cannot rebuild a non-platlib wheel.install-dir. Use an override to change if needed."
-        raise AssertionError(msg)
+    install_dir = settings.wheel.install_dir
+    if settings.editable.rebuild:
+        # The shim joins install_dir onto the platlib root; a platlib/purelib
+        # selector reduces to its remainder, any other tree is rejected.
+        install_dir = editable_rebuild_install_dir(install_dir)
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,
@@ -121,7 +122,7 @@ def editable_redirect_files(
         verbose=settings.editable.verbose,
         build_options=build_options,
         install_options=install_options,
-        install_dir=settings.wheel.install_dir,
+        install_dir=install_dir,
         as_entrypoint=use_start,
     )
     package_paths = tuple(packages)

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -106,8 +106,10 @@ def editable_redirect_files(
     modules = mapping_to_modules(mapping, libdir)
     installed = libdir_to_installed(libdir)
     directories, known_packages = collect_search_locations(mapping, libdir)
-    if settings.editable.rebuild and settings.wheel.install_dir.startswith("/"):
-        msg = "Editable installs cannot rebuild an absolute wheel.install-dir. Use an override to change if needed."
+    if settings.editable.rebuild and settings.wheel.install_dir.startswith(
+        ("/", "${SKBUILD_")
+    ):
+        msg = "Editable installs cannot rebuild a non-platlib wheel.install-dir. Use an override to change if needed."
         raise AssertionError(msg)
     editable_txt = editable_redirect(
         modules=modules,

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 
 __all__ = [
+    "editable_rebuild_install_dir",
     "is_module",
     "is_trackable",
     "iter_force_include",
@@ -94,6 +95,25 @@ def packages_to_file_mapping(
 # underscores), so ``[A-Z]+`` cannot swallow the trailing ``_DIR``.
 _WHEEL_TREE_VAR = re.compile(r"\$\{SKBUILD_([A-Z]+)_DIR\}(?:/(.*))?$")
 
+_VALID_TREE_HINT = "PLATLIB, PURELIB, DATA, HEADERS, SCRIPTS, METADATA, NULL"
+
+
+def _reject_unsafe_remainder(rest: str, dest: str) -> None:
+    """
+    Reject a wheel-tree remainder that would escape the selected tree base.
+
+    The remainder is joined onto the tree base with ``base / rest``; an absolute
+    path, a Windows drive, or a backslash would discard the base (e.g.
+    ``${SKBUILD_DATA_DIR}//pkg`` -> ``/pkg``), so those are errors. A ``..``
+    component is already rejected for the whole ``dest`` by the caller.
+    """
+    if "\\" in rest or PureWindowsPath(rest).drive or PurePosixPath(rest).is_absolute():
+        msg = (
+            f"Wheel destination {dest!r} has a remainder {rest!r} that must be a "
+            "relative path without a leading '/', a drive, or backslashes"
+        )
+        raise AssertionError(msg)
+
 
 def resolve_wheel_tree(
     dest: str,
@@ -113,6 +133,9 @@ def resolve_wheel_tree(
     variables. The deprecated leading-``/`` form (``/data``, ``/scripts``, ...)
     selects the same trees but requires experimental features, since it gives
     access one level above the platlib root.
+
+    A leading ``${...}`` that is not a recognized tree variable is an error (to
+    catch typos); a ``${...}`` later in the path is an ordinary path component.
     """
     # Reject a '..' parent-directory component (the traversal risk), but allow
     # adjacent dots inside a normal filename like 'data..json'.
@@ -128,10 +151,17 @@ def resolve_wheel_tree(
         if tree not in wheel_dirs:
             msg = f"Must target a valid wheel directory, not {tree!r}"
             raise AssertionError(msg)
+        _reject_unsafe_remainder(rest, dest)
         return wheel_dirs[tree], rest
 
-    var_match = _WHEEL_TREE_VAR.fullmatch(dest)
-    if var_match:
+    if dest.startswith("${"):
+        var_match = _WHEEL_TREE_VAR.fullmatch(dest)
+        if var_match is None:
+            msg = (
+                f"Wheel destination {dest!r} has an unrecognized '${{...}}' prefix; "
+                f"use '${{SKBUILD_<TREE>_DIR}}/...' with a valid tree ({_VALID_TREE_HINT})"
+            )
+            raise AssertionError(msg)
         return select(var_match.group(1).lower(), var_match.group(2) or "")
     if dest.startswith("/"):
         if not experimental:
@@ -140,6 +170,33 @@ def resolve_wheel_tree(
         tree, _, rest = dest[1:].partition("/")
         return select(tree, rest)
     return wheel_dirs[targetlib], dest
+
+
+def editable_rebuild_install_dir(install_dir: str) -> str:
+    """
+    Reduce ``wheel.install-dir`` to a platlib-relative path for the editable shim.
+
+    The rebuild shim joins ``install_dir`` onto the platlib root, so it only
+    understands a relative path. A platlib/purelib tree selector
+    (``${SKBUILD_PLATLIB_DIR}/pkg`` or ``/platlib/pkg``) is equivalent to a plain
+    ``pkg`` and is reduced to its remainder. A selector for any other tree
+    escapes the platlib and cannot be rebuilt on import, so it raises.
+    """
+    if install_dir.startswith("${"):
+        var_match = _WHEEL_TREE_VAR.fullmatch(install_dir)
+        if var_match:
+            tree = var_match.group(1).lower()
+            rest = var_match.group(2) or ""
+        else:
+            tree = rest = ""
+    elif install_dir.startswith("/"):
+        tree, _, rest = install_dir[1:].partition("/")
+    else:
+        return install_dir
+    if tree in {"platlib", "purelib"}:
+        return rest
+    msg = "Editable installs cannot rebuild a non-platlib wheel.install-dir. Use an override to change if needed."
+    raise AssertionError(msg)
 
 
 def resolve_from_sdist_force_include(

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import os
+import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Literal
 
@@ -88,6 +89,12 @@ def packages_to_file_mapping(
     return mapping
 
 
+# Matches a ``${SKBUILD_<TREE>_DIR}`` prefix, capturing the tree name and any
+# remainder after the following '/'. Tree names are single words (no
+# underscores), so ``[A-Z]+`` cannot swallow the trailing ``_DIR``.
+_WHEEL_TREE_VAR = re.compile(r"\$\{SKBUILD_([A-Z]+)_DIR\}(?:/(.*))?$")
+
+
 def resolve_wheel_tree(
     dest: str,
     *,
@@ -98,21 +105,22 @@ def resolve_wheel_tree(
     """
     Resolve a wheel destination into a ``(base_dir, relative_dest)`` pair.
 
-    A plain ``dest`` is relative to the target lib (platlib/purelib). A leading
-    ``/`` selects a wheel tree (``/data``, ``/scripts``, ``/headers``,
-    ``/platlib``, ``/metadata``, ...) and requires experimental features, since
-    this gives access one level above the platlib root.
+    A plain ``dest`` is relative to the target lib (platlib/purelib). A
+    ``${SKBUILD_<TREE>_DIR}`` prefix selects a wheel tree
+    (``${SKBUILD_DATA_DIR}``, ``${SKBUILD_SCRIPTS_DIR}``,
+    ``${SKBUILD_HEADERS_DIR}``, ``${SKBUILD_PLATLIB_DIR}``,
+    ``${SKBUILD_METADATA_DIR}``, ...), matching the ``SKBUILD_*_DIR`` CMake cache
+    variables. The deprecated leading-``/`` form (``/data``, ``/scripts``, ...)
+    selects the same trees but requires experimental features, since it gives
+    access one level above the platlib root.
     """
     # Reject a '..' parent-directory component (the traversal risk), but allow
     # adjacent dots inside a normal filename like 'data..json'.
     if ".." in PurePosixPath(dest).parts:
         msg = f"Wheel destination must not contain a '..' path component, got {dest!r}"
         raise AssertionError(msg)
-    if dest.startswith("/"):
-        if not experimental:
-            msg = "Experimental features must be enabled to use absolute paths (a leading '/') in a wheel destination"
-            raise AssertionError(msg)
-        tree, _, rest = dest[1:].partition("/")
+
+    def select(tree: str, rest: str) -> tuple[Path, str]:
         # platlib/purelib both name the target lib; map either to whichever this
         # wheel actually has (pure wheels are keyed by purelib, not platlib).
         if tree in {"platlib", "purelib"}:
@@ -121,6 +129,16 @@ def resolve_wheel_tree(
             msg = f"Must target a valid wheel directory, not {tree!r}"
             raise AssertionError(msg)
         return wheel_dirs[tree], rest
+
+    var_match = _WHEEL_TREE_VAR.fullmatch(dest)
+    if var_match:
+        return select(var_match.group(1).lower(), var_match.group(2) or "")
+    if dest.startswith("/"):
+        if not experimental:
+            msg = "Experimental features must be enabled to use absolute paths (a leading '/') in a wheel destination"
+            raise AssertionError(msg)
+        tree, _, rest = dest[1:].partition("/")
+        return select(tree, rest)
     return wheel_dirs[targetlib], dest
 
 
@@ -177,8 +195,9 @@ def iter_force_include(
     ``dest`` must be a relative path within ``base``; anything that could escape
     it is rejected -- an absolute path, ``..`` components, a backslash, or a
     Windows drive (e.g. ``C:/x``), which would otherwise escape on Windows where
-    ``base / dest`` treats those as filesystem syntax. Wheel-tree selection (a
-    leading ``/``) is handled earlier by :func:`resolve_wheel_tree`.
+    ``base / dest`` treats those as filesystem syntax. Wheel-tree selection
+    (``${SKBUILD_<TREE>_DIR}`` or a leading ``/``) is handled earlier by
+    :func:`resolve_wheel_tree`.
     """
     posix_dest = PurePosixPath(dest)
     if (

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -456,9 +456,15 @@ class WheelSettings:
     The original dir is still at ``SKBUILD_PLATLIB_DIR`` (also ``SKBUILD_DATA_DIR``, etc.
     are available).
 
+    A ``${SKBUILD_<TREE>_DIR}`` prefix (e.g. ``${SKBUILD_DATA_DIR}/foo``) targets that
+    wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake cache
+    variables. Available trees: ``PLATLIB``/``PURELIB``, ``DATA``, ``HEADERS``,
+    ``SCRIPTS``, ``METADATA``, ``NULL``.
+
     .. warning::
-       EXPERIMENTAL An absolute path will be one level higher than the platlib
-       root, giving access to "/platlib", "/data", "/headers", and "/scripts".
+       EXPERIMENTAL A leading-slash absolute path (``/platlib``, ``/data``,
+       ``/headers``, ``/scripts``, ...) is the deprecated spelling of the
+       ``${SKBUILD_<TREE>_DIR}`` form and is one level higher than the platlib root.
     """
 
     license_files: Optional[List[str]] = None
@@ -523,9 +529,11 @@ class WheelSettings:
     file or a directory; directories are copied recursively, skipping VCS and
     ``__pycache__`` junk.
 
-    A leading ``/data``, ``/scripts``, ``/headers``, ``/platlib``, or
-    ``/metadata`` destination targets that wheel tree instead of the platlib
-    (this requires :confval:`experimental`).
+    A ``${SKBUILD_<TREE>_DIR}`` prefix (e.g. ``${SKBUILD_DATA_DIR}/foo``) targets
+    that wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake
+    cache variables (``DATA``, ``SCRIPTS``, ``HEADERS``, ``PLATLIB``,
+    ``METADATA``, ...). The deprecated leading-slash form (``/data``, ``/scripts``,
+    ...) selects the same trees but requires :confval:`experimental`.
 
     Force-included files are placed last, so they override discovered package
     files and CMake output at the same destination. A missing source is an error.

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -414,7 +414,28 @@ def test_editable_redirect_files_absolute_install_dir_with_rebuild(tmp_path: Pat
         editable=EditableSettings(rebuild=True),
     )
 
-    with pytest.raises(AssertionError, match=r"absolute wheel\.install-dir"):
+    with pytest.raises(AssertionError, match=r"non-platlib wheel\.install-dir"):
+        editable_redirect_files(
+            libdir=tmp_path,
+            mapping={},
+            name="pkg",
+            packages=[],
+            reload_dir=None,
+            settings=settings,
+            use_start=False,
+        )
+
+
+def test_editable_redirect_files_var_install_dir_with_rebuild(tmp_path: Path):
+    # The ${SKBUILD_*_DIR} install-dir form is also incompatible with rebuild.
+    from scikit_build_core.settings.skbuild_model import EditableSettings, WheelSettings
+
+    settings = ScikitBuildSettings(
+        wheel=WheelSettings(install_dir="${SKBUILD_DATA_DIR}/pkg"),
+        editable=EditableSettings(rebuild=True),
+    )
+
+    with pytest.raises(AssertionError, match=r"non-platlib wheel\.install-dir"):
         editable_redirect_files(
             libdir=tmp_path,
             mapping={},

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -427,7 +427,7 @@ def test_editable_redirect_files_absolute_install_dir_with_rebuild(tmp_path: Pat
 
 
 def test_editable_redirect_files_var_install_dir_with_rebuild(tmp_path: Path):
-    # The ${SKBUILD_*_DIR} install-dir form is also incompatible with rebuild.
+    # A non-platlib ${SKBUILD_*_DIR} install-dir is incompatible with rebuild.
     from scikit_build_core.settings.skbuild_model import EditableSettings, WheelSettings
 
     settings = ScikitBuildSettings(
@@ -503,6 +503,38 @@ def test_get_packages_not_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     # A namespace dir with no __init__ on the leaf is not a discoverable package.
     (tmp_path / "src" / "ns" / "pkg").mkdir(parents=True)
     assert get_packages(packages=None, name="ns.pkg") == {}
+
+
+@pytest.mark.parametrize(
+    "install_dir", ["${SKBUILD_PLATLIB_DIR}/pkg", "${SKBUILD_PURELIB_DIR}/pkg"]
+)
+def test_editable_redirect_files_platlib_var_install_dir_with_rebuild(
+    tmp_path: Path, install_dir: str
+):
+    # A platlib/purelib selector resolves to the target lib (equivalent to a
+    # plain relative dir), so it stays compatible with rebuild. The shim must get
+    # the reduced remainder, not the raw ${...} string.
+    from scikit_build_core.settings.skbuild_model import EditableSettings, WheelSettings
+
+    settings = ScikitBuildSettings(
+        wheel=WheelSettings(install_dir=install_dir),
+        editable=EditableSettings(rebuild=True),
+    )
+
+    files = editable_redirect_files(
+        libdir=tmp_path,
+        mapping={},
+        name="pkg",
+        packages=[],
+        reload_dir=None,
+        settings=settings,
+        use_start=False,
+    )
+    shim = files["_editable_skbc_pkg.py"].decode()
+    # The reduced remainder is passed; the raw selector never reaches the shim.
+    assert "'pkg'" in shim
+    assert "SKBUILD_PLATLIB_DIR" not in shim
+    assert "SKBUILD_PURELIB_DIR" not in shim
 
 
 def test_is_trackable():

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -141,6 +141,49 @@ def test_force_include_leading_slash_targets_scripts(chdir_tmp: Path) -> None:
     assert "pkg-0.1.0.data/scripts/run.sh" in wheel_names(dist)
 
 
+def test_force_include_var_targets_scripts(chdir_tmp: Path) -> None:
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"run.sh" = "${SKBUILD_SCRIPTS_DIR}/run.sh"}',
+    )
+    (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg-0.1.0.data/scripts/run.sh" in wheel_names(dist)
+
+
+def test_force_include_var_no_experimental(chdir_tmp: Path) -> None:
+    """The ${SKBUILD_*_DIR} form is not gated on experimental (only the / form is)."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"run.sh" = "${SKBUILD_SCRIPTS_DIR}/run.sh"}',
+        experimental=False,
+    )
+    (chdir_tmp / "run.sh").write_text("#!/bin/sh\n")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg-0.1.0.data/scripts/run.sh" in wheel_names(dist)
+
+
+def test_force_include_var_pure_wheel_platlib_tree(chdir_tmp: Path) -> None:
+    """${SKBUILD_PLATLIB_DIR} resolves to purelib on a pure wheel, like /platlib."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"extra.txt" = "${SKBUILD_PLATLIB_DIR}/pkg/extra.txt"}',
+        experimental=False,
+    )
+    (chdir_tmp / "extra.txt").write_text("x")
+
+    dist = chdir_tmp / "dist"
+    build_wheel(str(dist), {})
+
+    assert "pkg/extra.txt" in wheel_names(dist)
+
+
 def test_force_include_script_shebang_normalized(chdir_tmp: Path) -> None:
     """A force-included script's python shebang is normalized to #!python."""
     make_pure_pkg(
@@ -619,3 +662,83 @@ def test_settings_force_include_config_settings(tmp_path: Path) -> None:
     )
     assert settings.sdist.force_include == {"a.txt": "data/a.txt"}
     assert settings.wheel.force_include == {"b.so": "pkg/b.so"}
+
+
+def _wheel_dirs(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "platlib": tmp_path / "platlib",
+        "data": tmp_path / "data",
+        "headers": tmp_path / "headers",
+        "scripts": tmp_path / "scripts",
+        "null": tmp_path / "null",
+        "metadata": tmp_path / "metadata",
+    }
+
+
+@pytest.mark.parametrize(
+    ("dest", "tree", "rest"),
+    [
+        ("${SKBUILD_DATA_DIR}/foo/bar", "data", "foo/bar"),
+        ("${SKBUILD_SCRIPTS_DIR}/run.sh", "scripts", "run.sh"),
+        ("${SKBUILD_HEADERS_DIR}/pkg.h", "headers", "pkg.h"),
+        ("${SKBUILD_METADATA_DIR}/x.txt", "metadata", "x.txt"),
+        ("${SKBUILD_NULL_DIR}/junk", "null", "junk"),
+        # No remainder resolves to the tree root itself.
+        ("${SKBUILD_DATA_DIR}", "data", ""),
+        # platlib/purelib both alias the actual target lib.
+        ("${SKBUILD_PLATLIB_DIR}/pkg/x", "platlib", "pkg/x"),
+        ("${SKBUILD_PURELIB_DIR}/pkg/x", "platlib", "pkg/x"),
+    ],
+)
+def test_resolve_wheel_tree_var(
+    tmp_path: Path, dest: str, tree: str, rest: str
+) -> None:
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    wheel_dirs = _wheel_dirs(tmp_path)
+    # The var form does not require experimental.
+    base, resolved_rest = resolve_wheel_tree(
+        dest, wheel_dirs=wheel_dirs, targetlib="platlib", experimental=False
+    )
+    assert base == wheel_dirs[tree]
+    assert resolved_rest == rest
+
+
+def test_resolve_wheel_tree_var_bad_name(tmp_path: Path) -> None:
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    with pytest.raises(AssertionError, match=r"valid wheel directory"):
+        resolve_wheel_tree(
+            "${SKBUILD_NOPE_DIR}/x",
+            wheel_dirs=_wheel_dirs(tmp_path),
+            targetlib="platlib",
+            experimental=True,
+        )
+
+
+def test_resolve_wheel_tree_var_rejects_traversal(tmp_path: Path) -> None:
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    with pytest.raises(AssertionError, match=r"'\.\.' path component"):
+        resolve_wheel_tree(
+            "${SKBUILD_DATA_DIR}/../escape",
+            wheel_dirs=_wheel_dirs(tmp_path),
+            targetlib="platlib",
+            experimental=True,
+        )
+
+
+def test_resolve_wheel_tree_unknown_var_is_literal(tmp_path: Path) -> None:
+    """A non-matching $-string (wrong shape) is a plain platlib-relative dest."""
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    wheel_dirs = _wheel_dirs(tmp_path)
+    # Lowercase / no _DIR suffix: not a wheel-tree token, treated literally.
+    base, rest = resolve_wheel_tree(
+        "${SKBUILD_DATA}/x",
+        wheel_dirs=wheel_dirs,
+        targetlib="platlib",
+        experimental=False,
+    )
+    assert base == wheel_dirs["platlib"]
+    assert rest == "${SKBUILD_DATA}/x"

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -728,17 +728,61 @@ def test_resolve_wheel_tree_var_rejects_traversal(tmp_path: Path) -> None:
         )
 
 
-def test_resolve_wheel_tree_unknown_var_is_literal(tmp_path: Path) -> None:
-    """A non-matching $-string (wrong shape) is a plain platlib-relative dest."""
+@pytest.mark.parametrize(
+    "dest",
+    [
+        "${SKBUILD_DATA}/x",  # missing _DIR suffix
+        "${SKBUILD_NOPE_DIR}/x",  # unknown tree name
+        "${HOME}/x",  # not a SKBUILD variable at all
+        "${SKBUILD_DATA_DIR",  # unterminated
+    ],
+)
+def test_resolve_wheel_tree_bad_leading_var_rejected(tmp_path: Path, dest: str) -> None:
+    """A leading ${...} that is not a valid tree variable is an error (typo guard)."""
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    with pytest.raises(AssertionError):
+        resolve_wheel_tree(
+            dest,
+            wheel_dirs=_wheel_dirs(tmp_path),
+            targetlib="platlib",
+            experimental=True,
+        )
+
+
+def test_resolve_wheel_tree_var_not_leading_is_literal(tmp_path: Path) -> None:
+    """A ${...} later in the path is an ordinary component, not a selector."""
     from scikit_build_core.build._pathutil import resolve_wheel_tree
 
     wheel_dirs = _wheel_dirs(tmp_path)
-    # Lowercase / no _DIR suffix: not a wheel-tree token, treated literally.
     base, rest = resolve_wheel_tree(
-        "${SKBUILD_DATA}/x",
+        "pkg/${NOT_A_VAR}/x",
         wheel_dirs=wheel_dirs,
         targetlib="platlib",
         experimental=False,
     )
     assert base == wheel_dirs["platlib"]
-    assert rest == "${SKBUILD_DATA}/x"
+    assert rest == "pkg/${NOT_A_VAR}/x"
+
+
+@pytest.mark.parametrize(
+    "dest",
+    [
+        "${SKBUILD_DATA_DIR}//pkg",  # absolute remainder discards the base
+        "${SKBUILD_DATA_DIR}/C:/pkg",  # drive-qualified remainder
+        "${SKBUILD_DATA_DIR}/a\\b",  # backslash remainder
+        "/data//pkg",  # same hazard via the leading-slash form
+    ],
+)
+def test_resolve_wheel_tree_rejects_escaping_remainder(
+    tmp_path: Path, dest: str
+) -> None:
+    from scikit_build_core.build._pathutil import resolve_wheel_tree
+
+    with pytest.raises(AssertionError, match=r"remainder"):
+        resolve_wheel_tree(
+            dest,
+            wheel_dirs=_wheel_dirs(tmp_path),
+            targetlib="platlib",
+            experimental=True,
+        )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a non-experimental `${SKBUILD_<TREE>_DIR}/...` prefix syntax for targeting special wheel trees in `wheel.install-dir` and `wheel.force-include`, mirroring the `SKBUILD_*_DIR` CMake cache variables. This replaces the confusing leading-slash "absolute path" form (`/data`, `/scripts`, ...) — which *looks* like a filesystem absolute path but isn't — with one consistent vocabulary shared between the config side and CMakeLists.

The old `/data/`-style form keeps working unchanged and stays gated behind `experimental = true`; the new form is **not** experimental.

```toml
[tool.scikit-build]
wheel.install-dir = "${SKBUILD_DATA_DIR}/mypackage"
wheel.force-include = { "tools/run.sh" = "${SKBUILD_SCRIPTS_DIR}/run.sh" }
```

Available trees: `${SKBUILD_PLATLIB_DIR}` (default), `${SKBUILD_PURELIB_DIR}`, `${SKBUILD_DATA_DIR}`, `${SKBUILD_HEADERS_DIR}`, `${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_METADATA_DIR}`, `${SKBUILD_NULL_DIR}`.

## Changes

- **`build/_pathutil.py`** — `resolve_wheel_tree()` matches a `${SKBUILD_<TREE>_DIR}` prefix and resolves it through the same path as the leading-slash form (same platlib/purelib aliasing, same valid-tree check, same `..` traversal rejection). Not experimental-gated. Single chokepoint, so wheel build / force-include / hatch plugin are all covered.
- **`build/_editable.py`** — the rebuild-incompatibility check now also rejects a `${SKBUILD_...}` install-dir (a rebuild can't target a tree above platlib).
- **Docs + model docstrings** — present the var form as preferred, leading-slash as deprecated; regenerated `configs.md`/`README` via `nox -t gen`. Documented the CLI single-quoting caveat (the shell would otherwise expand `${SKBUILD_DATA_DIR}` when passed through `config-settings`).
- **Tests** — integration tests (incl. one asserting the var form works with `experimental = false`), direct `resolve_wheel_tree` unit tests (all trees, no-remainder, purelib alias, bad name, traversal, non-matching literal), and an editable rebuild-rejection test.

## Notes / open question

The editable rebuild rejection is intentionally **coarse**: it rejects *any* `${SKBUILD_...}` install-dir, including `${SKBUILD_PLATLIB_DIR}/...` which technically stays within platlib. This matches the pre-existing behavior for `/platlib`. Could be refined to allow rebuild when the target tree is platlib/purelib — happy to do so if preferred.

## Verification

- `prek -a --quiet` clean (includes mypy)
- `tests/test_force_include.py`, `tests/test_editable_unit.py`, `tests/test_editable.py`, `tests/test_pyproject_pep517.py` pass