### PR TITLE
feat(wheel): reproducible wheels (closes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ wheel.build-tag = ""
 # Force-include files into the wheel.
 wheel.force-include = {}
 
+# Try to build a reproducible wheel.
+wheel.reproducible = true
+
 # If CMake is less than this value, backport a copy of FindPython.
 backport.find-python = "3.26.1"
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ wheel.build-tag = ""
 # Force-include files into the wheel.
 wheel.force-include = {}
 
-# Try to build a reproducible wheel.
-wheel.reproducible = true
+# Try to build a reproducible wheel. Opt-in, as normalizing permissions can
+wheel.reproducible = false
 
 # If CMake is less than this value, backport a copy of FindPython.
 backport.find-python = "3.26.1"

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ wheel.build-tag = ""
 # Force-include files into the wheel.
 wheel.force-include = {}
 
-# Try to build a reproducible wheel. Opt-in, as normalizing permissions can
+# Try to build a reproducible wheel.
 wheel.reproducible = false
 
 # If CMake is less than this value, backport a copy of FindPython.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -514,14 +514,15 @@ And you can turn off binary stripping:
 
 ```
 
-Like SDists, wheels are reproducible by default: archive timestamps and file
-permissions are normalized, and `SOURCE_DATE_EPOCH` is exported to the CMake
-build (if not already set) so compilers that honor it can produce deterministic
-output. This cannot make the compiled binaries themselves reproducible on its
-own — that also depends on a recent compiler and flags like `-ffile-prefix-map`.
-You can disable the normalization if you prefer:
+You can opt in to reproducible wheels (unlike SDists, this is off by default, as
+normalizing permissions can change the result for some projects). When enabled,
+archive timestamps and file permissions are normalized, and `SOURCE_DATE_EPOCH`
+is exported to the CMake build (if not already set) so compilers that honor it
+can produce deterministic output. This cannot make the compiled binaries
+themselves reproducible on its own — that also depends on a recent compiler and
+flags like `-ffile-prefix-map`.
 
-```{conftabs} wheel.reproducible False
+```{conftabs} wheel.reproducible True
 
 ```
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -514,6 +514,17 @@ And you can turn off binary stripping:
 
 ```
 
+Like SDists, wheels are reproducible by default: archive timestamps and file
+permissions are normalized, and `SOURCE_DATE_EPOCH` is exported to the CMake
+build (if not already set) so compilers that honor it can produce deterministic
+output. This cannot make the compiled binaries themselves reproducible on its
+own — that also depends on a recent compiler and flags like `-ffile-prefix-map`.
+You can disable the normalization if you prefer:
+
+```{conftabs} wheel.reproducible False
+
+```
+
 ## Configuring CMake arguments and defines
 
 You can select a different build type, such as `Debug`:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -514,13 +514,12 @@ And you can turn off binary stripping:
 
 ```
 
-You can opt in to reproducible wheels (unlike SDists, this is off by default, as
-normalizing permissions can change the result for some projects). When enabled,
-archive timestamps and file permissions are normalized, and `SOURCE_DATE_EPOCH`
-is exported to the CMake build (if not already set) so compilers that honor it
-can produce deterministic output. This cannot make the compiled binaries
-themselves reproducible on its own — that also depends on a recent compiler and
-flags like `-ffile-prefix-map`.
+You can opt in to reproducible wheels (unlike SDists, this is off by default).
+When enabled, archive timestamps and file permissions are normalized, and
+`SOURCE_DATE_EPOCH` is exported to the CMake build (if not already set) so
+compilers that honor it can produce deterministic output. This cannot make the
+compiled binaries themselves reproducible on its own — that also depends on a
+recent compiler and flags like `-ffile-prefix-map`.
 
 ```{conftabs} wheel.reproducible True
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -949,11 +949,12 @@ print(mk_skbuild_docs())
 .. confval:: wheel.reproducible
 
   :Type: ``bool``
-  :Default: true
+  :Default: false
   :Config-settings: ``wheel.reproducible`` or ``skbuild.wheel.reproducible``
   :Environment variable: ``SKBUILD_WHEEL_REPRODUCIBLE``
 
-  Try to build a reproducible wheel.
+  Try to build a reproducible wheel. Opt-in, as normalizing permissions can
+  change the result for some projects.
 
   Unix and Python 3.9+ recommended.
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -946,6 +946,27 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: wheel.reproducible
+
+  :Type: ``bool``
+  :Default: true
+  :Config-settings: ``wheel.reproducible`` or ``skbuild.wheel.reproducible``
+  :Environment variable: ``SKBUILD_WHEEL_REPRODUCIBLE``
+
+  Try to build a reproducible wheel.
+
+  Unix and Python 3.9+ recommended.
+
+  When enabled, archive timestamps and file permissions are normalized, and
+  ``SOURCE_DATE_EPOCH`` is exported to the CMake build (if not already set) so
+  compilers that honor it can produce deterministic output. ``SOURCE_DATE_EPOCH``
+  is used for timestamps if set, or a fixed value if not.
+
+  .. seealso::
+     :confval:`sdist.reproducible`
+```
+
+```{eval-rst}
 .. confval:: wheel.tags
 
   :Type: ``list[str]``

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -953,8 +953,7 @@ print(mk_skbuild_docs())
   :Config-settings: ``wheel.reproducible`` or ``skbuild.wheel.reproducible``
   :Environment variable: ``SKBUILD_WHEEL_REPRODUCIBLE``
 
-  Try to build a reproducible wheel. Opt-in, as normalizing permissions can
-  change the result for some projects.
+  Try to build a reproducible wheel.
 
   Unix and Python 3.9+ recommended.
 

--- a/src/scikit_build_core/_reproducible.py
+++ b/src/scikit_build_core/_reproducible.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+
+__all__ = ["MIN_TIMESTAMP", "get_reproducible_epoch", "normalize_file_permissions"]
+
+# The ZIP file format does not support timestamps before 1980-01-01 00:00:00 UTC.
+MIN_TIMESTAMP = 315532800
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def get_reproducible_epoch() -> int:
+    """
+    Return an integer representing the integer number of seconds since the Unix epoch.
+
+    If the `SOURCE_DATE_EPOCH` environment variable is set, use that value. Otherwise,
+    always return `1667997441`.
+    """
+    return int(os.environ.get("SOURCE_DATE_EPOCH", "1667997441"))
+
+
+def normalize_file_permissions(st_mode: int) -> int:
+    """
+    Normalize the permission bits in the st_mode field from stat to 644/755
+    Popular VCSs only track whether a file is executable or not. The exact
+    permissions can vary on systems with different umasks. Normalising
+    to 644 (non executable) or 755 (executable) makes builds more reproducible.
+
+    Taken from https://github.com/pypa/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
+    """
+    # Set 644 permissions, leaving higher bits of st_mode unchanged
+    new_mode = (st_mode | 0o644) & ~0o133
+    if st_mode & 0o100:
+        new_mode |= 0o111  # Executable: 644 -> 755
+    return new_mode

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -82,7 +82,7 @@ class WheelWriter:
     metadata_dir: Path | None
     variant_label: str = ""
     variant_dist_info_contents: bytes | None = None
-    reproducible: bool = True
+    reproducible: bool = False
     _zipfile: zipfile.ZipFile | None = None
 
     @property

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -18,6 +18,11 @@ from zipfile import ZipInfo
 import pathspec
 
 from .. import __version__
+from .._reproducible import (
+    MIN_TIMESTAMP,
+    get_reproducible_epoch,
+    normalize_file_permissions,
+)
 from .._variants import VARIANT_DIST_INFO_FILENAME
 
 if TYPE_CHECKING:
@@ -30,8 +35,6 @@ if TYPE_CHECKING:
     from .._vendor.pyproject_metadata import StandardMetadata
 
 EMAIL_POLICY = EmailPolicy(max_line_length=0, mangle_from_=False, utf8=True)
-
-MIN_TIMESTAMP = 315532800  # 1980-01-01 00:00:00 UTC
 
 
 def _b64encode(data: bytes) -> bytes:
@@ -79,6 +82,7 @@ class WheelWriter:
     metadata_dir: Path | None
     variant_label: str = ""
     variant_dist_info_contents: bytes | None = None
+    reproducible: bool = True
     _zipfile: zipfile.ZipFile | None = None
 
     @property
@@ -107,9 +111,14 @@ class WheelWriter:
     def dist_info(self) -> str:
         return f"{self.name_ver}.dist-info"
 
-    @staticmethod
-    def timestamp(mtime: float | None = None) -> tuple[int, int, int, int, int, int]:
-        timestamp = int(os.environ.get("SOURCE_DATE_EPOCH", mtime or time.time()))
+    def timestamp(
+        self, mtime: float | None = None
+    ) -> tuple[int, int, int, int, int, int]:
+        if self.reproducible:
+            # Honor SOURCE_DATE_EPOCH, else a fixed epoch (ignore per-file mtime).
+            timestamp = get_reproducible_epoch()
+        else:
+            timestamp = int(os.environ.get("SOURCE_DATE_EPOCH", mtime or time.time()))
         # The ZIP file format does not support timestamps before 1980.
         timestamp = max(timestamp, MIN_TIMESTAMP)
         return time.gmtime(timestamp)[0:6]
@@ -220,7 +229,10 @@ class WheelWriter:
             date_time=self.timestamp(st.st_mtime),
         )
         zinfo.compress_type = zipfile.ZIP_DEFLATED
-        zinfo.external_attr = (stat.S_IMODE(st.st_mode) | stat.S_IFMT(st.st_mode)) << 16
+        mode = (
+            normalize_file_permissions(st.st_mode) if self.reproducible else st.st_mode
+        )
+        zinfo.external_attr = (stat.S_IMODE(mode) | stat.S_IFMT(st.st_mode)) << 16
         self.writestr(zinfo, data)
 
     def writestr(self, zinfo_or_arcname: str | ZipInfo, data: bytes) -> None:

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -247,7 +247,8 @@ class WheelWriter:
                 date_time=self.timestamp(),
             )
             zinfo.compress_type = zipfile.ZIP_DEFLATED
-            zinfo.external_attr = (0o664 | stat.S_IFREG) << 16
+            mode = 0o644 if self.reproducible else 0o664
+            zinfo.external_attr = (mode | stat.S_IFREG) << 16
         assert "\\" not in zinfo.filename, (
             f"\\ not supported in zip; got {zinfo.filename!r}"
         )

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -5,7 +5,6 @@ import contextlib
 import copy
 import gzip
 import io
-import os
 import tarfile
 from pathlib import Path
 
@@ -15,6 +14,7 @@ from packaging.utils import canonicalize_name
 from .. import __version__
 from .._compat import tomllib
 from .._logging import rich_print
+from .._reproducible import get_reproducible_epoch, normalize_file_permissions
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
 from ._init import setup_logging
@@ -28,32 +28,6 @@ __all__ = ["build_sdist"]
 
 def __dir__() -> list[str]:
     return __all__
-
-
-def get_reproducible_epoch() -> int:
-    """
-    Return an integer representing the integer number of seconds since the Unix epoch.
-
-    If the `SOURCE_DATE_EPOCH` environment variable is set, use that value. Otherwise,
-    always return `1667997441`.
-    """
-    return int(os.environ.get("SOURCE_DATE_EPOCH", "1667997441"))
-
-
-def normalize_file_permissions(st_mode: int) -> int:
-    """
-    Normalize the permission bits in the st_mode field from stat to 644/755
-    Popular VCSs only track whether a file is executable or not. The exact
-    permissions can vary on systems with different umasks. Normalising
-    to 644 (non executable) or 755 (executable) makes builds more reproducible.
-
-    Taken from https://github.com/pypa/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
-    """
-    # Set 644 permissions, leaving higher bits of st_mode unchanged
-    new_mode = (st_mode | 0o644) & ~0o133
-    if st_mode & 0o100:
-        new_mode |= 0o111  # Executable: 644 -> 755
-    return new_mode
 
 
 def normalize_tar_info(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -316,6 +316,7 @@ def _build_wheel_impl_impl(
             variant_dist_info_contents=(
                 wheel_variant.dist_info_contents if wheel_variant else None
             ),
+            reproducible=settings.wheel.reproducible,
         )
 
         # Include the metadata license.file entry if provided

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from .. import __version__
 from .._compat.importlib import metadata, resources
 from .._logging import logger
+from .._reproducible import get_reproducible_epoch
 from ..resources import find_python
 from .generator import set_environment_for_gen
 from .sysconfig import (
@@ -157,6 +158,14 @@ class Builder:
         # visible to all CMake subprocesses (which share ``config.env``).
         if self.settings.env:
             set_environment_from_settings(self.config.env, self.settings)
+
+        # Export SOURCE_DATE_EPOCH so compilers that honor it (recent GCC/Clang)
+        # can produce deterministic output. setdefault preserves an explicit value
+        # from the environment or the user's env table.
+        if self.settings.wheel.reproducible:
+            self.config.env.setdefault(
+                "SOURCE_DATE_EPOCH", str(get_reproducible_epoch())
+            )
 
     def get_cmake_args(self) -> list[str]:
         """

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -300,8 +300,8 @@
         },
         "reproducible": {
           "type": "boolean",
-          "default": true,
-          "description": "Try to build a reproducible wheel."
+          "default": false,
+          "description": "Try to build a reproducible wheel. Opt-in, as normalizing permissions can"
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -301,7 +301,7 @@
         "reproducible": {
           "type": "boolean",
           "default": false,
-          "description": "Try to build a reproducible wheel. Opt-in, as normalizing permissions can"
+          "description": "Try to build a reproducible wheel."
         }
       }
     },

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -297,6 +297,11 @@
             }
           },
           "description": "Force-include files into the wheel."
+        },
+        "reproducible": {
+          "type": "boolean",
+          "default": true,
+          "description": "Try to build a reproducible wheel."
         }
       }
     },

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -555,8 +555,7 @@ class WheelSettings:
 
     reproducible: bool = False
     """
-    Try to build a reproducible wheel. Opt-in, as normalizing permissions can
-    change the result for some projects.
+    Try to build a reproducible wheel.
 
     Unix and Python 3.9+ recommended.
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -553,9 +553,10 @@ class WheelSettings:
     from both a source tree and an unpacked sdist.
     """
 
-    reproducible: bool = True
+    reproducible: bool = False
     """
-    Try to build a reproducible wheel.
+    Try to build a reproducible wheel. Opt-in, as normalizing permissions can
+    change the result for some projects.
 
     Unix and Python 3.9+ recommended.
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -553,6 +553,21 @@ class WheelSettings:
     from both a source tree and an unpacked sdist.
     """
 
+    reproducible: bool = True
+    """
+    Try to build a reproducible wheel.
+
+    Unix and Python 3.9+ recommended.
+
+    When enabled, archive timestamps and file permissions are normalized, and
+    ``SOURCE_DATE_EPOCH`` is exported to the CMake build (if not already set) so
+    compilers that honor it can produce deterministic output. ``SOURCE_DATE_EPOCH``
+    is used for timestamps if set, or a fixed value if not.
+
+    .. seealso::
+       :confval:`sdist.reproducible`
+    """
+
 
 @dataclasses.dataclass
 class BackportSettings:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -32,6 +32,7 @@ from scikit_build_core.settings.skbuild_model import (
     BuildSettings,
     CMakeSettings,
     CMakeSettingsDefine,
+    EnvValue,
     ScikitBuildSettings,
     SearchSettings,
     WheelSettings,
@@ -312,8 +313,52 @@ def test_builder_get_cmake_args(monkeypatch, cmake_args, answer):
     assert tmpbuilder.get_cmake_args() == answer
 
 
+def test_builder_exports_source_date_epoch(monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
+    builder = Builder(
+        settings=ScikitBuildSettings(wheel=WheelSettings(reproducible=True)),
+        config=tmpcfg,
+    )
+    assert builder.config.env["SOURCE_DATE_EPOCH"] == "1667997441"
+
+
+def test_builder_keeps_existing_source_date_epoch(monkeypatch):
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1234567890")
+    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
+    builder = Builder(
+        settings=ScikitBuildSettings(wheel=WheelSettings(reproducible=True)),
+        config=tmpcfg,
+    )
+    assert builder.config.env["SOURCE_DATE_EPOCH"] == "1234567890"
+
+
+def test_builder_env_table_wins_over_source_date_epoch(monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
+    builder = Builder(
+        settings=ScikitBuildSettings(
+            wheel=WheelSettings(reproducible=True),
+            env={"SOURCE_DATE_EPOCH": EnvValue("42")},
+        ),
+        config=tmpcfg,
+    )
+    assert builder.config.env["SOURCE_DATE_EPOCH"] == "42"
+
+
+def test_builder_no_source_date_epoch_when_not_reproducible(monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
+    builder = Builder(
+        settings=ScikitBuildSettings(wheel=WheelSettings(reproducible=False)),
+        config=tmpcfg,
+    )
+    assert "SOURCE_DATE_EPOCH" not in builder.config.env
+
+
 def test_build_tool_args():
     config = unittest.mock.create_autospec(CMaker)
+    config.env = {}
     settings = ScikitBuildSettings(build=BuildSettings(tool_args=["b"]))
     tmpbuilder = Builder(
         settings=settings,

--- a/tests/test_simplest_c.py
+++ b/tests/test_simplest_c.py
@@ -112,7 +112,7 @@ def test_pep517_wheel_reproducible(tmp_path, monkeypatch):
     def build_members() -> list[tuple[str, tuple[int, int, int, int, int, int], int]]:
         dist = tmp_path / f"dist{len(list(tmp_path.glob('dist*')))}"
         dist.mkdir()
-        build_wheel(str(dist))
+        build_wheel(str(dist), {"wheel.reproducible": "true"})
         (wheel,) = dist.glob("simplest-0.0.1-*.whl")
         with zipfile.ZipFile(wheel.resolve()) as zf:
             return [(i.filename, i.date_time, i.external_attr) for i in zf.infolist()]

--- a/tests/test_simplest_c.py
+++ b/tests/test_simplest_c.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tarfile
 import zipfile
 from pathlib import Path
@@ -98,6 +100,24 @@ def test_pep517_wheel(tmp_path, monkeypatch, virtualenv, component):
 
     version = virtualenv.execute("from simplest import square; print(square(2))")
     assert version == "4.0"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+def test_pep517_wheel_reproducible(tmp_path, monkeypatch):
+    """The wheel archive metadata is identical across builds (SOURCE_DATE_EPOCH unset)."""
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    monkeypatch.chdir(SIMPLEST)
+
+    def build_members() -> list[tuple[str, tuple[int, int, int, int, int, int], int]]:
+        dist = tmp_path / f"dist{len(list(tmp_path.glob('dist*')))}"
+        dist.mkdir()
+        build_wheel(str(dist))
+        (wheel,) = dist.glob("simplest-0.0.1-*.whl")
+        with zipfile.ZipFile(wheel.resolve()) as zf:
+            return [(i.filename, i.date_time, i.external_attr) for i in zf.infolist()]
+
+    assert build_members() == build_members()
 
 
 @pytest.mark.compile

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -1,11 +1,63 @@
 import stat
+import time
 import zipfile
+from pathlib import Path
 
 import pytest
 from packaging.tags import Tag
 
 import scikit_build_core.build._wheelfile
+from scikit_build_core._reproducible import get_reproducible_epoch
 from scikit_build_core._vendor.pyproject_metadata import StandardMetadata
+from scikit_build_core.build._wheelfile import WheelWriter
+
+
+def _make_writer(tmp_path: Path, *, reproducible: bool = True) -> WheelWriter:
+    metadata = StandardMetadata.from_pyproject(
+        {"project": {"name": "something", "version": "1.2.3"}},
+        metadata_version="2.3",
+    )
+    return scikit_build_core.build._wheelfile.WheelWriter(
+        metadata,
+        tmp_path / "out",
+        {Tag("py3", "none", "any")},
+        scikit_build_core.build._wheelfile.WheelMetadata(),
+        None,
+        reproducible=reproducible,
+    )
+
+
+def test_wheel_timestamp_reproducible_fixed_epoch(tmp_path, monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    wheel = _make_writer(tmp_path)
+    expected = time.gmtime(get_reproducible_epoch())[0:6]
+    # A per-file mtime is ignored in reproducible mode.
+    assert wheel.timestamp(0) == expected
+    assert wheel.timestamp() == expected
+
+
+def test_wheel_timestamp_non_reproducible_uses_mtime(tmp_path, monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    wheel = _make_writer(tmp_path, reproducible=False)
+    mtime = 1234567890
+    assert wheel.timestamp(mtime) == time.gmtime(mtime)[0:6]
+
+
+def test_wheel_write_normalizes_permissions(tmp_path, monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    src = tmp_path / "src.txt"
+    src.write_text("data")
+    src.chmod(0o777)
+
+    out_dir = tmp_path / "out"
+    for reproducible, expected in [(True, 0o755), (False, 0o777)]:
+        wheel = _make_writer(tmp_path, reproducible=reproducible)
+        wheel.folder = out_dir / str(reproducible)
+        with wheel:
+            wheel.write(str(src), "src.txt")
+        with zipfile.ZipFile(wheel.wheelpath) as zf:
+            info = zf.getinfo("src.txt")
+            assert stat.S_IMODE(info.external_attr >> 16) == expected
 
 
 def test_wheel_metadata() -> None:

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -1,4 +1,5 @@
 import stat
+import sys
 import time
 import zipfile
 from pathlib import Path
@@ -47,16 +48,34 @@ def test_wheel_write_normalizes_permissions(tmp_path, monkeypatch):
     monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     src = tmp_path / "src.txt"
     src.write_text("data")
+    src.chmod(0o600)
+
+    wheel = _make_writer(tmp_path)
+    with wheel:
+        wheel.write(str(src), "src.txt")
+    with zipfile.ZipFile(wheel.wheelpath) as zf:
+        info = zf.getinfo("src.txt")
+        # A non-executable file normalizes to 0o644 on every platform.
+        assert stat.S_IMODE(info.external_attr >> 16) == 0o644
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX permissions")
+def test_wheel_write_permissions_posix(tmp_path, monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    src = tmp_path / "exe"
+    src.write_text("data")
     src.chmod(0o777)
 
     out_dir = tmp_path / "out"
+    # Reproducible mode normalizes an executable to 0o755; otherwise the raw mode
+    # is preserved.
     for reproducible, expected in [(True, 0o755), (False, 0o777)]:
         wheel = _make_writer(tmp_path, reproducible=reproducible)
         wheel.folder = out_dir / str(reproducible)
         with wheel:
-            wheel.write(str(src), "src.txt")
+            wheel.write(str(src), "exe")
         with zipfile.ZipFile(wheel.wheelpath) as zf:
-            info = zf.getinfo("src.txt")
+            info = zf.getinfo("exe")
             assert stat.S_IMODE(info.external_attr >> 16) == expected
 
 

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -79,6 +79,20 @@ def test_wheel_write_permissions_posix(tmp_path, monkeypatch):
             assert stat.S_IMODE(info.external_attr >> 16) == expected
 
 
+def test_wheel_reproducible_normalizes_generated_metadata(tmp_path, monkeypatch):
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    wheel = _make_writer(tmp_path)
+    platlib = tmp_path / "platlib"
+    platlib.mkdir()
+    with wheel:
+        wheel.build({"platlib": platlib})
+    with zipfile.ZipFile(wheel.wheelpath) as zf:
+        # Generated .dist-info entries are written via writestr, not write; they
+        # must be normalized too in reproducible mode.
+        for info in zf.infolist():
+            assert stat.S_IMODE(info.external_attr >> 16) == 0o644
+
+
 def test_wheel_metadata() -> None:
     metadata = scikit_build_core.build._wheelfile.WheelMetadata(
         generator="scikit-build-core 1.2.3"


### PR DESCRIPTION
I need to edit all the mentions of "changing some wheels".

🤖 _AI text below_ :robot:

Closes #62.

SDists are already reproducible; this brings wheels in line and helps the build step produce deterministic binaries. Reproducible wheels are **opt-in** (`wheel.reproducible = true`), since normalizing permissions can change the result for some existing projects.

## What changed

- **Shared helper** — new `src/scikit_build_core/_reproducible.py` (`get_reproducible_epoch`, `normalize_file_permissions`, `MIN_TIMESTAMP`), at the package root so both `build/` and `builder/` can import it. `build/sdist.py` now reuses it instead of its own copies (behavior unchanged).
- **Wheel archive** (`build/_wheelfile.py`) — `WheelWriter` gains a `reproducible` flag (default `false`):
  - `timestamp()` falls back to the fixed epoch (`1667997441`, honoring `SOURCE_DATE_EPOCH` if set) instead of each file's `st_mtime`/`time.time()`.
  - `write()` normalizes permissions to 644/755 instead of copying raw on-disk bits.
- **Setting** — new `wheel.reproducible` (default `false`, opt-in) mirroring `sdist.reproducible`; schema and config reference regenerated.
- **Build env** (`builder/builder.py`) — when enabled, `setdefault`s `SOURCE_DATE_EPOCH` into the CMake environment, so compilers that honor it (recent GCC/Clang) can emit deterministic `__DATE__`/`__TIME__`. An explicit value (shell or `tool.scikit-build.env`) always wins. Full binary reproducibility still needs compiler flags like `-ffile-prefix-map` from the user — that part is out of our control.

## Tests

- Unit: fixed-epoch timestamp and permission normalization, with a POSIX-only split for the executable/raw-mode cases (`test_wheelfile_utils.py`).
- Build env: four `SOURCE_DATE_EPOCH` export cases incl. user-env-table-wins (`test_builder.py`).
- End-to-end: build a compiled package twice with `wheel.reproducible = true` and assert identical archive metadata (`test_simplest_c.py`).

## Notes

- `wheel.reproducible` defaults to `false` (opt-in); `sdist.reproducible` remains `true`.
- The local `check-sdist` hook flags only pre-existing untracked files (`uv.lock`, `.claude/settings.local.json`), unrelated to this change.