### PR TITLE
feat: support dynamic-metadata 0.3 spec

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -6,10 +6,10 @@ Scikit-build-core supports dynamic metadata with four built-in plugins.
 
 Beyond the built-in plugins, your package and third parties can provide their
 own. These are fully supported through the standard `[[tool.dynamic-metadata]]`
-interface described below. The legacy `tool.scikit-build.metadata` table still
-treats them as provisional: there, plugins not shipped with scikit-build-core
-require `tool.scikit-build.experimental=true`, since that interface may change
-between _minor_ versions.
+interface described below. The legacy `tool.scikit-build.metadata` table was
+provisional: there, plugins not shipped with scikit-build-core require
+`tool.scikit-build.experimental=true`, since that interface was not stable
+(now replaced by the new one). We are providing backward compatiblity for now.
 
 :::
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -52,7 +52,8 @@ dynamic.
 The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
 rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]` and
 is expected to be deprecated in a future release. It still works and is shown in
-the examples below.
+the examples below, but the two forms **cannot be combined** in one project; use
+one or the other.
 
 :::
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -2,13 +2,14 @@
 
 Scikit-build-core supports dynamic metadata with four built-in plugins.
 
-:::{warning}
+:::{note}
 
-Your package and third-party packages can also extend these with new plugins,
-but this is currently not ready for development outside of scikit-build-core;
-`tool.scikit-build.experimental=true` is required to use plugins that are not
-shipped with scikit-build-core, since the interface is provisional and may
-change between _minor_ versions.
+Beyond the built-in plugins, your package and third parties can provide their
+own. These are fully supported through the standard `[[tool.dynamic-metadata]]`
+interface described below. The legacy `tool.scikit-build.metadata` table still
+treats them as provisional: there, plugins not shipped with scikit-build-core
+require `tool.scikit-build.experimental=true`, since that interface may change
+between _minor_ versions.
 
 :::
 
@@ -37,13 +38,13 @@ field = "version"
 input = "src/mypackage/__init__.py"
 ```
 
-Generic plugins (`regex`, `template`) take the field they target from a `field`
-setting. A `provider-path` key may point at a local directory so a plugin can
-live inside your own project. Following [PEP 808][], a list or table field can
-be given a static value in `[project]` _and_ listed in `dynamic`, in which case
-a provider only **adds** to it; the single-value fields (`version`,
-`description`, `requires-python`, `license`, `readme`) cannot be both static and
-dynamic.
+The field-agnostic plugins (`regex`, `template`) can target any field, chosen
+with a `field` setting. A `provider-path` key may point at a local directory so
+a plugin can live inside your own project. Following [PEP 808][], a list or
+table field can be given a static value in `[project]` _and_ listed in
+`dynamic`, in which case a provider only **adds** to it; the single-value fields
+(`version`, `description`, `requires-python`, `license`, `readme`) cannot be
+both static and dynamic.
 
 [PEP 808]: https://peps.python.org/pep-0808/
 
@@ -57,7 +58,16 @@ one or the other.
 
 :::
 
-## `version`: Setuptools-scm
+## Built-in plugins
+
+We provide some built-in plugins in `scikit_build_core.metadata`. These work in
+either mode, though they always require a `field =` key in the modern
+`[[tool.dynamic-metadata]]` mode.
+
+Third party plugins (like those inside the `dynamic-metadata` package) and
+custom plugins are fully supported in the new mode.
+
+### `version`: Setuptools-scm
 
 You can use [setuptools-scm](https://github.com/pypa/setuptools-scm) to pull the
 version from VCS:
@@ -121,7 +131,7 @@ dynamic_version()
 project(MyPackage VERSION ${PROJECT_VERSION})
 ```
 
-## Regex
+### Regex
 
 If you want to pull a string-valued expression (usually version) from an
 existing file, you can the integrated `regex` plugin to pull the information.
@@ -207,7 +217,7 @@ Support for `result` and `remove` added.
 
 ```
 
-## `readme`: Fancy-pypi-readme
+### `readme`: Fancy-pypi-readme
 
 You can use
 [hatch-fancy-pypi-readme](https://github.com/hynek/hatch-fancy-pypi-readme) to
@@ -252,7 +262,7 @@ the version in the `[[tool.dynamic-metadata]]` mode.
 The version number feature now works.
 ```
 
-## Template
+### Template
 
 You can access other metadata fields and produce templated outputs.
 
@@ -289,6 +299,32 @@ static in `[project]`).
 
 ```{versionadded} 0.11.2
 
+```
+
+## Custom plugins
+
+You can write your own plugins. Full details are in the
+[dynamic metadata docs](https://dynamic-metadata.readthedocs.io/en/latest/plugin_authors.html).
+Here's a quick overview.
+
+There's one required hook:
+
+```python
+def dynamic_metadata(
+    settings: Mapping[str, Any],
+    project: Mapping[str, Any],
+) -> dict[str, Any]: ...  # return a fragment of [project], e.g. {"version": ...}
+```
+
+And several optional ones (`build_state`, `dynamic_wheel`, and
+`get_requires_for_dynamic_metadata`). You can optionally use a class, as well.
+
+To use a local plugin, you need to set both `provider` and `provider-path`:
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "my_plugin"
+provider-path = "helpers/plugins"
 ```
 
 ## `build-system.requires`: Scikit-build-core's `build.requires`

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -50,9 +50,9 @@ dynamic.
 :::{warning}
 
 The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
-rather than an ordered array) is **deprecated** in favor of
-`[[tool.dynamic-metadata]]` and will be removed in a future release. It still
-works (and is shown in the examples below), but emits a deprecation warning.
+rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]` and
+is expected to be deprecated in a future release. It still works and is shown in
+the examples below.
 
 :::
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -80,7 +80,7 @@ field = "version"
 write_to = "src/package/_version.py"
 ```
 
-````
+`````
 
 ````{tab} `tool.scikit-build.metadata`
 
@@ -97,7 +97,7 @@ sdist.include = ["src/package/_version.py"]
 write_to = "src/package/_version.py"
 ```
 
-````
+`````
 
 This sets the python project version according to
 [git tags](https://github.com/pypa/setuptools-scm/blob/fb261332d9b46aa5a258042d85baa5aa7b9f4fa2/README.rst#default-versioning-scheme)
@@ -139,7 +139,7 @@ field = "version"
 input = "src/mypackage/__init__.py"
 ```
 
-````
+`````
 
 ````{tab} `tool.scikit-build.metadata`
 
@@ -153,7 +153,7 @@ provider = "scikit_build_core.metadata.regex"
 input = "src/mypackage/__init__.py"
 ```
 
-````
+`````
 
 You can set a custom regex with `regex=`. By default when targeting version, you
 get a reasonable regex for python files,
@@ -179,7 +179,7 @@ result = "{major}.{minor}.{patch}dev{dev}"
 remove = "dev0"
 ```
 
-````
+`````
 
 ````{tab} `tool.scikit-build.metadata`
 
@@ -197,7 +197,7 @@ result = "{major}.{minor}.{patch}dev{dev}"
 remove = "dev0"
 ```
 
-````
+`````
 
 This will remove the "dev" tag when it is equal to 0.
 
@@ -227,7 +227,7 @@ field = "readme"
 # tool.hatch.metadata.hooks.fancy-pypi-readme options here
 ```
 
-````
+`````
 
 ````{tab} `tool.scikit-build.metadata`
 
@@ -242,7 +242,7 @@ metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
 # tool.hatch.metadata.hooks.fancy-pypi-readme options here
 ```
 
-````
+`````
 
 ```{versionchanged} 0.11.2
 
@@ -262,7 +262,7 @@ field = "optional-dependencies"
 result = {"dev" = ["{project[name]}=={project[version]}"]}
 ```
 
-````
+`````
 
 ````{tab} `tool.scikit-build.metadata`
 
@@ -272,7 +272,7 @@ provider = "scikit_build_core.metadata.template"
 result = {"dev" = ["{project[name]}=={project[version]}"]}
 ```
 
-````
+`````
 
 You can use `project` to access the current metadata values. You can use
 `result` to specify the output. The result must match the type of the metadata

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -8,8 +8,8 @@ Beyond the built-in plugins, your package and third parties can provide their
 own. These are fully supported through the standard `[[tool.dynamic-metadata]]`
 interface described below. The legacy `tool.scikit-build.metadata` table was
 provisional: there, plugins not shipped with scikit-build-core require
-`tool.scikit-build.experimental=true`, since that interface was not stable
-(now replaced by the new one). We are providing backward compatiblity for now.
+`tool.scikit-build.experimental=true`, since that interface was not stable (now
+replaced by the new one). We are providing backward compatibility for now.
 
 :::
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -12,6 +12,50 @@ change between _minor_ versions.
 
 :::
 
+## The `[[tool.dynamic-metadata]]` table
+
+```{versionadded} 1.0
+Support for the standard
+[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.3 specification.
+```
+
+The standard, cross-backend way to configure plugins is the top-level
+`[[tool.dynamic-metadata]]` **ordered array of tables**. Each entry names a
+`provider` (a module, or `"<module>:<Class>"`); every other key is passed to
+that plugin as its settings. Entries run **in order**, so a later entry sees
+every field an earlier one produced (no dependency graph, no cycles), and a
+plugin can read an already-resolved field with `project[...]`.
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.regex"
+field = "version"
+input = "src/mypackage/__init__.py"
+```
+
+Generic plugins (`regex`, `template`) take the field they target from a `field`
+setting. A `provider-path` key may point at a local directory so a plugin can
+live inside your own project. Following [PEP 808][], a list or table field can
+be given a static value in `[project]` _and_ listed in `dynamic`, in which case
+a provider only **adds** to it; the single-value fields (`version`,
+`description`, `requires-python`, `license`, `readme`) cannot be both static and
+dynamic.
+
+[PEP 808]: https://peps.python.org/pep-0808/
+
+:::{warning}
+
+The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
+rather than an ordered array) is **deprecated** in favor of
+`[[tool.dynamic-metadata]]` and will be removed in a future release. It still
+works (and is shown in the examples below), but emits a deprecation warning.
+
+:::
+
 ## `version`: Setuptools-scm
 
 You can use [setuptools-scm](https://github.com/pypa/setuptools-scm) to pull the

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -62,6 +62,28 @@ one or the other.
 You can use [setuptools-scm](https://github.com/pypa/setuptools-scm) to pull the
 version from VCS:
 
+````{tab} `[[tool.dynamic-metadata]]`
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["version"]
+
+[tool.scikit-build]
+sdist.include = ["src/package/_version.py"]
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.setuptools_scm"
+field = "version"
+
+[tool.setuptools_scm]  # Section required
+write_to = "src/package/_version.py"
+```
+
+````
+
+````{tab} `tool.scikit-build.metadata`
+
 ```toml
 [project]
 name = "mypackage"
@@ -74,6 +96,8 @@ sdist.include = ["src/package/_version.py"]
 [tool.setuptools_scm]  # Section required
 write_to = "src/package/_version.py"
 ```
+
+````
 
 This sets the python project version according to
 [git tags](https://github.com/pypa/setuptools-scm/blob/fb261332d9b46aa5a258042d85baa5aa7b9f4fa2/README.rst#default-versioning-scheme)
@@ -102,6 +126,23 @@ project(MyPackage VERSION ${PROJECT_VERSION})
 If you want to pull a string-valued expression (usually version) from an
 existing file, you can the integrated `regex` plugin to pull the information.
 
+````{tab} `[[tool.dynamic-metadata]]`
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.regex"
+field = "version"
+input = "src/mypackage/__init__.py"
+```
+
+````
+
+````{tab} `tool.scikit-build.metadata`
+
 ```toml
 [project]
 name = "mypackage"
@@ -112,12 +153,35 @@ provider = "scikit_build_core.metadata.regex"
 input = "src/mypackage/__init__.py"
 ```
 
+````
+
 You can set a custom regex with `regex=`. By default when targeting version, you
 get a reasonable regex for python files,
 `'(?i)^(__version__|VERSION)(?: ?\: ?str)? *= *([\'"])v?(?P<value>.+?)\2'`. You
 can set `result` to a format string to process the matches; the default is
 `"{value}"`. You can also specify a regex for `remove=` which will strip any
 matches from the final result. A more complex example:
+
+````{tab} `[[tool.dynamic-metadata]]`
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.regex"
+field = "version"
+input = "src/mypackage/version.hpp"
+regex = '''(?sx)
+\#define \s+ VERSION_MAJOR \s+ (?P<major>\d+) .*?
+\#define \s+ VERSION_MINOR \s+ (?P<minor>\d+) .*?
+\#define \s+ VERSION_PATCH \s+ (?P<patch>\d+) .*?
+\#define \s+ VERSION_DEV   \s+ (?P<dev>\d+)   .*?
+'''
+result = "{major}.{minor}.{patch}dev{dev}"
+remove = "dev0"
+```
+
+````
+
+````{tab} `tool.scikit-build.metadata`
 
 ```toml
 [tool.scikit-build.metadata.version]
@@ -133,6 +197,8 @@ result = "{major}.{minor}.{patch}dev{dev}"
 remove = "dev0"
 ```
 
+````
+
 This will remove the "dev" tag when it is equal to 0.
 
 ```{versionchanged} 0.10
@@ -147,6 +213,24 @@ You can use
 [hatch-fancy-pypi-readme](https://github.com/hynek/hatch-fancy-pypi-readme) to
 render your README:
 
+````{tab} `[[tool.dynamic-metadata]]`
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["readme"]
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.fancy_pypi_readme"
+field = "readme"
+
+# tool.hatch.metadata.hooks.fancy-pypi-readme options here
+```
+
+````
+
+````{tab} `tool.scikit-build.metadata`
+
 ```toml
 [project]
 name = "mypackage"
@@ -158,6 +242,8 @@ metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
 # tool.hatch.metadata.hooks.fancy-pypi-readme options here
 ```
 
+````
+
 ```{versionchanged} 0.11.2
 
 The version number feature now works.
@@ -167,16 +253,36 @@ The version number feature now works.
 
 You can access other metadata fields and produce templated outputs.
 
+````{tab} `[[tool.dynamic-metadata]]`
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.template"
+field = "optional-dependencies"
+result = {"dev" = ["{project[name]}=={project[version]}"]}
+```
+
+````
+
+````{tab} `tool.scikit-build.metadata`
+
 ```toml
 [tool.scikit-build.metadata.optional-dependencies]
 provider = "scikit_build_core.metadata.template"
 result = {"dev" = ["{project[name]}=={project[version]}"]}
 ```
 
-You can use `project` to access the current metadata values. You can reference
-other dynamic metadata fields, and they will be computed before this one. You
-can use `result` to specify the output. The result must match the type of the
-metadata field you are writing to.
+````
+
+You can use `project` to access the current metadata values. You can use
+`result` to specify the output. The result must match the type of the metadata
+field you are writing to.
+
+You can reference other dynamic metadata fields. With the legacy
+`tool.scikit-build.metadata` table they are resolved on demand, so the order in
+the file does not matter; with `[[tool.dynamic-metadata]]` entries run top to
+bottom, so any referenced field must be produced by an earlier entry (or be
+static in `[project]`).
 
 ```{versionadded} 0.11.2
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -244,6 +244,9 @@ metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
 
 `````
 
+In order to use the version number in readme feature, this must be listed after
+the version in the `[[tool.dynamic-metadata]]` mode.
+
 ```{versionchanged} 0.11.2
 
 The version number feature now works.

--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -5,7 +5,10 @@ from typing import Literal
 
 from .._compat import tomllib
 from .._logging import rich_warning
-from ..builder._load_provider import process_dynamic_metadata
+from ..builder._load_provider import (
+    process_dynamic_metadata,
+    process_legacy_dynamic_metadata,
+)
 from . import (
     get_requires_for_build_editable,
     get_requires_for_build_sdist,
@@ -19,9 +22,13 @@ def main_project_table(_args: argparse.Namespace, /) -> None:
         pyproject = tomllib.load(f)
 
     project = pyproject.get("project", {})
-    metadata = pyproject.get("tool", {}).get("scikit-build", {}).get("metadata", {})
-    new_project = process_dynamic_metadata(project, metadata)
-    print(json.dumps(new_project, indent=2))
+    legacy = pyproject.get("tool", {}).get("scikit-build", {}).get("metadata", {})
+    if legacy:
+        project = process_legacy_dynamic_metadata(project, legacy)
+    entries = pyproject.get("tool", {}).get("dynamic-metadata", [])
+    if entries:
+        project = process_dynamic_metadata(project, entries)
+    print(json.dumps(project, indent=2))
 
 
 def main_requires(args: argparse.Namespace, /) -> None:

--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -1,11 +1,12 @@
 import argparse
 import json
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 from .._compat import tomllib
 from .._logging import rich_warning
 from ..builder._load_provider import (
+    BuildState,
     process_dynamic_metadata,
     process_legacy_dynamic_metadata,
 )
@@ -16,7 +17,7 @@ from . import (
 )
 
 
-def main_project_table(_args: argparse.Namespace, /) -> None:
+def main_project_table(args: argparse.Namespace, /) -> None:
     """Get the full project table, including dynamic metadata."""
     with Path("pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
@@ -27,7 +28,7 @@ def main_project_table(_args: argparse.Namespace, /) -> None:
         project = process_legacy_dynamic_metadata(project, legacy)
     entries = pyproject.get("tool", {}).get("dynamic-metadata", [])
     if entries:
-        project = process_dynamic_metadata(project, entries)
+        project = process_dynamic_metadata(project, entries, build_state=args.state)
     print(json.dumps(project, indent=2))
 
 
@@ -76,6 +77,12 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
         description="Processes static and dynamic metadata without triggering the backend, only handles scikit-build-core's dynamic metadata.",
     )
     project_table.set_defaults(func=main_project_table)
+    project_table.add_argument(
+        "--state",
+        choices=get_args(BuildState),
+        default="metadata_wheel",
+        help="The build state reported to [[tool.dynamic-metadata]] providers",
+    )
 
 
 def main() -> None:

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -13,11 +13,15 @@ from .._vendor.pyproject_metadata import (
     extras_build_system,
     extras_top_level,
 )
-from ..builder._load_provider import process_dynamic_metadata
+from ..builder._load_provider import (
+    process_dynamic_metadata,
+    process_legacy_dynamic_metadata,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from ..builder._load_provider import BuildState
     from ..settings.skbuild_model import ScikitBuildSettings
 
 __all__ = ["get_standard_metadata"]
@@ -37,13 +41,26 @@ if sys.version_info < (3, 11):
 def get_standard_metadata(
     pyproject_dict: Mapping[str, Any],
     settings: ScikitBuildSettings,
+    build_state: BuildState = "metadata_wheel",
 ) -> StandardMetadata:
     new_pyproject_dict = copy.deepcopy(dict(pyproject_dict))
+    project = new_pyproject_dict["project"]
 
-    # Handle any dynamic metadata
-    new_pyproject_dict["project"] = process_dynamic_metadata(
-        new_pyproject_dict["project"], settings.metadata
-    )
+    # Handle the deprecated tool.scikit-build.metadata table, then the standard
+    # top-level [[tool.dynamic-metadata]] entries (dynamic-metadata 0.3). Both
+    # forms may be present; the legacy table is resolved first.
+    if settings.metadata:
+        logger.warning(
+            "tool.scikit-build.metadata is deprecated; move your providers to the "
+            "standard top-level [[tool.dynamic-metadata]] array of tables"
+        )
+        project = process_legacy_dynamic_metadata(project, settings.metadata)
+
+    entries = new_pyproject_dict.get("tool", {}).get("dynamic-metadata", [])
+    if entries:
+        project = process_dynamic_metadata(project, entries, build_state)
+
+    new_pyproject_dict["project"] = project
 
     if settings.strict_config:
         extra_keys_top = extras_top_level(new_pyproject_dict)

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -46,14 +46,10 @@ def get_standard_metadata(
     new_pyproject_dict = copy.deepcopy(dict(pyproject_dict))
     project = new_pyproject_dict["project"]
 
-    # Handle the deprecated tool.scikit-build.metadata table, then the standard
+    # Handle the legacy tool.scikit-build.metadata table, then the standard
     # top-level [[tool.dynamic-metadata]] entries (dynamic-metadata 0.3). Both
     # forms may be present; the legacy table is resolved first.
     if settings.metadata:
-        logger.warning(
-            "tool.scikit-build.metadata is deprecated; move your providers to the "
-            "standard top-level [[tool.dynamic-metadata]] array of tables"
-        )
         project = process_legacy_dynamic_metadata(project, settings.metadata)
 
     entries = new_pyproject_dict.get("tool", {}).get("dynamic-metadata", [])

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -111,7 +111,7 @@ def build_sdist(
     reproducible = settings.sdist.reproducible
     timestamp = get_reproducible_epoch() if reproducible else None
 
-    metadata = get_standard_metadata(pyproject, settings)
+    metadata = get_standard_metadata(pyproject, settings, build_state="sdist")
     pkg_info = bytes(metadata.as_rfc822())
 
     # Names must be normalized per PEP 625

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -244,7 +244,7 @@ def _build_wheel_impl_impl(
     Build a wheel or just prepare metadata (if wheel dir is None). Can be editable.
     """
 
-    metadata = get_standard_metadata(pyproject, settings)
+    metadata = get_standard_metadata(pyproject, settings, build_state=state)
 
     if metadata.version is None:
         msg = "project.version is not specified, must be statically present or tool.scikit-build metadata.version.provider configured when dynamic"

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -395,9 +395,14 @@ def process_legacy_dynamic_metadata(
     """
     initial = {f: (p, c) for (f, p, c) in _load_dynamic_metadata(metadata)}
 
+    # Copy the mutable project, including the "dynamic" list that providers
+    # remove resolved fields from, so the caller's dict is left untouched.
+    project_copy = dict(project)
+    project_copy["dynamic"] = list(project_copy.get("dynamic", []))
+
     settings = DynamicPyProject(
         settings={f: c for f, (_, c) in initial.items()},
-        project=dict(project),
+        project=project_copy,
         providers={k: v for k, (v, _) in initial.items()},
     )
 

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -8,7 +8,16 @@ import inspect
 import sys
 from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, Union, runtime_checkable
+from types import MappingProxyType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Protocol,
+    Union,
+    get_args,
+    runtime_checkable,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
@@ -19,39 +28,70 @@ if TYPE_CHECKING:
 else:
     StrMapping = Mapping
 
-from ..metadata import _ALL_FIELDS
+from ..metadata import (
+    _ALL_FIELDS,
+    _DICT_STR_FIELDS,
+    _EXTENDABLE_FIELDS,
+    _LIST_DICT_FIELDS,
+    _LIST_STR_FIELDS,
+    _SCALAR_FIELDS,
+)
 
-__all__ = ["load_provider", "process_dynamic_metadata"]
+__all__ = [
+    "BUILD_STATES",
+    "BuildState",
+    "load_dynamic_metadata",
+    "load_provider",
+    "process_dynamic_metadata",
+    "process_legacy_dynamic_metadata",
+]
 
 
 def __dir__() -> list[str]:
     return __all__
 
 
+# The five build states a backend can report to a provider's ``build_state``
+# hook; the last two are the ``prepare_metadata_for_build_*`` phases.
+BuildState = Literal[
+    "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
+]
+BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
+
+# Per-entry keys consumed by the loader itself; everything else is plugin
+# settings, passed through verbatim to the provider.
+_RESERVED_KEYS = frozenset(["provider", "provider-path"])
+
+
 @runtime_checkable
 class DynamicMetadataProtocol(Protocol):
     def dynamic_metadata(
         self,
-        field: str,
-        settings: dict[str, Any],
+        settings: Mapping[str, Any],
         project: Mapping[str, Any],
     ) -> Any: ...
 
 
 @runtime_checkable
+class DynamicMetadataBuildStateProtocol(DynamicMetadataProtocol, Protocol):
+    def build_state(self, build_state: BuildState) -> None: ...
+
+
+@runtime_checkable
 class DynamicMetadataRequirementsProtocol(DynamicMetadataProtocol, Protocol):
     def get_requires_for_dynamic_metadata(
-        self, settings: dict[str, Any]
+        self, settings: Mapping[str, Any]
     ) -> list[str]: ...
 
 
 @runtime_checkable
 class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
-    def dynamic_wheel(self, field: str, settings: Mapping[str, Any]) -> bool: ...
+    def dynamic_wheel(self, settings: Mapping[str, Any]) -> dict[str, bool]: ...
 
 
 DMProtocols = Union[
     DynamicMetadataProtocol,
+    DynamicMetadataBuildStateProtocol,
     DynamicMetadataRequirementsProtocol,
     DynamicMetadataWheelProtocol,
 ]
@@ -96,19 +136,187 @@ def load_provider(
     provider: str,
     provider_path: str | None = None,
 ) -> DMProtocols:
+    """Load a provider, returning the object whose hooks are called.
+
+    ``provider`` is either a module path (``"pkg.mod"``) or a module path and a
+    class within it (``"pkg.mod:Class"``). A bare module is returned as-is, so
+    its hooks are plain module-level functions; a class is instantiated with no
+    arguments and the instance is returned, so its hooks are bound methods and
+    may share state through ``self`` (e.g. the optional ``build_state`` hook
+    stashing the build state for ``dynamic_metadata`` to read).
+    """
+    module_name, _, class_name = provider.partition(":")
+
     if provider_path is None:
-        return importlib.import_module(provider)
+        module = importlib.import_module(module_name)
+    else:
+        if not Path(provider_path).is_dir():
+            msg = "provider-path must be an existing directory"
+            raise AssertionError(msg)
+        finder = _ProviderPathFinder([provider_path], module_name)
+        sys.meta_path.insert(0, finder)
+        try:
+            module = importlib.import_module(module_name)
+        finally:
+            sys.meta_path.remove(finder)
 
-    if not Path(provider_path).is_dir():
-        msg = "provider-path must be an existing directory"
-        raise AssertionError(msg)
+    return getattr(module, class_name)() if class_name else module
 
-    finder = _ProviderPathFinder([provider_path], provider)
-    sys.meta_path.insert(0, finder)
-    try:
-        return importlib.import_module(provider)
-    finally:
-        sys.meta_path.remove(finder)
+
+def load_dynamic_metadata(
+    entries: Sequence[Mapping[str, Any]],
+) -> Generator[tuple[DMProtocols, dict[str, Any]], None, None]:
+    """Load each ``[[tool.dynamic-metadata]]`` entry's provider in order.
+
+    ``provider`` and ``provider-path`` are consumed here; the remaining keys are
+    returned as that provider's plugin settings.
+    """
+    for entry in entries:
+        if "provider" not in entry:
+            msg = "Each [[tool.dynamic-metadata]] entry must set a 'provider'"
+            raise KeyError(msg)
+        settings = {k: v for k, v in entry.items() if k not in _RESERVED_KEYS}
+        provider = load_provider(entry["provider"], entry.get("provider-path"))
+        yield provider, settings
+
+
+def _merge_dict(
+    field: str, base: Mapping[str, Any], additions: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Add new keys to a table; a provider may not change existing values."""
+    merged = dict(base)
+    for key, value in additions.items():
+        if key in merged and merged[key] != value:
+            msg = f"Provider for {field!r} may not modify existing key {key!r}"
+            raise ValueError(msg)
+        merged[key] = value
+    return merged
+
+
+def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
+    """Merge a current value with a provider's additions (PEP 808).
+
+    Existing entries are preserved as-is and kept first; the provider's value is
+    appended after them. Single-value fields cannot be extended; merging onto a
+    static value of one is the invalid "static *and* dynamic" case and raises.
+    """
+    if field not in _EXTENDABLE_FIELDS:
+        msg = f"Field {field!r} cannot be given both statically and dynamically"
+        raise ValueError(msg)
+
+    if field in _LIST_STR_FIELDS or field in _LIST_DICT_FIELDS:
+        return [*static, *dynamic]
+
+    if field in _DICT_STR_FIELDS:
+        return _merge_dict(field, static, dynamic)
+
+    if field == "optional-dependencies":
+        merged_extras = {extra: list(deps) for extra, deps in static.items()}
+        for extra, deps in dynamic.items():
+            merged_extras.setdefault(extra, []).extend(deps)
+        return merged_extras
+
+    # entry-points: a table of groups, each a table of name -> object reference
+    merged_groups = {group: dict(eps) for group, eps in static.items()}
+    for group, eps in dynamic.items():
+        merged_groups[group] = _merge_dict(
+            f"entry-points group {group!r}", merged_groups.get(group, {}), eps
+        )
+    return merged_groups
+
+
+def _call_dynamic_metadata(
+    provider: DMProtocols,
+    settings: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Call a provider's ``dynamic_metadata`` hook, returning a project fragment.
+
+    Supports both the 0.3 hook ``dynamic_metadata(settings, project) -> dict``
+    and the legacy ``dynamic_metadata(field, settings[, project]) -> value``
+    used by scikit-build-core's bundled plugins. A legacy hook is detected by
+    its first parameter being named ``field``; the target field comes from the
+    entry's ``field`` setting and its scalar return is wrapped into a fragment.
+    """
+    # Legacy hooks have a different shape, so they are called untyped.
+    hook: Any = provider.dynamic_metadata
+    params = list(inspect.signature(hook).parameters)
+    if params and params[0] == "field":
+        field = settings.get("field")
+        if not isinstance(field, str):
+            msg = "This plugin requires a 'field' setting naming the target field"
+            raise RuntimeError(msg)
+        sub = {k: v for k, v in settings.items() if k != "field"}
+        if len(params) >= 3:
+            value = hook(field, sub, snapshot)
+        elif sub:
+            value = hook(field, sub)
+        else:
+            value = hook(field)
+        return {field: value}
+
+    fragment: dict[str, Any] = hook(settings, snapshot)
+    return fragment
+
+
+def process_dynamic_metadata(
+    project: Mapping[str, Any],
+    entries: Sequence[Mapping[str, Any]],
+    build_state: BuildState = "metadata_wheel",
+) -> dict[str, Any]:
+    """Resolve ``[[tool.dynamic-metadata]]`` entries (the 0.3 spec).
+
+    Entries run in list order; each provider is called with a read-only snapshot
+    of the project as resolved so far, so a later entry can read a field an
+    earlier one produced via ``project[...]``. A provider returns a ``dict``
+    fragment of ``[project]`` which is merged in (PEP 808 add-only for list and
+    table fields; a later entry replaces a scalar). ``build_state`` is reported
+    to any provider implementing the optional ``build_state`` hook before its
+    ``dynamic_metadata`` is called.
+    """
+    if build_state not in BUILD_STATES:
+        msg = f"build_state must be one of {sorted(BUILD_STATES)}, got {build_state!r}"
+        raise ValueError(msg)
+
+    result = dict(project)
+    result["dynamic"] = list(result.get("dynamic", []))
+    declared_dynamic = set(result["dynamic"])
+    snapshot = MappingProxyType(result)
+
+    # Fields already written by an earlier entry: a further entry merges onto
+    # that result (and may *replace* a scalar), as opposed to a static value
+    # still sitting in [project], which is the PEP 808 add-only case.
+    produced: set[str] = set()
+
+    for provider, settings in load_dynamic_metadata(entries):
+        if isinstance(provider, DynamicMetadataBuildStateProtocol):
+            provider.build_state(build_state)
+        fragment = _call_dynamic_metadata(provider, settings, snapshot)
+
+        for field in fragment:
+            if field not in _ALL_FIELDS:
+                msg = f"{field!r} is not a settable dynamic-metadata field"
+                raise KeyError(msg)
+            if field not in declared_dynamic:
+                msg = f"{field!r} must be listed in project.dynamic to be set"
+                raise KeyError(msg)
+
+        for field, value in fragment.items():
+            if field in produced:
+                result[field] = (
+                    value
+                    if field in _SCALAR_FIELDS
+                    else _merge_metadata(field, result[field], value)
+                )
+            elif field in result:
+                result[field] = _merge_metadata(field, result[field], value)
+            else:
+                result[field] = value
+            produced.add(field)
+            if field in result["dynamic"]:
+                result["dynamic"].remove(field)
+
+    return result
 
 
 def _load_dynamic_metadata(
@@ -148,14 +356,14 @@ class DynamicPyProject(StrMapping):
             raise ValueError(msg)
 
         provider = self.providers.pop(key)
-        sig = inspect.signature(provider.dynamic_metadata)
+        # Legacy hooks have a different shape, so they are called untyped.
+        hook: Any = provider.dynamic_metadata
+        sig = inspect.signature(hook)
         if len(sig.parameters) < 3:
             # Backcompat for dynamic_metadata without metadata dict
-            self.project[key] = provider.dynamic_metadata(  # type: ignore[call-arg]
-                key, self.settings[key]
-            )
+            self.project[key] = hook(key, self.settings[key])
         else:
-            self.project[key] = provider.dynamic_metadata(key, self.settings[key], self)
+            self.project[key] = hook(key, self.settings[key], self)
         self.project["dynamic"].remove(key)
 
         return self.project[key]
@@ -175,10 +383,16 @@ class DynamicPyProject(StrMapping):
         return key in self.project or key in self.providers
 
 
-def process_dynamic_metadata(
+def process_legacy_dynamic_metadata(
     project: Mapping[str, Any],
     metadata: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any]:
+    """Resolve the deprecated ``tool.scikit-build.metadata`` table.
+
+    Each field names a provider; fields resolve lazily, so a provider may read
+    another field (even one defined later in the table) via ``project[...]``,
+    with circular references detected and reported.
+    """
     initial = {f: (p, c) for (f, p, c) in _load_dynamic_metadata(metadata)}
 
     settings = DynamicPyProject(

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -6,7 +6,8 @@ import importlib.util
 import os
 import shlex
 import sysconfig
-from typing import TYPE_CHECKING, Literal
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
 from packaging.tags import sys_tags
 
@@ -22,7 +23,7 @@ from ..program_search import (
 )
 from ..resources import resources
 from ..settings.skbuild_read_settings import SettingsReader
-from ._load_provider import load_provider
+from ._load_provider import load_dynamic_metadata, load_provider
 from .generator import parse_generator
 
 if TYPE_CHECKING:
@@ -72,6 +73,19 @@ def _load_scikit_build_settings(
     return SettingsReader.from_file(
         "pyproject.toml", config_settings, state=state
     ).settings
+
+
+def _read_dynamic_metadata() -> list[dict[str, Any]]:
+    """Read the top-level ``[[tool.dynamic-metadata]]`` entries (0.3)."""
+    try:
+        with Path("pyproject.toml").open("rb") as f:
+            pyproject = tomllib.load(f)
+    except FileNotFoundError:
+        return []
+    entries: list[dict[str, Any]] = pyproject.get("tool", {}).get(
+        "dynamic-metadata", []
+    )
+    return entries
 
 
 @dataclasses.dataclass(frozen=True)
@@ -157,6 +171,7 @@ class GetRequires:
                 )
             )
 
+        # Deprecated tool.scikit-build.metadata table.
         for dynamic_metadata in self.settings.metadata.values():
             if "provider" in dynamic_metadata:
                 config = dynamic_metadata.copy()
@@ -166,6 +181,12 @@ class GetRequires:
                 yield from getattr(
                     module, "get_requires_for_dynamic_metadata", lambda _: []
                 )(config)
+
+        # Standard top-level [[tool.dynamic-metadata]] entries (0.3).
+        for provider, settings in load_dynamic_metadata(_read_dynamic_metadata()):
+            get_requires = getattr(provider, "get_requires_for_dynamic_metadata", None)
+            if get_requires is not None:
+                yield from get_requires(settings)
 
     def variants(self) -> Generator[str, None, None]:
         if self.settings.fail:

--- a/src/scikit_build_core/metadata/__init__.py
+++ b/src/scikit_build_core/metadata/__init__.py
@@ -6,7 +6,12 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
 
-__all__: list[str] = ["_ALL_FIELDS", "_process_dynamic_metadata"]
+__all__: list[str] = [
+    "_ALL_FIELDS",
+    "_EXTENDABLE_FIELDS",
+    "_SCALAR_FIELDS",
+    "_process_dynamic_metadata",
+]
 
 
 # Name is not dynamically settable, so not in this list
@@ -44,6 +49,10 @@ _LIST_DICT_FIELDS = frozenset(
     ]
 )
 
+# Single-value fields: a later entry replaces the value rather than extending
+# it, and PEP 808 forbids giving them both statically and dynamically.
+_SCALAR_FIELDS = _STR_FIELDS | frozenset(["readme"])
+
 # "dynamic" and "name" can't be set or requested
 _ALL_FIELDS = (
     _STR_FIELDS
@@ -58,6 +67,11 @@ _ALL_FIELDS = (
         ]
     )
 )
+
+# Fields PEP 808 allows to be given statically in [project] *and* listed in
+# dynamic, so a provider may add to the static portion: everything except the
+# scalar fields, which hold a single value and so cannot be extended.
+_EXTENDABLE_FIELDS = _ALL_FIELDS - _SCALAR_FIELDS
 
 T = typing.TypeVar(
     "T",

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -278,6 +278,10 @@ class SettingsReader:
             pyproject["tool"]["scikit-build"]["minimum-version"] = str(min_v)
         toml_srcs = [TOMLSource("tool", "scikit-build", settings=pyproject)]
 
+        # Standard top-level [[tool.dynamic-metadata]] entries (0.3); kept for
+        # validation only (cannot be combined with tool.scikit-build.metadata).
+        self._dynamic_metadata = pyproject.get("tool", {}).get("dynamic-metadata", [])
+
         # Support for cmake.version='CMakeLists.txt'
         # We will save the value for now since we need the CMakeLists location
         force_auto_cmake = (
@@ -537,6 +541,13 @@ class SettingsReader:
             dynamic_sources=self._dynamic_srcs,
             toml_sources=self._toml_srcs,
         )
+
+        if self.settings.metadata and self._dynamic_metadata:
+            sys.stdout.flush()
+            rich_error(
+                "tool.scikit-build.metadata cannot be combined with the standard "
+                "top-level [[tool.dynamic-metadata]]; use only one"
+            )
 
         for key, value in self.settings.metadata.items():
             if "provider" not in value:

--- a/tests/packages/dynamic_metadata/plugin_array_project.toml
+++ b/tests/packages/dynamic_metadata/plugin_array_project.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "fancy"
+dynamic = ["readme", "version", "optional-dependencies"]
+
+# Entries run in order: version is resolved first so the later providers can
+# read it via project[...].
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.setuptools_scm"
+field = "version"
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.fancy_pypi_readme"
+field = "readme"
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.template"
+field = "optional-dependencies"
+result = {"dev" = ["{project[name]}=={project[version]}"]}
+
+[tool.setuptools_scm]
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/x-rst"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "Fragment #1"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "Fragment #2 -- $HFPR_VERSION"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "Fragment #3 -- $HFPR_PACKAGE_NAME"

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -107,3 +107,55 @@ def test_metadata_command(
         "dynamic": [],
         "dependencies": ["self==0.1.3"],
     }
+
+
+PYPROJECT_STATE = """
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+[project]
+name = "test"
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "state_plugin:DynamicMetadata"
+provider-path = "plugins"
+"""
+
+STATE_PLUGIN = """
+class DynamicMetadata:
+    def build_state(self, build_state):
+        self._state = build_state
+
+    def dynamic_metadata(self, settings, project):
+        return {"version": self._state}
+"""
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ([], "metadata_wheel"),
+        (["--state", "sdist"], "sdist"),
+        (["--state", "editable"], "editable"),
+    ],
+)
+def test_metadata_command_state(
+    args: list[str],
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        sys, "argv", ["scikit_build_core.build", "project-table", *args]
+    )
+    (tmp_path / "pyproject.toml").write_text(PYPROJECT_STATE)
+    (tmp_path / "plugins").mkdir()
+    (tmp_path / "plugins" / "state_plugin.py").write_text(STATE_PLUGIN)
+    monkeypatch.chdir(tmp_path)
+
+    main()
+    out, _ = capsys.readouterr()
+    jout = json.loads(out)
+    assert jout["version"] == expected

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -373,6 +373,58 @@ def test_regex_remove(
     assert version == ("1.2.3dev1" if dev else "1.2.3")
 
 
+def test_array_dynamic_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end check of the standard top-level [[tool.dynamic-metadata]]."""
+    d = tmp_path / "test_array"
+    d.mkdir()
+    monkeypatch.chdir(d)
+
+    Path("version.txt").write_text("VERSION = '1.2.3'\n", encoding="utf-8")
+    Path("local_plugins").mkdir()
+    Path("local_plugins/req_plugin.py").write_text(
+        "def dynamic_metadata(settings, project):\n"
+        "    return {'requires-python': '>=' + project['version']}\n"
+        "def get_requires_for_dynamic_metadata(settings):\n"
+        "    return ['extra-build-dep']\n",
+        encoding="utf-8",
+    )
+    Path("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "test-array"
+            dynamic = ["version", "requires-python"]
+
+            [[tool.dynamic-metadata]]
+            provider = "scikit_build_core.metadata.regex"
+            field = "version"
+            input = "version.txt"
+
+            [[tool.dynamic-metadata]]
+            provider = "req_plugin"
+            provider-path = "local_plugins"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with Path("pyproject.toml").open("rb") as ft:
+        pyproject = tomllib.load(ft)
+    settings = SettingsReader(pyproject, {}, state="metadata_wheel").settings
+
+    metadata = get_standard_metadata(pyproject, settings, build_state="sdist")
+    assert str(metadata.version) == "1.2.3"
+    assert str(metadata.requires_python) == ">=1.2.3"
+
+    assert "extra-build-dep" in set(GetRequires().dynamic_metadata())
+
+
 @pytest.mark.parametrize("override", [None, "env", "sdist"])
 @pytest.mark.parametrize("package", ["dynamic_metadata"], indirect=True)
 @pytest.mark.usefixtures("package")

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -425,6 +425,29 @@ def test_array_dynamic_metadata(
     assert "extra-build-dep" in set(GetRequires().dynamic_metadata())
 
 
+def test_mixing_metadata_forms_rejected() -> None:
+    pyproject = {
+        "project": {"name": "t", "dynamic": ["version"]},
+        "tool": {
+            "scikit-build": {
+                "metadata": {
+                    "version": {"provider": "scikit_build_core.metadata.setuptools_scm"}
+                }
+            },
+            "dynamic-metadata": [
+                {
+                    "provider": "scikit_build_core.metadata.regex",
+                    "field": "version",
+                    "input": "x",
+                }
+            ],
+        },
+    }
+    reader = SettingsReader(pyproject, {}, state="metadata_wheel")
+    with pytest.raises(SystemExit):
+        reader.validate_may_exit()
+
+
 @pytest.mark.parametrize("override", [None, "env", "sdist"])
 @pytest.mark.parametrize("package", ["dynamic_metadata"], indirect=True)
 @pytest.mark.usefixtures("package")

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -117,9 +117,10 @@ def test_dynamic_metadata():
     assert metadata.readme == pyproject_metadata.Readme("Some text", None, "text/x-rst")
 
 
+@pytest.mark.parametrize("source", ["plugin_project.toml", "plugin_array_project.toml"])
 @pytest.mark.parametrize("package", ["dynamic_metadata"], indirect=True)
 @pytest.mark.usefixtures("package")
-def test_plugin_metadata():
+def test_plugin_metadata(source):
     reason_msg = (
         "install hatch-fancy-pypi-readme and setuptools-scm to test the "
         "dynamic metadata plugins"
@@ -131,7 +132,7 @@ def test_plugin_metadata():
 
     hfpr_version = Version(importlib.metadata.version("hatch_fancy_pypi_readme"))
 
-    shutil.copy("plugin_project.toml", "pyproject.toml")
+    shutil.copy(source, "pyproject.toml")
 
     subprocess.run(["git", "init", "--initial-branch=main"], check=True)
     subprocess.run(["git", "config", "user.name", "bot"], check=True)
@@ -423,6 +424,87 @@ def test_array_dynamic_metadata(
     assert str(metadata.requires_python) == ">=1.2.3"
 
     assert "extra-build-dep" in set(GetRequires().dynamic_metadata())
+
+
+def test_regex_both_forms(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bundled regex plugin gives the same result in both config forms."""
+    from scikit_build_core.builder._load_provider import (
+        process_dynamic_metadata,
+        process_legacy_dynamic_metadata,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    Path("__init__.py").write_text("__version__ = '0.1.0'\n", encoding="utf-8")
+
+    def project() -> dict[str, Any]:
+        return {"name": "p", "dynamic": ["version"]}
+
+    legacy = process_legacy_dynamic_metadata(
+        project(),
+        {
+            "version": {
+                "provider": "scikit_build_core.metadata.regex",
+                "input": "__init__.py",
+            }
+        },
+    )
+    array = process_dynamic_metadata(
+        project(),
+        [
+            {
+                "provider": "scikit_build_core.metadata.regex",
+                "field": "version",
+                "input": "__init__.py",
+            }
+        ],
+    )
+    assert legacy["version"] == array["version"] == "0.1.0"
+
+
+def test_template_both_forms() -> None:
+    """The bundled template plugin gives the same result in both config forms."""
+    from scikit_build_core.builder._load_provider import (
+        process_dynamic_metadata,
+        process_legacy_dynamic_metadata,
+    )
+
+    result = {"dev": ["{project[name]}=={project[version]}"]}
+
+    def project() -> dict[str, Any]:
+        return {"name": "pkg", "version": "1.0", "dynamic": ["optional-dependencies"]}
+
+    legacy = process_legacy_dynamic_metadata(
+        project(),
+        {
+            "optional-dependencies": {
+                "provider": "scikit_build_core.metadata.template",
+                "result": result,
+            }
+        },
+    )
+    array = process_dynamic_metadata(
+        project(),
+        [
+            {
+                "provider": "scikit_build_core.metadata.template",
+                "field": "optional-dependencies",
+                "result": result,
+            }
+        ],
+    )
+    assert legacy["optional-dependencies"] == array["optional-dependencies"]
+    assert array["optional-dependencies"] == {"dev": ["pkg==1.0"]}
+
+
+def test_array_legacy_plugin_requires_field() -> None:
+    """A bundled (legacy-signature) plugin in the array form needs a 'field'."""
+    from scikit_build_core.builder._load_provider import process_dynamic_metadata
+
+    with pytest.raises(RuntimeError, match="field"):
+        process_dynamic_metadata(
+            {"name": "p", "dynamic": ["version"]},
+            [{"provider": "scikit_build_core.metadata.regex", "input": "x"}],
+        )
 
 
 def test_mixing_metadata_forms_rejected() -> None:

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -496,6 +496,28 @@ def test_template_both_forms() -> None:
     assert array["optional-dependencies"] == {"dev": ["pkg==1.0"]}
 
 
+def test_legacy_does_not_mutate_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The legacy table must not mutate the caller's project dict."""
+    from scikit_build_core.builder._load_provider import process_legacy_dynamic_metadata
+
+    monkeypatch.chdir(tmp_path)
+    Path("__init__.py").write_text("__version__ = '0.1.0'\n", encoding="utf-8")
+
+    project = {"name": "p", "dynamic": ["version"]}
+    process_legacy_dynamic_metadata(
+        project,
+        {
+            "version": {
+                "provider": "scikit_build_core.metadata.regex",
+                "input": "__init__.py",
+            }
+        },
+    )
+    assert project == {"name": "p", "dynamic": ["version"]}
+
+
 def test_array_legacy_plugin_requires_field() -> None:
     """A bundled (legacy-signature) plugin in the array form needs a 'field'."""
     from scikit_build_core.builder._load_provider import process_dynamic_metadata

--- a/tests/test_dynamic_metadata_unit.py
+++ b/tests/test_dynamic_metadata_unit.py
@@ -6,6 +6,7 @@ import pytest
 from scikit_build_core.builder._load_provider import (
     load_provider,
     process_dynamic_metadata,
+    process_legacy_dynamic_metadata,
 )
 from scikit_build_core.metadata import _process_dynamic_metadata
 from scikit_build_core.metadata.regex import dynamic_metadata as regex_dynamic_metadata
@@ -15,7 +16,7 @@ from scikit_build_core.metadata.template import (
 
 
 def test_template_basic() -> None:
-    pyproject = process_dynamic_metadata(
+    pyproject = process_legacy_dynamic_metadata(
         {
             "name": "test",
             "version": "0.1.0",
@@ -34,7 +35,7 @@ def test_template_basic() -> None:
 
 def test_template_needs() -> None:
     # These are intentionally out of order to test the order of processing
-    pyproject = process_dynamic_metadata(
+    pyproject = process_legacy_dynamic_metadata(
         {
             "name": "test",
             "version": "0.1.0",
@@ -60,7 +61,7 @@ def test_template_needs() -> None:
 
 
 def test_regex() -> None:
-    pyproject = process_dynamic_metadata(
+    pyproject = process_legacy_dynamic_metadata(
         {
             "name": "test",
             "version": "0.1.0",
@@ -152,8 +153,8 @@ def test_load_provider_path_loads_local(tmp_path: Path) -> None:
     )
 
     provider = load_provider("local_prov_ok", str(plugin_dir))
-    version: Any = provider.dynamic_metadata("version", {}, {})
-    assert version == "1.2.3"
+    hook: Any = provider.dynamic_metadata
+    assert hook("version", {}, {}) == "1.2.3"
 
 
 def test_load_provider_path_not_shadowed(
@@ -170,3 +171,167 @@ def test_load_provider_path_not_shadowed(
     empty.mkdir()
     with pytest.raises(ModuleNotFoundError):
         load_provider("shadow_prov", str(empty))
+
+
+def test_array_regex_via_field_setting() -> None:
+    # The bundled (legacy-signature) regex plugin works in the 0.3 array form;
+    # the adapter sources the target field from the entry's ``field`` setting.
+    project = process_dynamic_metadata(
+        {"name": "test", "version": "0.1.0", "dynamic": ["requires-python"]},
+        [
+            {
+                "provider": "scikit_build_core.metadata.regex",
+                "field": "requires-python",
+                "input": "pyproject.toml",
+                "regex": r"name = \"(?P<name>.+)\"",
+                "result": ">={name}",
+            }
+        ],
+    )
+    assert project["requires-python"] == ">=scikit_build_core"
+    assert "requires-python" not in project["dynamic"]
+
+
+def test_array_runs_in_order() -> None:
+    # A later entry reads a field an earlier entry produced.
+    project = process_dynamic_metadata(
+        {"name": "test", "version": "0.1.0", "dynamic": ["requires-python", "license"]},
+        [
+            {
+                "provider": "scikit_build_core.metadata.template",
+                "field": "requires-python",
+                "result": ">={project[version]}",
+            },
+            {
+                "provider": "scikit_build_core.metadata.template",
+                "field": "license",
+                "result": "needs {project[requires-python]}",
+            },
+        ],
+    )
+    assert project["requires-python"] == ">=0.1.0"
+    assert project["license"] == "needs >=0.1.0"
+
+
+def test_array_forward_reference_raises() -> None:
+    # Unlike the legacy table, the array resolves strictly in order, so reading
+    # a not-yet-produced field is a plain KeyError.
+    with pytest.raises(KeyError):
+        process_dynamic_metadata(
+            {
+                "name": "t",
+                "version": "0.1.0",
+                "dynamic": ["requires-python", "license"],
+            },
+            [
+                {
+                    "provider": "scikit_build_core.metadata.template",
+                    "field": "requires-python",
+                    "result": "{project[license]}",
+                },
+                {
+                    "provider": "scikit_build_core.metadata.template",
+                    "field": "license",
+                    "result": "MIT",
+                },
+            ],
+        )
+
+
+def _write_provider(tmp_path: Path, name: str, body: str) -> str:
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir(exist_ok=True)
+    (plugin_dir / f"{name}.py").write_text(body)
+    return str(plugin_dir)
+
+
+def test_array_new_style_multi_field(tmp_path: Path) -> None:
+    path = _write_provider(
+        tmp_path,
+        "multi_prov",
+        "def dynamic_metadata(settings, project):\n"
+        "    return {'version': '1.2.3', 'description': 'hi'}\n",
+    )
+    project = process_dynamic_metadata(
+        {"name": "t", "dynamic": ["version", "description"]},
+        [{"provider": "multi_prov", "provider-path": path}],
+    )
+    assert project["version"] == "1.2.3"
+    assert project["description"] == "hi"
+    assert project["dynamic"] == []
+
+
+def test_array_pep808_add_only_list(tmp_path: Path) -> None:
+    path = _write_provider(
+        tmp_path,
+        "deps_prov",
+        "def dynamic_metadata(settings, project):\n"
+        "    return {'dependencies': ['numpy']}\n",
+    )
+    project = process_dynamic_metadata(
+        {"name": "t", "dependencies": ["torch"], "dynamic": ["dependencies"]},
+        [{"provider": "deps_prov", "provider-path": path}],
+    )
+    # Existing static entries kept first, provider additions appended.
+    assert project["dependencies"] == ["torch", "numpy"]
+
+
+def test_array_scalar_static_and_dynamic_raises(tmp_path: Path) -> None:
+    path = _write_provider(
+        tmp_path,
+        "ver_prov",
+        "def dynamic_metadata(settings, project):\n    return {'version': '9'}\n",
+    )
+    with pytest.raises(ValueError, match="both statically and dynamically"):
+        process_dynamic_metadata(
+            {"name": "t", "version": "1.0", "dynamic": ["version"]},
+            [{"provider": "ver_prov", "provider-path": path}],
+        )
+
+
+def test_array_field_not_in_dynamic_raises(tmp_path: Path) -> None:
+    path = _write_provider(
+        tmp_path,
+        "ver_prov2",
+        "def dynamic_metadata(settings, project):\n    return {'version': '9'}\n",
+    )
+    with pytest.raises(KeyError, match="must be listed in project"):
+        process_dynamic_metadata(
+            {"name": "t", "dynamic": []},
+            [{"provider": "ver_prov2", "provider-path": path}],
+        )
+
+
+def test_array_build_state_hook(tmp_path: Path) -> None:
+    path = _write_provider(
+        tmp_path,
+        "state_prov",
+        "class Provider:\n"
+        "    def build_state(self, build_state):\n"
+        "        self.state = build_state\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        return {'version': self.state}\n",
+    )
+    project = process_dynamic_metadata(
+        {"name": "t", "dynamic": ["version"]},
+        [{"provider": "state_prov:Provider", "provider-path": path}],
+        build_state="sdist",
+    )
+    assert project["version"] == "sdist"
+
+
+def test_array_bad_build_state_raises() -> None:
+    with pytest.raises(ValueError, match="build_state must be one of"):
+        process_dynamic_metadata(
+            {"name": "t", "dynamic": ["version"]},
+            [],
+            build_state="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_array_missing_provider_raises() -> None:
+    with pytest.raises(KeyError, match="must set a 'provider'"):
+        process_dynamic_metadata(
+            {"name": "t", "dynamic": ["version"]},
+            [{"field": "version"}],
+        )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds support for the standard [dynamic-metadata 0.3](https://dynamic-metadata.readthedocs.io) specification: the top-level `[[tool.dynamic-metadata]]` ordered array of tables. Reimplemented inline (no new dependency); the existing `tool.scikit-build.metadata` table keeps working but is now deprecated.

## What 0.3 changes vs. the old `tool.scikit-build.metadata`
- **Config**: top-level `[[tool.dynamic-metadata]]` *ordered array of tables* instead of a field-keyed table.
- **Hook**: `dynamic_metadata(settings, project) -> dict` (a `[project]` fragment, may set several fields) instead of `dynamic_metadata(field, settings, project) -> value`.
- **Resolution**: strictly sequential against a read-only project snapshot — no dependency graph, no cycles — plus PEP 808 add-only merge of static + dynamic values.
- **New**: optional `build_state(state)` hook; `module:Class` providers (instantiated); `dynamic_wheel(settings) -> dict[str, bool]`.

## Changes
- `metadata/__init__.py` — `_SCALAR_FIELDS` / `_EXTENDABLE_FIELDS` taxonomy for merge semantics.
- `builder/_load_provider.py` — `module:Class` loading, `BuildState`/`BUILD_STATES`, new protocols, `load_dynamic_metadata`, PEP 808 merge helpers, an adapter so the bundled legacy-signature plugins work in the array form, and `process_dynamic_metadata(project, entries, build_state)`. The old loader is preserved as `process_legacy_dynamic_metadata` (its lazy out-of-order resolution is still relied on by `test_template_needs`).
- `build/metadata.py` — `get_standard_metadata` runs the legacy table first (with a deprecation warning) then the new array, threading `build_state`.
- `build/wheel.py` / `build/sdist.py` — pass the real build state.
- `builder/get_requires.py` — also collects `get_requires_for_dynamic_metadata` from array entries.
- `build/__main__.py` — `project-table` CLI handles both forms.
- Docs + tests — new `[[tool.dynamic-metadata]]` section; 11 new unit tests + an end-to-end integration test.

## Backwards compatibility
- `tool.scikit-build.metadata` is fully supported, mapped through the preserved legacy loader, and emits a deprecation warning.
- The new array form is **not** gated behind `experimental` (the experimental gate existed because the *old* plugin interface was provisional; 0.3 is the stabilized standard).

## Open questions for review
1. `versionadded` is set to **1.0** (the spec names "scikit-build-core (1.0+)" as the supporting backend). Adjust if this lands in a different release.
2. The new array form is intentionally not `experimental`-gated — happy to add parity gating if preferred.

## Testing
- `prek -a` clean (ruff + mypy).
- Dynamic-metadata / requires test suites green (98 passed in the broad run).
- Smoke-tested the array form end-to-end via the `project-table` CLI (regex → template pipeline producing `version` and `requires-python`).