### PR TITLE
feat: allow a list for cmake.build-type

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -509,6 +509,21 @@ type without editing `pyproject.toml` (for example
 `CMAKE_BUILD_TYPE=RelWithDebInfo`), mirroring CMake's own handling of the
 variable.
 
+You can also pass a _list_ of build types to build and install more than one
+configuration into the same wheel:
+
+```{conftabs} cmake.build-type ["Release", "Debug"]
+
+```
+
+Single-config generators (Ninja, Makefiles) are reconfigured in place for each
+extra build type, then rebuilt; multi-config generators (Visual Studio, Xcode,
+Ninja Multi-Config) build each `--config`. Every configuration installs to the
+same prefix, so set `CMAKE_<CONFIG>_POSTFIX` (such as `CMAKE_DEBUG_POSTFIX=_d`)
+on your targets to keep the configurations from clobbering each other, and
+select the right module at runtime in your package's `__init__.py`. This is
+currently only supported by the default (native) and Hatchling backends.
+
 You can specify CMake defines as strings or bools:
 
 ````{tab} pyproject.toml

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -275,7 +275,7 @@ print(mk_skbuild_docs())
 ```{eval-rst}
 .. confval:: cmake.build-type
 
-  :Type: ``str``
+  :Type: ``str | list[str]``
   :Default: "Release"
   :Config-settings: ``cmake.build-type`` or ``skbuild.cmake.build-type``
   :Environment variable: ``SKBUILD_CMAKE_BUILD_TYPE``
@@ -285,6 +285,14 @@ print(mk_skbuild_docs())
   Pre-defined CMake options are: ``Debug``, ``Release``, ``RelWithDebInfo``, ``MinSizeRel``
 
   Custom values can also be used.
+
+  A list of build types can be given to build and install more than one
+  configuration into the same wheel (for example ``["Release", "Debug"]``).
+  Single-config generators (Ninja, Makefiles) are reconfigured in place for
+  each extra build type; multi-config generators (Visual Studio, Xcode,
+  Ninja Multi-Config) build each ``--config``. Every build type is installed
+  to the same prefix, so use ``CMAKE_<CONFIG>_POSTFIX`` to avoid clobbering
+  files between configurations.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -287,7 +287,9 @@ print(mk_skbuild_docs())
   Custom values can also be used.
 
   A list of build types can be given to build and install more than one
-  configuration into the same wheel (for example ``["Release", "Debug"]``).
+  configuration into the same wheel: ``["Release", "Debug"]`` in TOML, a
+  repeated ``-Ccmake.build-type=...`` config-setting, or ``Release;Debug`` as
+  an environment variable.
   Single-config generators (Ninja, Makefiles) are reconfigured in place for
   each extra build type; multi-config generators (Visual Studio, Xcode,
   Ninja Multi-Config) build each ``--config``. Every build type is installed

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -150,8 +150,9 @@ def _run_configure(
     name: str,
     version: Version,
     extra_cache_entries: Mapping[str, str | Path] | None,
+    build_type: str | None = None,
 ) -> None:
-    """Run ``cmake`` configure for ``builder.config.build_type``."""
+    """Run ``cmake`` configure, optionally overriding the build type."""
     # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
     # Otherwise `cmake --install --prefix` would work by itself
     defines = {"CMAKE_INSTALL_PREFIX": install_dir}
@@ -166,6 +167,7 @@ def _run_configure(
         cache_entries=cache_entries,
         name=name,
         version=version,
+        build_type=build_type,
     )
 
 
@@ -254,13 +256,12 @@ def build_install_extra_build_types(
     each extra build type; multi-config generators just build the extra
     ``--config``. Everything installs to the same prefix.
 
-    Call this after the primary build and install, and after
-    :func:`editable_rebuild_options` (which reads ``builder.config.build_type``,
-    mutated here).
+    The build type is passed per call, so ``builder.config.build_type`` keeps
+    pointing at the primary build type. Call this after the primary build and
+    install.
     """
     build_types = normalize_build_types(settings.cmake.build_type)
     for extra_build_type in build_types[1:]:
-        builder.config.build_type = extra_build_type
         if builder.config.single_config:
             rich_print(
                 "{green}***",
@@ -274,18 +275,19 @@ def build_install_extra_build_types(
                 name=name,
                 version=version,
                 extra_cache_entries=extra_cache_entries,
+                build_type=extra_build_type,
             )
         rich_print(
             "{green}***",
             f"{{bold}}Building {{blue}}{extra_build_type}{{default}} project...",
         )
-        builder.build(build_args=[])
+        builder.build(build_args=[], build_type=extra_build_type)
         if not (editable and settings.editable.mode == "inplace"):
             rich_print(
                 "{green}***",
                 f"{{bold}}Installing {{blue}}{extra_build_type}{{default}} project into wheel...",
             )
-            builder.install(install_dir)
+            builder.install(install_dir, build_type=extra_build_type)
 
 
 def editable_rebuild_options(builder: Builder) -> tuple[list[str], list[str]]:

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -269,6 +269,30 @@ def build_install_extra_build_types(
             )
             builder.install(install_dir, build_type=extra_build_type)
 
+    # A single-config rebuild shim shares this build directory and runs
+    # ``cmake --build`` without a ``--config`` (it was given the primary build
+    # type's options), so the loop above must not leave it on the last extra
+    # type. Restore the primary configuration so import-time rebuilds refresh it.
+    if (
+        len(build_types) > 1
+        and builder.config.single_config
+        and editable
+        and settings.editable.mode == "redirect"
+        and settings.editable.rebuild
+    ):
+        configure_wheel(
+            cmake=builder.config.cmake,
+            build_dir=builder.config.build_dir,
+            build_type=build_types[0],
+            settings=settings,
+            wheel_dirs=wheel_dirs,
+            install_dir=install_dir,
+            state=state,
+            name=name,
+            version=version,
+            extra_cache_entries=extra_cache_entries,
+        )
+
 
 def editable_rebuild_options(builder: Builder) -> tuple[list[str], list[str]]:
     """

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -25,6 +25,7 @@ from ..builder.builder import (
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMaker
 from ..format import pyproject_format
+from ..settings.skbuild_model import normalize_build_types
 from ._pathutil import resolve_wheel_tree
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from ..settings.skbuild_model import ScikitBuildSettings
 
 __all__ = [
+    "build_install_extra_build_types",
     "build_wheel",
     "configure_wheel",
     "editable_rebuild_options",
@@ -139,6 +141,34 @@ def get_install_dir(
     return base / rest
 
 
+def _run_configure(
+    builder: Builder,
+    *,
+    wheel_dirs: Mapping[str, Path],
+    install_dir: Path,
+    state: WheelState,
+    name: str,
+    version: Version,
+    extra_cache_entries: Mapping[str, str | Path] | None,
+) -> None:
+    """Run ``cmake`` configure for ``builder.config.build_type``."""
+    # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
+    # Otherwise `cmake --install --prefix` would work by itself
+    defines = {"CMAKE_INSTALL_PREFIX": install_dir}
+    cache_entries: dict[str, str | Path] = {
+        f"SKBUILD_{k.upper()}_DIR": v for k, v in wheel_dirs.items()
+    }
+    cache_entries["SKBUILD_STATE"] = state
+    if extra_cache_entries:
+        cache_entries.update(extra_cache_entries)
+    builder.configure(
+        defines=defines,
+        cache_entries=cache_entries,
+        name=name,
+        version=version,
+    )
+
+
 def configure_wheel(
     *,
     cmake: CMake,
@@ -154,30 +184,28 @@ def configure_wheel(
     """
     Configure the CMake project, returning the
     :class:`~scikit_build_core.builder.builder.Builder` to build with.
+
+    Only the primary (first) build type is configured here; extra build types
+    are handled by :func:`build_install_extra_build_types` after the primary
+    build and install.
     """
     config = CMaker(
         cmake,
         source_dir=settings.cmake.source_dir,
         build_dir=build_dir,
-        build_type=settings.cmake.build_type,
+        build_type=normalize_build_types(settings.cmake.build_type)[0],
     )
     builder = Builder(settings=settings, config=config)
 
     rich_print("{green}***", "{bold}Configuring CMake...")
-    # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
-    # Otherwise `cmake --install --prefix` would work by itself
-    defines = {"CMAKE_INSTALL_PREFIX": install_dir}
-    cache_entries: dict[str, str | Path] = {
-        f"SKBUILD_{k.upper()}_DIR": v for k, v in wheel_dirs.items()
-    }
-    cache_entries["SKBUILD_STATE"] = state
-    if extra_cache_entries:
-        cache_entries.update(extra_cache_entries)
-    builder.configure(
-        defines=defines,
-        cache_entries=cache_entries,
+    _run_configure(
+        builder,
+        wheel_dirs=wheel_dirs,
+        install_dir=install_dir,
+        state=state,
         name=name,
         version=version,
+        extra_cache_entries=extra_cache_entries,
     )
     return builder
 
@@ -205,6 +233,59 @@ def install_wheel(builder: Builder, *, install_dir: Path, editable: bool) -> Non
         return
     rich_print("{green}***", "{bold}Installing project into wheel...")
     builder.install(install_dir)
+
+
+def build_install_extra_build_types(
+    builder: Builder,
+    *,
+    settings: ScikitBuildSettings,
+    wheel_dirs: Mapping[str, Path],
+    install_dir: Path,
+    state: WheelState,
+    name: str,
+    version: Version,
+    editable: bool,
+    extra_cache_entries: Mapping[str, str | Path] | None = None,
+) -> None:
+    """
+    Build and install build types beyond the primary into the same wheel.
+
+    Single-config generators (Ninja, Makefiles) are reconfigured in place for
+    each extra build type; multi-config generators just build the extra
+    ``--config``. Everything installs to the same prefix.
+
+    Call this after the primary build and install, and after
+    :func:`editable_rebuild_options` (which reads ``builder.config.build_type``,
+    mutated here).
+    """
+    build_types = normalize_build_types(settings.cmake.build_type)
+    for extra_build_type in build_types[1:]:
+        builder.config.build_type = extra_build_type
+        if builder.config.single_config:
+            rich_print(
+                "{green}***",
+                f"{{bold}}Reconfiguring CMake for {{blue}}{extra_build_type}{{default}}...",
+            )
+            _run_configure(
+                builder,
+                wheel_dirs=wheel_dirs,
+                install_dir=install_dir,
+                state=state,
+                name=name,
+                version=version,
+                extra_cache_entries=extra_cache_entries,
+            )
+        rich_print(
+            "{green}***",
+            f"{{bold}}Building {{blue}}{extra_build_type}{{default}} project...",
+        )
+        builder.build(build_args=[])
+        if not (editable and settings.editable.mode == "inplace"):
+            rich_print(
+                "{green}***",
+                f"{{bold}}Installing {{blue}}{extra_build_type}{{default}} project into wheel...",
+            )
+            builder.install(install_dir)
 
 
 def editable_rebuild_options(builder: Builder) -> tuple[list[str], list[str]]:

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -141,18 +141,44 @@ def get_install_dir(
     return base / rest
 
 
-def _run_configure(
-    builder: Builder,
+def configure_wheel(
     *,
+    cmake: CMake,
+    settings: ScikitBuildSettings,
     wheel_dirs: Mapping[str, Path],
     install_dir: Path,
+    build_dir: Path,
     state: WheelState,
     name: str,
     version: Version,
-    extra_cache_entries: Mapping[str, str | Path] | None,
+    extra_cache_entries: Mapping[str, str | Path] | None = None,
     build_type: str | None = None,
-) -> None:
-    """Run ``cmake`` configure, optionally overriding the build type."""
+) -> Builder:
+    """
+    Configure the CMake project, returning the
+    :class:`~scikit_build_core.builder.builder.Builder` to build with.
+
+    Defaults to the primary (first) build type. It is rerunnable: pass an extra
+    ``build_type`` to reconfigure a single-config generator into a fresh builder
+    for that build type (see :func:`build_install_extra_build_types`).
+    """
+    if build_type is None:
+        build_type = normalize_build_types(settings.cmake.build_type)[0]
+        rich_print("{green}***", "{bold}Configuring CMake...")
+    else:
+        rich_print(
+            "{green}***",
+            f"{{bold}}Reconfiguring CMake for {{blue}}{build_type}{{default}}...",
+        )
+
+    config = CMaker(
+        cmake,
+        source_dir=settings.cmake.source_dir,
+        build_dir=build_dir,
+        build_type=build_type,
+    )
+    builder = Builder(settings=settings, config=config)
+
     # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
     # Otherwise `cmake --install --prefix` would work by itself
     defines = {"CMAKE_INSTALL_PREFIX": install_dir}
@@ -167,47 +193,6 @@ def _run_configure(
         cache_entries=cache_entries,
         name=name,
         version=version,
-        build_type=build_type,
-    )
-
-
-def configure_wheel(
-    *,
-    cmake: CMake,
-    settings: ScikitBuildSettings,
-    wheel_dirs: Mapping[str, Path],
-    install_dir: Path,
-    build_dir: Path,
-    state: WheelState,
-    name: str,
-    version: Version,
-    extra_cache_entries: Mapping[str, str | Path] | None = None,
-) -> Builder:
-    """
-    Configure the CMake project, returning the
-    :class:`~scikit_build_core.builder.builder.Builder` to build with.
-
-    Only the primary (first) build type is configured here; extra build types
-    are handled by :func:`build_install_extra_build_types` after the primary
-    build and install.
-    """
-    config = CMaker(
-        cmake,
-        source_dir=settings.cmake.source_dir,
-        build_dir=build_dir,
-        build_type=normalize_build_types(settings.cmake.build_type)[0],
-    )
-    builder = Builder(settings=settings, config=config)
-
-    rich_print("{green}***", "{bold}Configuring CMake...")
-    _run_configure(
-        builder,
-        wheel_dirs=wheel_dirs,
-        install_dir=install_dir,
-        state=state,
-        name=name,
-        version=version,
-        extra_cache_entries=extra_cache_entries,
     )
     return builder
 
@@ -252,30 +237,25 @@ def build_install_extra_build_types(
     """
     Build and install build types beyond the primary into the same wheel.
 
-    Single-config generators (Ninja, Makefiles) are reconfigured in place for
-    each extra build type; multi-config generators just build the extra
-    ``--config``. Everything installs to the same prefix.
-
-    The build type is passed per call, so ``builder.config.build_type`` keeps
-    pointing at the primary build type. Call this after the primary build and
-    install.
+    Single-config generators (Ninja, Makefiles) are reconfigured into a fresh
+    builder for each extra build type; multi-config generators just build the
+    extra ``--config`` with the original builder. Everything installs to the same
+    prefix. Call this after the primary build and install.
     """
     build_types = normalize_build_types(settings.cmake.build_type)
     for extra_build_type in build_types[1:]:
         if builder.config.single_config:
-            rich_print(
-                "{green}***",
-                f"{{bold}}Reconfiguring CMake for {{blue}}{extra_build_type}{{default}}...",
-            )
-            _run_configure(
-                builder,
+            builder = configure_wheel(
+                cmake=builder.config.cmake,
+                build_dir=builder.config.build_dir,
+                build_type=extra_build_type,
+                settings=settings,
                 wheel_dirs=wheel_dirs,
                 install_dir=install_dir,
                 state=state,
                 name=name,
                 version=version,
                 extra_cache_entries=extra_cache_entries,
-                build_type=extra_build_type,
             )
         rich_print(
             "{green}***",

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -415,7 +415,6 @@ def _build_wheel_impl_impl(
                 return WheelImplReturn("", settings=settings)
             build_wheel(builder)
             install_wheel(builder, install_dir=install_dir, editable=editable)
-            # Read the primary build type before extra build types mutate it.
             build_options, install_options = editable_rebuild_options(builder)
             build_install_extra_build_types(
                 builder,

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -32,6 +32,7 @@ from ._pathutil import (
 from ._scripts import process_script_dir
 from ._wheelfile import WheelMetadata, WheelWriter
 from .common_wheel_helpers import (
+    build_install_extra_build_types,
     build_wheel,
     configure_wheel,
     editable_rebuild_options,
@@ -414,7 +415,18 @@ def _build_wheel_impl_impl(
                 return WheelImplReturn("", settings=settings)
             build_wheel(builder)
             install_wheel(builder, install_dir=install_dir, editable=editable)
+            # Read the primary build type before extra build types mutate it.
             build_options, install_options = editable_rebuild_options(builder)
+            build_install_extra_build_types(
+                builder,
+                settings=settings,
+                wheel_dirs=wheel_dirs,
+                install_dir=install_dir,
+                state=state,
+                name=metadata.name,
+                version=metadata.version,
+                editable=editable,
+            )
 
         assert wheel_directory is not None
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -193,7 +193,6 @@ class Builder:
         version: Version | None = None,
         limited_api: bool | None = None,
         configure_args: Iterable[str] = (),
-        build_type: str | None = None,
     ) -> None:
         cmake_defines = {
             k: ("TRUE" if v else "FALSE") if isinstance(v, bool) else str(v)
@@ -382,7 +381,6 @@ class Builder:
             defines=cmake_defines,
             cmake_args=[*self.get_cmake_args(), *configure_args],
             toolchain=self.settings.cmake.toolchain_file,
-            build_type=build_type,
         )
 
     def build(

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -193,6 +193,7 @@ class Builder:
         version: Version | None = None,
         limited_api: bool | None = None,
         configure_args: Iterable[str] = (),
+        build_type: str | None = None,
     ) -> None:
         cmake_defines = {
             k: ("TRUE" if v else "FALSE") if isinstance(v, bool) else str(v)
@@ -381,9 +382,12 @@ class Builder:
             defines=cmake_defines,
             cmake_args=[*self.get_cmake_args(), *configure_args],
             toolchain=self.settings.cmake.toolchain_file,
+            build_type=build_type,
         )
 
-    def build(self, build_args: Sequence[str]) -> None:
+    def build(
+        self, build_args: Sequence[str], *, build_type: str | None = None
+    ) -> None:
         build_tool_args = self.settings.build.tool_args
         if build_tool_args:
             build_args = [*build_args, "--", *build_tool_args]
@@ -392,9 +396,12 @@ class Builder:
             build_args=build_args,
             targets=self.settings.build.targets,
             verbose=self.settings.build.verbose,
+            build_type=build_type,
         )
 
-    def install(self, install_dir: Path | None) -> None:
+    def install(
+        self, install_dir: Path | None, *, build_type: str | None = None
+    ) -> None:
         """
         Install to a path.
 
@@ -407,5 +414,9 @@ class Builder:
         strip = self.settings.install.strip
         assert strip is not None
         self.config.install(
-            install_dir, strip=strip, components=components, targets=targets
+            install_dir,
+            strip=strip,
+            components=components,
+            targets=targets,
+            build_type=build_type,
         )

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -266,7 +266,11 @@ class CMaker:
         defines: Mapping[str, str | os.PathLike[str] | bool] | None = None,
         cmake_args: Sequence[str] = (),
         toolchain: os.PathLike[str] | None = None,
+        build_type: str | None = None,
     ) -> None:
+        # ``build_type`` overrides ``self.build_type`` for this call only, e.g.
+        # to reconfigure a single-config generator for an extra build type.
+        build_type = self.build_type if build_type is None else build_type
         _cmake_args = self._compute_cmake_args(defines or {}, toolchain)
         all_args = [*_cmake_args, *cmake_args]
 
@@ -274,8 +278,8 @@ class CMaker:
         if gen:
             self.single_config = gen == "Ninja" or "Makefiles" in gen
 
-        if self.single_config and self.build_type:
-            all_args.insert(2, f"-DCMAKE_BUILD_TYPE:STRING={self.build_type}")
+        if self.single_config and build_type:
+            all_args.insert(2, f"-DCMAKE_BUILD_TYPE:STRING={build_type}")
 
         try:
             Run(env=self.env).live(self.cmake, *all_args)
@@ -294,12 +298,14 @@ class CMaker:
         self,
         *,
         verbose: bool,
+        build_type: str | None = None,
     ) -> Generator[str, None, None]:
+        build_type = self.build_type if build_type is None else build_type
         if verbose:
             yield "-v"
-        if self.build_type and not self.single_config:
+        if build_type and not self.single_config:
             yield "--config"
-            yield self.build_type
+            yield build_type
 
     def build(
         self,
@@ -307,8 +313,11 @@ class CMaker:
         *,
         targets: Sequence[str] = (),
         verbose: bool = False,
+        build_type: str | None = None,
     ) -> None:
-        local_args = list(self._compute_build_args(verbose=verbose))
+        local_args = list(
+            self._compute_build_args(verbose=verbose, build_type=build_type)
+        )
         if not targets:
             self._build(*local_args, *build_args)
             return
@@ -330,17 +339,21 @@ class CMaker:
         strip: bool = False,
         components: Sequence[str] = (),
         targets: Sequence[str] = (),
+        build_type: str | None = None,
     ) -> None:
+        build_type = self.build_type if build_type is None else build_type
         opts = ["--prefix", str(prefix)] if prefix else []
-        if not self.single_config and self.build_type:
-            opts += ["--config", self.build_type]
+        if not self.single_config and build_type:
+            opts += ["--config", build_type]
         if strip:
             opts.append("--strip")
 
         # These are "built", so --prefix/--strip/--component do not apply.
         for target in targets:
             logger.info("Installing target {}", target)
-            build_args = list(self._compute_build_args(verbose=False))
+            build_args = list(
+                self._compute_build_args(verbose=False, build_type=build_type)
+            )
             self._build(*build_args, "--target", target)
 
         if not components:

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -266,11 +266,7 @@ class CMaker:
         defines: Mapping[str, str | os.PathLike[str] | bool] | None = None,
         cmake_args: Sequence[str] = (),
         toolchain: os.PathLike[str] | None = None,
-        build_type: str | None = None,
     ) -> None:
-        # ``build_type`` overrides ``self.build_type`` for this call only, e.g.
-        # to reconfigure a single-config generator for an extra build type.
-        build_type = self.build_type if build_type is None else build_type
         _cmake_args = self._compute_cmake_args(defines or {}, toolchain)
         all_args = [*_cmake_args, *cmake_args]
 
@@ -278,8 +274,8 @@ class CMaker:
         if gen:
             self.single_config = gen == "Ninja" or "Makefiles" in gen
 
-        if self.single_config and build_type:
-            all_args.insert(2, f"-DCMAKE_BUILD_TYPE:STRING={build_type}")
+        if self.single_config and self.build_type:
+            all_args.insert(2, f"-DCMAKE_BUILD_TYPE:STRING={self.build_type}")
 
         try:
             Run(env=self.env).live(self.cmake, *all_args)

--- a/src/scikit_build_core/format.py
+++ b/src/scikit_build_core/format.py
@@ -8,6 +8,8 @@ import typing
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
+from .settings.skbuild_model import primary_build_type
+
 if TYPE_CHECKING:
     from typing import Literal
 
@@ -106,7 +108,7 @@ def pyproject_format(
         # We are assuming the Path.cwd always evaluates to the folder containing pyproject.toml
         # as part of PEP517 standard.
         root=RootPathResolver(),
-        build_type=settings.cmake.build_type,
+        build_type=primary_build_type(settings.cmake.build_type),
     )
     # Then compute all optional keys depending on the function input
     if tags is not None:

--- a/src/scikit_build_core/format.py
+++ b/src/scikit_build_core/format.py
@@ -8,7 +8,7 @@ import typing
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
-from .settings.skbuild_model import primary_build_type
+from .settings.skbuild_model import normalize_build_types
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -108,7 +108,7 @@ def pyproject_format(
         # We are assuming the Path.cwd always evaluates to the folder containing pyproject.toml
         # as part of PEP517 standard.
         root=RootPathResolver(),
-        build_type=primary_build_type(settings.cmake.build_type),
+        build_type=normalize_build_types(settings.cmake.build_type)[0],
     )
     # Then compute all optional keys depending on the function input
     if tags is not None:

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -211,7 +211,6 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         )
         build_wheel(builder)
         install_wheel(builder, install_dir=install_dir, editable=editable)
-        # Read the primary build type before extra build types mutate it.
         build_options, install_options = editable_rebuild_options(builder)
         build_install_extra_build_types(
             builder,

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -22,6 +22,7 @@ from ..build._editable import (
 from ..build._init import setup_logging
 from ..build._pathutil import packages_to_file_mapping, scantree
 from ..build.common_wheel_helpers import (
+    build_install_extra_build_types,
     build_wheel,
     configure_wheel,
     editable_rebuild_options,
@@ -194,6 +195,9 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         build_data["tag"] = str(tags)
         build_data["pure_python"] = False
 
+        extra_cache_entries = {
+            "SKBUILD_HATCHLING": importlib.metadata.version("hatchling")
+        }
         builder = configure_wheel(
             cmake=cmake,
             settings=settings,
@@ -203,13 +207,23 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             state=state,
             name=self.build_config.builder.metadata.name,
             version=Version(self.build_config.builder.metadata.version),
-            extra_cache_entries={
-                "SKBUILD_HATCHLING": importlib.metadata.version("hatchling")
-            },
+            extra_cache_entries=extra_cache_entries,
         )
         build_wheel(builder)
         install_wheel(builder, install_dir=install_dir, editable=editable)
+        # Read the primary build type before extra build types mutate it.
         build_options, install_options = editable_rebuild_options(builder)
+        build_install_extra_build_types(
+            builder,
+            settings=settings,
+            wheel_dirs=wheel_dirs,
+            install_dir=install_dir,
+            state=state,
+            name=self.build_config.builder.metadata.name,
+            version=Version(self.build_config.builder.metadata.version),
+            editable=editable,
+            extra_cache_entries=extra_cache_entries,
+        )
 
         files = list(wheel_dirs["headers"].iterdir())
         if files:

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -82,7 +82,17 @@
           "deprecated": true
         },
         "build-type": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
           "default": "Release",
           "description": "The build type to use when building the project."
         },
@@ -607,6 +617,9 @@
                     "$ref": "#/$defs/inherit"
                   },
                   "define": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "build-type": {
                     "$ref": "#/$defs/inherit"
                   },
                   "targets": {

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -43,14 +43,6 @@ def normalize_build_types(build_type: Union[str, List[str]]) -> List[str]:
     return build_type or [""]
 
 
-def primary_build_type(build_type: Union[str, List[str]]) -> str:
-    """
-    The first (primary) build type, used wherever a single build type is needed
-    (for example the ``{build_type}`` format variable).
-    """
-    return normalize_build_types(build_type)[0]
-
-
 class SettingsFieldMetadata(TypedDict, total=False):
     display_default: Optional[str]
     deprecated: bool

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -31,6 +31,26 @@ def __dir__() -> List[str]:
     return __all__
 
 
+def normalize_build_types(build_type: Union[str, List[str]]) -> List[str]:
+    """
+    Normalize ``cmake.build-type`` into a non-empty list of build types.
+
+    A plain string becomes a single-element list. An empty list is treated as
+    a single empty build type, preserving the "no explicit build type" behavior.
+    """
+    if isinstance(build_type, str):
+        return [build_type]
+    return build_type or [""]
+
+
+def primary_build_type(build_type: Union[str, List[str]]) -> str:
+    """
+    The first (primary) build type, used wherever a single build type is needed
+    (for example the ``{build_type}`` format variable).
+    """
+    return normalize_build_types(build_type)[0]
+
+
 class SettingsFieldMetadata(TypedDict, total=False):
     display_default: Optional[str]
     deprecated: bool
@@ -193,13 +213,21 @@ class CMakeSettings:
     DEPRECATED in 0.10, use build.verbose instead.
     """
 
-    build_type: str = "Release"
+    build_type: Union[str, List[str]] = "Release"
     """
     The build type to use when building the project.
 
     Pre-defined CMake options are: ``Debug``, ``Release``, ``RelWithDebInfo``, ``MinSizeRel``
 
     Custom values can also be used.
+
+    A list of build types can be given to build and install more than one
+    configuration into the same wheel (for example ``["Release", "Debug"]``).
+    Single-config generators (Ninja, Makefiles) are reconfigured in place for
+    each extra build type; multi-config generators (Visual Studio, Xcode,
+    Ninja Multi-Config) build each ``--config``. Every build type is installed
+    to the same prefix, so use ``CMAKE_<CONFIG>_POSTFIX`` to avoid clobbering
+    files between configurations.
     """
 
     source_dir: Path = Path()

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -214,7 +214,9 @@ class CMakeSettings:
     Custom values can also be used.
 
     A list of build types can be given to build and install more than one
-    configuration into the same wheel (for example ``["Release", "Debug"]``).
+    configuration into the same wheel: ``["Release", "Debug"]`` in TOML, a
+    repeated ``-Ccmake.build-type=...`` config-setting, or ``Release;Debug`` as
+    an environment variable.
     Single-config generators (Ninja, Makefiles) are reconfigured in place for
     each extra build type; multi-config generators (Visual Studio, Xcode,
     Ninja Multi-Config) build each ``--config``. Every build type is installed

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -20,7 +20,12 @@ from ..errors import CMakeConfigError
 from ..utils.typing import get_target_raw_type
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
-from .skbuild_model import CMakeSettings, NinjaSettings, ScikitBuildSettings
+from .skbuild_model import (
+    CMakeSettings,
+    NinjaSettings,
+    ScikitBuildSettings,
+    normalize_build_types,
+)
 from .skbuild_overrides import process_overrides
 from .sources import ConfSource, EnvSource, Source, SourceChain, TOMLSource
 
@@ -360,9 +365,9 @@ class SettingsReader:
             or self.settings.minimum_version >= Version("0.5")
         )
         if self.settings.install.strip is None:
-            self.settings.install.strip = (
-                install_policy
-                and self.settings.cmake.build_type in {"Release", "MinSizeRel"}
+            self.settings.install.strip = install_policy and all(
+                bt in {"Release", "MinSizeRel"}
+                for bt in normalize_build_types(self.settings.cmake.build_type)
             )
 
         # If we noted earlier that auto-cmake was requested, handle it now

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -71,6 +71,7 @@ When setting up your dataclasses, these types are handled:
 - Any callable (`Path`, `Version`): Passed the string input.
 - ``Optional[T]``: Treated like T. Default should be None, since no input format supports None's.
 - ``Union[str, ...]``: Supports other input types in TOML form (bool currently). Otherwise a string.
+- ``Union[str, List[str]]``: A single string, or a list (a repeated option in config form, ``;`` separated in EnvVar/config forms, or native in TOML).
 - ``List[T]``: A list of items. `;` separated supported in EnvVar/config forms. T can be a dataclass (TOML only).
 - ``Dict[str, T]``: A table of items. TOML supports a layer of nesting. Any is supported as an item type.
 - ``Union[list[T], Dict[str, T]]`` (TOML only): A list or dict of items.
@@ -390,6 +391,15 @@ class EnvSource(Source):
 
         if is_union_type(raw_target):
             args = {get_target_raw_type(t): t for t in get_args(target)}
+            # A str+list union (e.g. cmake.build-type) takes a single string or
+            # a ``;``-separated list, like a plain List[str] field.
+            if str in args and list in args:
+                if ";" in item:
+                    return [
+                        cls.convert(i.strip(), get_inner_type(args[list]))
+                        for i in item.split(";")
+                    ]
+                return item
             if str in args:
                 return item
             if dict in args and "=" in item:
@@ -563,6 +573,17 @@ class ConfSource(Source):
             return {k: cls.convert(v, get_inner_type(target)) for k, v in item.items()}
         if is_union_type(raw_target):
             args = {get_target_raw_type(t): t for t in get_args(target)}
+            # A str+list union (e.g. cmake.build-type) takes a single string or
+            # a list. The preferred way to pass a list is to repeat the option
+            # (``-Ccmake.build-type=A -Ccmake.build-type=B``), which the backend
+            # delivers as a real list (handled by the ``str in args`` branch
+            # below). A ``;``-separated string is also accepted, matching a
+            # plain List[str] field.
+            if str in args and list in args and isinstance(item, str) and ";" in item:
+                return [
+                    cls.convert(i.strip(), get_inner_type(args[list]))
+                    for i in item.split(";")
+                ]
             if str in args:
                 return item
             if dict in args and isinstance(item, dict):

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -19,7 +19,7 @@ from .._logging import LEVEL_VALUE, raw_logger
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
 from ..cmake import CMake, CMaker
-from ..settings.skbuild_model import primary_build_type
+from ..settings.skbuild_model import normalize_build_types
 from ..settings.skbuild_read_settings import SettingsReader
 
 if TYPE_CHECKING:
@@ -571,7 +571,7 @@ class BuildCMake(setuptools.Command):
             cmake,
             source_dir=Path(source_dir),
             build_dir=build_temp,
-            build_type=primary_build_type(settings.cmake.build_type),
+            build_type=normalize_build_types(settings.cmake.build_type)[0],
         )
 
         builder = Builder(
@@ -589,7 +589,7 @@ class BuildCMake(setuptools.Command):
             config.env.setdefault("MACOSX_DEPLOYMENT_TARGET", str(orig_macos))
 
         builder.config.build_type = (
-            "Debug" if self.debug else primary_build_type(settings.cmake.build_type)
+            "Debug" if self.debug else normalize_build_types(settings.cmake.build_type)[0]
         )
 
         # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -19,6 +19,7 @@ from .._logging import LEVEL_VALUE, raw_logger
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
 from ..cmake import CMake, CMaker
+from ..settings.skbuild_model import primary_build_type
 from ..settings.skbuild_read_settings import SettingsReader
 
 if TYPE_CHECKING:
@@ -570,7 +571,7 @@ class BuildCMake(setuptools.Command):
             cmake,
             source_dir=Path(source_dir),
             build_dir=build_temp,
-            build_type=settings.cmake.build_type,
+            build_type=primary_build_type(settings.cmake.build_type),
         )
 
         builder = Builder(
@@ -587,7 +588,9 @@ class BuildCMake(setuptools.Command):
             orig_macos = normalize_macos_version(orig_macos_str, arm=arm_only)
             config.env.setdefault("MACOSX_DEPLOYMENT_TARGET", str(orig_macos))
 
-        builder.config.build_type = "Debug" if self.debug else settings.cmake.build_type
+        builder.config.build_type = (
+            "Debug" if self.debug else primary_build_type(settings.cmake.build_type)
+        )
 
         # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX
         # Otherwise `cmake --install --prefix` would work by itself

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -589,7 +589,9 @@ class BuildCMake(setuptools.Command):
             config.env.setdefault("MACOSX_DEPLOYMENT_TARGET", str(orig_macos))
 
         builder.config.build_type = (
-            "Debug" if self.debug else normalize_build_types(settings.cmake.build_type)[0]
+            "Debug"
+            if self.debug
+            else normalize_build_types(settings.cmake.build_type)[0]
         )
 
         # Setting the install prefix because some libs hardcode CMAKE_INSTALL_PREFIX

--- a/tests/packages/multi_build_type/CMakeLists.txt
+++ b/tests/packages/multi_build_type/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15...3.30)
+
+project(
+  ${SKBUILD_PROJECT_NAME}
+  LANGUAGES NONE
+  VERSION ${SKBUILD_PROJECT_VERSION})
+
+# Install a marker file into a per-configuration directory. With
+# cmake.build-type set to a list, this should produce one marker per build type,
+# regardless of whether a single- or multi-config generator is used.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/marker.txt "marker")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/marker.txt
+        DESTINATION ${SKBUILD_PROJECT_NAME}/$<CONFIG>)

--- a/tests/packages/multi_build_type/pyproject.toml
+++ b/tests/packages/multi_build_type/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "multi_build_type"
+version = "0.0.1"
+
+[tool.scikit-build]
+cmake.build-type = ["Release", "Debug"]

--- a/tests/packages/multi_build_type/src/multi_build_type/__init__.py
+++ b/tests/packages/multi_build_type/src/multi_build_type/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+__all__ = ["__version__"]
+__version__ = "0.0.1"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -321,7 +321,10 @@ def test_build_tool_args():
     )
     tmpbuilder.build(["a"])
     config.build.assert_called_once_with(
-        build_args=["a", "--", "b"], targets=[], verbose=settings.build.verbose
+        build_args=["a", "--", "b"],
+        targets=[],
+        verbose=settings.build.verbose,
+        build_type=None,
     )
 
 

--- a/tests/test_multi_build_type.py
+++ b/tests/test_multi_build_type.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from packaging.specifiers import SpecifierSet
 
-from scikit_build_core.build import build_wheel
+from scikit_build_core.build import build_editable, build_wheel
 from scikit_build_core.program_search import best_program, get_cmake_programs
 
 DIR = Path(__file__).parent.absolute()
@@ -79,3 +79,34 @@ def test_multi_build_type_override_single(tmp_path: Path) -> None:
 
     assert "multi_build_type/Release/marker.txt" in names
     assert "multi_build_type/Debug/marker.txt" not in names
+
+
+def _read_cache_build_type(build_dir: Path) -> str:
+    for line in (build_dir / "CMakeCache.txt").read_text().splitlines():
+        if line.startswith("CMAKE_BUILD_TYPE:"):
+            return line.split("=", 1)[1]
+    return ""
+
+
+@pytest.mark.configure
+@pytest.mark.skipif(not has_ninja, reason="ninja required")
+@pytest.mark.parametrize("package", ["multi_build_type"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_multi_build_type_editable_rebuild_restores_primary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single-config rebuild build dir is left on the primary build type.
+
+    The redirect rebuild shim runs ``cmake --build`` without ``--config`` and was
+    given the primary configuration's options, so the shared build directory must
+    end configured for the primary type, not the last extra one.
+    """
+    monkeypatch.setenv("CMAKE_GENERATOR", "Ninja")
+    build_dir = tmp_path / "build"
+    dist = tmp_path / "dist"
+    build_editable(
+        str(dist),
+        {"build-dir": str(build_dir), "editable.rebuild": "true"},
+    )
+
+    assert _read_cache_build_type(build_dir) == "Release"

--- a/tests/test_multi_build_type.py
+++ b/tests/test_multi_build_type.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scikit_build_core.build import build_wheel
+
+DIR = Path(__file__).parent.absolute()
+
+has_ninja = shutil.which("ninja") is not None
+
+
+@pytest.fixture(
+    params=[
+        None,
+        pytest.param(
+            "Ninja",
+            marks=pytest.mark.skipif(not has_ninja, reason="ninja required"),
+        ),
+        pytest.param(
+            "Ninja Multi-Config",
+            marks=pytest.mark.skipif(not has_ninja, reason="ninja required"),
+        ),
+    ]
+)
+def generator(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> str | None:
+    if request.param is None:
+        monkeypatch.delenv("CMAKE_GENERATOR", raising=False)
+    else:
+        monkeypatch.setenv("CMAKE_GENERATOR", request.param)
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.mark.configure
+@pytest.mark.parametrize("package", ["multi_build_type"], indirect=True)
+@pytest.mark.usefixtures("package", "generator")
+def test_multi_build_type_wheel(tmp_path: Path) -> None:
+    """A list cmake.build-type installs every configuration into one wheel."""
+    dist = tmp_path / "dist"
+    out = build_wheel(str(dist), {})
+    wheel = (dist / out).resolve()
+
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+
+    # Both the Release and Debug configurations should be installed.
+    assert "multi_build_type/Release/marker.txt" in names
+    assert "multi_build_type/Debug/marker.txt" in names
+
+
+@pytest.mark.configure
+@pytest.mark.parametrize("package", ["multi_build_type"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_multi_build_type_override_single(tmp_path: Path) -> None:
+    """A single build type passed via config-settings overrides the list."""
+    dist = tmp_path / "dist"
+    out = build_wheel(str(dist), {"cmake.build-type": "Release"})
+    wheel = (dist / out).resolve()
+
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+
+    assert "multi_build_type/Release/marker.txt" in names
+    assert "multi_build_type/Debug/marker.txt" not in names

--- a/tests/test_multi_build_type.py
+++ b/tests/test_multi_build_type.py
@@ -5,12 +5,18 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from packaging.specifiers import SpecifierSet
 
 from scikit_build_core.build import build_wheel
+from scikit_build_core.program_search import best_program, get_cmake_programs
 
 DIR = Path(__file__).parent.absolute()
 
 has_ninja = shutil.which("ninja") is not None
+# Ninja Multi-Config requires CMake 3.17+.
+has_multi_config = (
+    best_program(get_cmake_programs(), version=SpecifierSet(">=3.17")) is not None
+)
 
 
 @pytest.fixture(
@@ -22,7 +28,13 @@ has_ninja = shutil.which("ninja") is not None
         ),
         pytest.param(
             "Ninja Multi-Config",
-            marks=pytest.mark.skipif(not has_ninja, reason="ninja required"),
+            marks=[
+                pytest.mark.skipif(not has_ninja, reason="ninja required"),
+                pytest.mark.skipif(
+                    not has_multi_config,
+                    reason="CMake 3.17+ required for Ninja Multi-Config",
+                ),
+            ],
         ),
     ]
 )

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -184,6 +184,66 @@ def test_skbuild_settings_cmake_build_type_list(
     assert settings_reader.settings.install.strip is False
 
 
+def test_skbuild_settings_cmake_build_type_list_envvar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A ``;``-separated SKBUILD_CMAKE_BUILD_TYPE becomes a list of build types."""
+    monkeypatch.delenv("CMAKE_BUILD_TYPE", raising=False)
+    monkeypatch.setenv("SKBUILD_CMAKE_BUILD_TYPE", "Release;Debug")
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.cmake.build_type == ["Release", "Debug"]
+    assert settings_reader.settings.install.strip is False
+
+
+def test_skbuild_settings_cmake_build_type_single_envvar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A plain SKBUILD_CMAKE_BUILD_TYPE stays a single string."""
+    monkeypatch.delenv("CMAKE_BUILD_TYPE", raising=False)
+    monkeypatch.setenv("SKBUILD_CMAKE_BUILD_TYPE", "Debug")
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.cmake.build_type == "Debug"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # The preferred way is a repeated option, which the backend delivers as
+        # a real list; a ``;``-separated string is also accepted.
+        pytest.param(["Release", "Debug"], ["Release", "Debug"], id="list"),
+        pytest.param("Release;Debug", ["Release", "Debug"], id="string"),
+        pytest.param("Debug", "Debug", id="single"),
+    ],
+)
+def test_skbuild_settings_cmake_build_type_list_config_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | list[str],
+    expected: str | list[str],
+):
+    """cmake.build-type from config-settings accepts a list or ``;``-string."""
+    monkeypatch.delenv("CMAKE_BUILD_TYPE", raising=False)
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml, {"cmake.build-type": value}
+    )
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.cmake.build_type == expected
+
+
 def test_skbuild_settings_cmake_build_type_explicit_wins(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -160,6 +160,30 @@ def test_skbuild_settings_cmake_build_type_envvar(
     assert settings_reader.settings.cmake.build_type == "RelWithAssert"
 
 
+def test_skbuild_settings_cmake_build_type_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """cmake.build-type accepts a list of build types."""
+    monkeypatch.delenv("CMAKE_BUILD_TYPE", raising=False)
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            cmake.build-type = ["Release", "Debug"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, {})
+    assert list(settings_reader.unrecognized_options()) == []
+    assert settings_reader.settings.cmake.build_type == ["Release", "Debug"]
+    # A Debug configuration in the list disables the default strip.
+    assert settings_reader.settings.install.strip is False
+
+
 def test_skbuild_settings_cmake_build_type_explicit_wins(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
Closes #873.

## What

`cmake.build-type` now accepts **either a string (unchanged) or a list** of build types. When a list is given, every configuration is built and installed into the same wheel:

- **Single-config generators** (Ninja, Makefiles): reconfigure in place with `-DCMAKE_BUILD_TYPE` for each extra build type and rebuild.
- **Multi-config generators** (Visual Studio, Xcode, Ninja Multi-Config): build and install each `--config` (no reconfigure).

```toml
[tool.scikit-build]
cmake.build-type = ["Release", "Debug"]
```

All configurations install to the same prefix, so users should set `CMAKE_<CONFIG>_POSTFIX` (e.g. `_d`) to avoid clobbering files between configurations and select the right module at runtime in their package's `__init__.py` — matching the [py-build-cmake approach](https://github.com/tttapa/py-build-cmake/blob/main/docs/usage/debug.md) referenced in the issue.

## Changes

- **`settings/skbuild_model.py`** — `build_type: Union[str, List[str]]`, plus `normalize_build_types()` / `primary_build_type()` helpers.
- **`build/wheel.py`** and **`hatch/plugin.py`** — after the primary configure/build/install, loop over any extra build types (reconfiguring in place only for single-config generators).
- **`format.py`**, **`setuptools/build_cmake.py`** — use the primary (first) build type wherever a single string is required.
- **`settings/skbuild_read_settings.py`** — the default install strip is now only enabled when *every* build type is release-like, so a list containing `Debug` is not stripped.
- Regenerated `scikit-build.schema.json` (schema generator) and `docs/reference/configs.md` (cog); added prose to the configuration guide.

## Scope / notes

- Supported by the default (native) and **Hatchling** backends. The **setuptools** plugin uses the first (primary) build type only, since its `build_ext` flow builds a single extension.
- This implements the in-place-reconfigure baseline from the issue. The optional "separate build directories per config for single-config generators" idea is a natural follow-up and is **not** included here.

## Testing

- New `multi_build_type` test package + `tests/test_multi_build_type.py`: builds real wheels on **Ninja** and **Ninja Multi-Config** and asserts both `Release/` and `Debug/` artifacts land in the wheel; also checks that a single build type passed via config-settings overrides the list.
- New settings test covering list parsing and the strip default.
- Existing direct-build suites pass locally (`test_pyproject_pep517`, `test_schema`, `test_skbuild_settings`, `test_settings_docs`, `test_cmake_config`, `test_format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFo86D5t1WASYQR5h43CJb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFo86D5t1WASYQR5h43CJb)_