### PR TITLE
fix: use `Path.as_posix()` for including generated files in sdist/wheel

### DIFF
--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -128,7 +128,7 @@ def build_sdist(
         if gen.location == "source":
             contents = generate_file_contents(gen, metadata)
             gen.path.write_text(contents, encoding="utf-8")
-            settings.sdist.include.append(str(gen.path))
+            settings.sdist.include.append(gen.path.as_posix())
 
     sdist_dir.mkdir(parents=True, exist_ok=True)
     with contextlib.ExitStack() as stack:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -396,7 +396,7 @@ def _build_wheel_impl_impl(
             if gen.location == "source":
                 contents = generate_file_contents(gen, metadata)
                 gen.path.write_text(contents, encoding="utf-8")
-                settings.sdist.include.append(str(gen.path))
+                settings.sdist.include.append(gen.path.as_posix())
 
         if wheel_directory is None and not exit_after_config:
             if metadata_directory is None:

--- a/tests/packages/generate_include/.gitignore
+++ b/tests/packages/generate_include/.gitignore
@@ -1,0 +1,1 @@
+src/generate_include/_version.py

--- a/tests/packages/generate_include/pyproject.toml
+++ b/tests/packages/generate_include/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "generate-include"
+version = "0.0.1"
+
+[tool.scikit-build]
+wheel.cmake = false
+sdist.cmake = false
+
+[[tool.scikit-build.generate]]
+path = "src/generate_include/_version.py"
+location = "source"
+template = """
+version = "${version}"
+"""

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -10,8 +10,6 @@ from scikit_build_core.build import build_sdist, build_wheel
 # automatically add the generated file to the sdist/wheel includes
 
 
-@pytest.mark.compile
-@pytest.mark.configure
 @pytest.mark.parametrize("package", ["generate_include"], indirect=True)
 @pytest.mark.usefixtures("package")
 def test_generate_include_sdist(tmp_path: Path):
@@ -25,8 +23,6 @@ def test_generate_include_sdist(tmp_path: Path):
         assert "generate_include-0.0.1/src/generate_include/_version.py" in file_names
 
 
-@pytest.mark.compile
-@pytest.mark.configure
 @pytest.mark.parametrize("package", ["generate_include"], indirect=True)
 @pytest.mark.usefixtures("package")
 def test_generate_include_wheel(tmp_path: Path):

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -6,41 +6,31 @@ import pytest
 
 from scikit_build_core.build import build_sdist, build_wheel
 
-DIR = Path(__file__).parent.resolve()
-SRC = DIR / "packages/generate_include"
 
-
-@pytest.fixture
-def cleanup_generated():
-    version_file = SRC / "src/generate_include/_version.py"
-    yield version_file
-    version_file.unlink(missing_ok=True)
-
-
-def test_generate_include_sdist(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cleanup_generated: Path
-):
-    dist = tmp_path.resolve() / "dist"
-    monkeypatch.chdir(SRC)
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.parametrize("package", ["generate_include"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_generate_include_sdist(tmp_path: Path):
+    dist = tmp_path / "dist"
 
     out = build_sdist(str(dist))
     sdist = dist / out
-    assert cleanup_generated.is_file()
 
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())
         assert "generate_include-0.0.1/src/generate_include/_version.py" in file_names
 
 
-def test_generate_include_wheel(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cleanup_generated: Path
-):
-    dist = tmp_path.resolve() / "dist"
-    monkeypatch.chdir(SRC)
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.parametrize("package", ["generate_include"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_generate_include_wheel(tmp_path: Path):
+    dist = tmp_path / "dist"
 
     out = build_wheel(str(dist))
     wheel = dist / out
-    assert cleanup_generated.is_file()
 
     with zipfile.ZipFile(wheel) as zf:
         file_names = set(zf.namelist())

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -9,6 +9,7 @@ from scikit_build_core.build import build_sdist, build_wheel
 # Using [[tool.scikit-build.generate]] in with `location = "source"` mode should
 # automatically add the generated file to the sdist/wheel includes
 
+
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.parametrize("package", ["generate_include"], indirect=True)

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -1,0 +1,47 @@
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.build import build_sdist, build_wheel
+
+DIR = Path(__file__).parent.resolve()
+SRC = DIR / "packages/generate_include"
+
+
+@pytest.fixture
+def cleanup_generated():
+    version_file = SRC / "src/generate_include/_version.py"
+    yield version_file
+    version_file.unlink(missing_ok=True)
+
+
+def test_generate_include_sdist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cleanup_generated: Path
+):
+    dist = tmp_path.resolve() / "dist"
+    monkeypatch.chdir(SRC)
+
+    out = build_sdist(str(dist))
+    sdist = dist / out
+    assert cleanup_generated.is_file()
+
+    with tarfile.open(sdist) as f:
+        file_names = set(f.getnames())
+        assert "generate_include-0.0.1/src/generate_include/_version.py" in file_names
+
+
+def test_generate_include_wheel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cleanup_generated: Path
+):
+    dist = tmp_path.resolve() / "dist"
+    monkeypatch.chdir(SRC)
+
+    out = build_wheel(str(dist))
+    wheel = dist / out
+    assert cleanup_generated.is_file()
+
+    with zipfile.ZipFile(wheel) as zf:
+        file_names = set(zf.namelist())
+        assert "generate_include/_version.py" in file_names

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -6,6 +6,8 @@ import pytest
 
 from scikit_build_core.build import build_sdist, build_wheel
 
+# Using [[tool.scikit-build.generate]] in with `location = "source"` mode should
+# automatically add the generated file to the sdist/wheel includes
 
 @pytest.mark.compile
 @pytest.mark.configure

--- a/tests/test_generate_include.py
+++ b/tests/test_generate_include.py
@@ -6,7 +6,7 @@ import pytest
 
 from scikit_build_core.build import build_sdist, build_wheel
 
-# Using [[tool.scikit-build.generate]] in with `location = "source"` mode should
+# Using [[tool.scikit-build.generate]] with `location = "source"` should
 # automatically add the generated file to the sdist/wheel includes
 
 


### PR DESCRIPTION
Heya! I noticed that our CI seemed to be failing after adding an auto-generated `_version.py` file ([config](https://github.com/DisnakeDev/dave.py/blob/409901d0337ea37b35bf0d3d6c54574c0bb24abe/pyproject.toml#L153-L159), as outlined in the [docs](https://scikit-build-core.readthedocs.io/en/stable/configuration/dynamic.html#generate-files-with-dynamic-metadata)), but weirdly only on Windows, which didn't seem to find the module while running tests from the built wheel.
As it turns out, gitignore files (and, by extension, `pathspec`) exclusively support forward slashes, whereas the `str(gen.path)` call would turn the forward slashes from the config into the windows backslash path separator, which meant the generated file wasn't being added to the wheel in the first place. Using `.as_posix()` instead avoids that.

I hope the test setup is okay-ish and in line with the rest of the project, I mostly just took inspiration from `test_pyproject_purelib.py` and `test_force_include.py` c: