### PR TITLE
fix(types): handle typed vcs_versioning.overrides in mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
           - pytest<9 # pytest 9 requires Python 3.10+
           - pytest-subprocess
           - rich
-          - setuptools-scm
+          - setuptools-scm>=10.1 # 10.1 pulls in typed vcs-versioning>=2.0
           - tomli
           - types-setuptools>=80.9
 

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -11,7 +11,7 @@ from scikit_build_core.setuptools.build_meta import build_wheel
 try:
     from vcs_versioning.overrides import GlobalOverrides
 except ImportError:  # pragma: no cover - setuptools-scm < 10 or missing dependency
-    GlobalOverrides = None
+    GlobalOverrides = None  # type: ignore[assignment, misc]
 
 pytestmark = pytest.mark.setuptools
 

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -21,7 +21,7 @@ from scikit_build_core.setuptools.build_meta import build_sdist, build_wheel
 try:
     from vcs_versioning.overrides import GlobalOverrides
 except ImportError:  # pragma: no cover - setuptools-scm < 10 or missing dependency
-    GlobalOverrides = None
+    GlobalOverrides = None  # type: ignore[assignment, misc]
 
 pytestmark = pytest.mark.setuptools
 setuptools_version = Version(importlib.metadata.version("setuptools"))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Fixes the `mypy` pre-commit hook failure currently breaking CI on unrelated PRs (e.g. #1387). The errors are in `tests/test_setuptools_abi3.py` and `tests/test_setuptools_pep517.py`:

```
error: Cannot assign to a type  [misc]
error: Incompatible types in assignment (expression has type "None", variable has type "type[GlobalOverrides]")  [assignment]
```

## Why

`setuptools-scm` 10.1 requires `vcs-versioning>=2.0`, which now ships a `py.typed` marker. mypy therefore resolves `vcs_versioning.overrides.GlobalOverrides` to a real type, and the optional-import fallback `except ImportError: GlobalOverrides = None` no longer type-checks.

This only surfaced in CI because the mypy hook pinned `setuptools-scm` unpinned, and could resolve locally to the older, untyped `vcs-versioning` 1.1.1 (treated as `Any`), where the assignment was fine.

## How

- Pin `setuptools-scm>=10.1` in the mypy hook's `additional_dependencies` so the typed `vcs_versioning` resolves locally too — the failure now reproduces (and is fixed) in `prek`/`pre-commit`, not just CI.
- Add a targeted `# type: ignore[assignment, misc]` on the `GlobalOverrides = None` fallback in both test files.

Verified with `prek mypy -a` (passes under `strict` + `warn_unused_ignores`, confirming the ignore is genuinely used) and the 22 setuptools tests still pass.