### PR TITLE
fix: emit installer-compatible abi3t wheel tag

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -450,9 +450,7 @@ newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
 `Development.SABIModule` when targeting ABI3 or ABI3T, and is an empty string
 otherwise. For free-threaded Python (PEP 703), you can use `cp315t` to target
 the free-threaded stable ABI, which sets `Py_TARGET_ABI3T` (if using CMake
-4.4+). The emitted wheel tag is `cp315-abi3t-*`: per PEP 803, free-threadedness
-is carried by the `abi3t` ABI tag, while the interpreter tag stays
-GIL-independent.
+4.4+). The emitted wheel tag is `cp315-abi3t-*` following per PEP 803.
 
 If you are not using CPython at all, you can specify any version of Python is
 fine:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -450,7 +450,9 @@ newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
 `Development.SABIModule` when targeting ABI3 or ABI3T, and is an empty string
 otherwise. For free-threaded Python (PEP 703), you can use `cp315t` to target
 the free-threaded stable ABI, which sets `Py_TARGET_ABI3T` (if using CMake
-4.4+).
+4.4+). The emitted wheel tag is `cp315-abi3t-*`: per PEP 803, free-threadedness
+is carried by the `abi3t` ABI tag, while the interpreter tag stays
+GIL-independent.
 
 If you are not using CPython at all, you can specify any version of Python is
 fine:

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -151,9 +151,7 @@ class WheelTag:
                     if ft_tags:
                         target = ft_tags[0]
                         if target.minor <= sys.version_info.minor:
-                            # Free-threadedness lives in the abi3t ABI tag only;
-                            # the interpreter tag is GIL-independent (cp315, not
-                            # cp315t), matching PEP 803 / packaging's sys_tags().
+                            # Free-threadedness lives in the abi3t ABI tag only
                             pyvers = [f"cp3{target.minor}"]
                             abi = "abi3t"
                         else:

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -151,7 +151,10 @@ class WheelTag:
                     if ft_tags:
                         target = ft_tags[0]
                         if target.minor <= sys.version_info.minor:
-                            pyvers = [str(target)]
+                            # Free-threadedness lives in the abi3t ABI tag only;
+                            # the interpreter tag is GIL-independent (cp315, not
+                            # cp315t), matching PEP 803 / packaging's sys_tags().
+                            pyvers = [f"cp3{target.minor}"]
                             abi = "abi3t"
                         else:
                             logger.debug(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -596,7 +596,7 @@ def test_wheel_tag_with_abi3t_darwin(monkeypatch):
     monkeypatch.setattr(sys, "version_info", VersionInfo(3, 15))
 
     tags = WheelTag.compute_best(["x86_64"], py_api="cp315t")
-    assert str(tags) == "cp315t-abi3t-macosx_10_10_x86_64"
+    assert str(tags) == "cp315-abi3t-macosx_10_10_x86_64"
 
     tags = WheelTag.compute_best(["x86_64"], py_api="cp316t")
     assert "abi3t" not in str(tags)


### PR DESCRIPTION
This has only been in main.

:robot: _AI text below_ :robot:

## Problem

Free-threaded stable-ABI wheels built from `main` are tagged `cp315t-abi3t-*`, but current pip/packaging (PEP 803) does not accept that tag — `packaging.tags.sys_tags()` on a free-threaded interpreter contains `cp315-abi3t-*`, never `cp315t-abi3t-*`. The result is that abi3t wheels are **uninstallable without manual retagging**.

Reported in #1378.

## Root cause

In `WheelTag.compute_best`, the free-threaded branch set the interpreter tag from the raw `py-api` selector:

```python
pyvers = [str(target)]   # "cp315t"
abi = "abi3t"
```

Per PEP 803, free-threadedness lives **only** in the `abi3t` ABI tag; the interpreter tag stays GIL-independent. `packaging.tags.cpython_tags` always emits `interpreter = f"cp{version}"` and encodes free-threading via the ABI tag.

## Fix

Emit `cp315` (not `cp315t`) as the interpreter tag:

```python
pyvers = [f"cp3{target.minor}"]   # "cp315"
abi = "abi3t"
```

`wheel.py-api = "cp315t"` remains the user-facing selector — only the emitted tag changes, from `cp315t-abi3t-*` to the installer-compatible `cp315-abi3t-*`.

## Tests

- Updated `test_wheel_tag_with_abi3t_darwin` to assert `cp315-abi3t-macosx_10_10_x86_64`. This assertion was added before the fix and confirmed to fail for exactly the right reason (`cp315t-abi3t` vs `cp315-abi3t`), then passes after.

## Docs

- Noted in `docs/configuration/index.md` that the emitted tag is `cp315-abi3t-*`.

## Out of scope

The combined `cp315-abi3.abi3t` wheel tag (a stronger compatibility claim covering both GIL and free-threaded stable ABI) raised in the issue follow-up is a separate feature and not addressed here.

Closes #1378