### PR TITLE
docs: add GitHub icon to header icon row

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
-        exclude: "^tests|src/scikit_build_core/resources/scikit-build.schema.json|^docs/projects.md"
+        exclude: "^tests|src/scikit_build_core/resources/scikit-build.schema.json|^docs/projects.md|^docs/_templates/"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: d2823d321df3af8f878f7ee3414dc94d037145b9 # frozen: v2.1.0

--- a/docs/_templates/components/edit-this-page.html
+++ b/docs/_templates/components/edit-this-page.html
@@ -1,0 +1,29 @@
+{% extends "!components/edit-this-page.html" %}
+
+{#- Add a repo link next to the view/edit icons at the top of the page, using
+   furo's `source_repository` option. Reuses furo's `.muted-link` styling so it
+   matches and stays responsive. -#}
+{%- macro furo_github_button() -%}
+{%- if theme_source_repository -%}
+<div class="github-this-page">
+  <a class="muted-link" href="{{ theme_source_repository }}"
+     title="{{ _("View on GitHub") }}">
+    <svg viewBox="0 0 16 16" stroke="currentColor" fill="currentColor" stroke-width="0"
+         style="height: 1.25rem; width: 1.25rem;" aria-hidden="true">
+      <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+    </svg>
+    <span class="visually-hidden">{{ _("View on GitHub") }}</span>
+  </a>
+</div>
+{%- endif -%}
+{%- endmacro -%}
+
+{% block link_available -%}
+{{ super() }}
+{{ furo_github_button() }}
+{%- endblock %}
+
+{% block link_not_available -%}
+{{ super() }}
+{{ furo_github_button() }}
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = []
+templates_path = ["_templates"]
 
 source_suffix = [".rst", ".md"]
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Adds a GitHub repository link to the row of icons at the top right of each docs page, next to the existing **view** and **edit** source icons.

## How

Overrides furo's `components/edit-this-page.html` to append a GitHub octocat link after the edit button. It reuses furo's own `.muted-link` class so it visually matches the view/edit icons and inherits their responsive behavior (it lives in `.content-icon-container`, so no fixed positioning or narrow-screen overflow). The SVG is sized to `1.25rem` to match furo's view/edit icon rule.

The link URL comes from furo's existing `source_repository` theme option (exposed to the template as `theme_source_repository`), so it is not hardcoded; the icon is omitted if that option is unset.

`templates_path` is set to `["_templates"]` to enable the override. Jinja templates under `docs/_templates/` are excluded from prettier, which cannot parse the `{{ }}` expressions.

## Notes

- This replaces an earlier "fork me" corner-ribbon idea, which didn't handle narrow screens well.
- Verified the docs build cleanly and the icon renders on every page.