### PR TITLE
docs: clarify README example and unify cmake_minimum_required ranges

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -248,7 +248,7 @@ test = ["pytest>=6.0"]
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)
@@ -291,7 +291,7 @@ build-backend = "scikit_build_core.setuptools.build_meta"
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/README.md
+++ b/README.md
@@ -120,21 +120,26 @@ the minimum to get started.
 An example `CMakeLists.txt`:
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...3.30)
-project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
+cmake_minimum_required(VERSION 3.15...4.3)
+project(scikit_build_simplest LANGUAGES C)
 
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 Python_add_library(_module MODULE src/module.c WITH_SOABI)
-install(TARGETS _module DESTINATION ${SKBUILD_PROJECT_NAME})
+install(TARGETS _module DESTINATION scikit_build_simplest)
 ```
 
-Scikit-build-core will backport FindPython from CMake 3.26.1 to older versions
-of Python, and will handle PyPy for you if you are building from PyPy. You will
-need to install everything you want into the full final path inside site-modules
-(so you will usually prefix everything by the package name).
+The `install(DESTINATION ...)` is relative to site-packages, so the `_module`
+extension above lands at `scikit_build_simplest/_module.*` when the package is
+`pip install`ed. Scikit-build-core will backport FindPython from CMake 3.26.1 to
+older versions of Python, and will handle PyPy for you if you are building from
+PyPy. You will need to install everything you want into the full final path
+inside site-packages (so you will usually prefix everything by the package name)
+— including any `__init__.py`, which CMake can place alongside the extension
+with `install(FILES src/__init__.py DESTINATION scikit_build_simplest)`.
 
-More examples are in the
+The [Getting started guide][getting-started] walks through a complete package
+step by step. More examples are in the
 [tests/packages](https://github.com/scikit-build/scikit-build-core/tree/main/tests/packages).
 
 ## Configuration
@@ -364,6 +369,7 @@ Science Foundation.
 [download-badge]:           https://static.pepy.tech/badge/scikit-build-core/month
 [download-link]:            https://pepy.tech/project/scikit-build-core
 [enscons]:                  https://pypi.org/project/enscons
+[getting-started]:          https://scikit-build-core.readthedocs.io/en/latest/guide/getting_started.html
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
 [github-discussions-link]:  https://github.com/orgs/scikit-build/discussions
 [hatchling]:                https://hatch.pypa.io/latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,10 +335,10 @@ def package_simple_pyproject_ext(
     package = PackageInfo(
         "simple_pyproject_ext",
         tmp_path_factory.mktemp("pkg"),
-        "71b4e95854ef8d04886758d24d18fe55ebe63648310acf58c7423387cca73508",
-        "ed930179fbf5adc2e71a64a6f9686c61fdcce477c85bc94dd51598641be886a7",
-        "0178462b64b4eb9c41ae70eb413a9cc111c340e431b240af1b218fe81b0c2ecb",
-        "de79895a9d5c2112257715214ab419d3635e841716655e8a55390e5d52445819",
+        "02ddfa3e5907ef6a991d54ba4bf23d0aaafb46841d74b4327da91eaf66c95b53",
+        "8330d31d6c798455b0d8c0615dbb8b72219d0e11fb6aa34c50d7313f90facbc4",
+        "b7835a2da5732feab1bc29fde44da4e996405566922e718d8c9ad0f6f1a58903",
+        "b2d90702df52ce7b3bd1093fc5933be836b610b4d1f000857822420af4abba4a",
     )
     process_package(package, monkeypatch)
     return package

--- a/tests/packages/abi3_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/abi3_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/abi3_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/abi3_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/broken_fallback/CMakeLists.txt
+++ b/tests/packages/broken_fallback/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 if(DEFINED BROKEN_CMAKE)

--- a/tests/packages/cmake_defines/CMakeLists.txt
+++ b/tests/packages/cmake_defines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(cmake_defines LANGUAGES NONE)
 
 set(ONE_LEVEL_LIST

--- a/tests/packages/cmake_generated/CMakeLists.txt
+++ b/tests/packages/cmake_generated/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/custom_cmake/CMakeLists.txt
+++ b/tests/packages/custom_cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/cython_pxd_editable/pkg1/CMakeLists.txt
+++ b/tests/packages/cython_pxd_editable/pkg1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/cython_pxd_editable/pkg2/CMakeLists.txt
+++ b/tests/packages/cython_pxd_editable/pkg2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.19)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/dynamic_metadata/CMakeLists.txt
+++ b/tests/packages/dynamic_metadata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.25)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/filepath_pure/CMakeLists.txt
+++ b/tests/packages/filepath_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/fortran_example/CMakeLists.txt
+++ b/tests/packages/fortran_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.2...3.29)
+cmake_minimum_required(VERSION 3.17.2...4.3)
 
 project(
   fibby

--- a/tests/packages/hatchling/cpp/CMakeLists.txt
+++ b/tests/packages/hatchling/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(extensionlib_example_cmake LANGUAGES C)
 
 find_package(

--- a/tests/packages/importlib_editable/src/CMakeLists.txt
+++ b/tests/packages/importlib_editable/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/mixed_setuptools/CMakeLists.txt
+++ b/tests/packages/mixed_setuptools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES C)
 
 if(NOT EXAMPLE_DEFINE1 EQUAL 1)

--- a/tests/packages/multi_build_type/CMakeLists.txt
+++ b/tests/packages/multi_build_type/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.30)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/navigate_editable/CMakeLists.txt
+++ b/tests/packages/navigate_editable/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/plugin_setuptools_install_dir/CMakeLists.txt
+++ b/tests/packages/plugin_setuptools_install_dir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/sdist_config/CMakeLists.txt
+++ b/tests/packages/sdist_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.27)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   sdist_config
   LANGUAGES C

--- a/tests/packages/sdist_config/external/dummy/CMakeLists.txt
+++ b/tests/packages/sdist_config/external/dummy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(dummy LANGUAGES NONE)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/tools/dummy_helper.cmake")

--- a/tests/packages/simple_pure/CMakeLists.txt
+++ b/tests/packages/simple_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(simple_pure LANGUAGES C)
 

--- a/tests/packages/simple_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES CXX

--- a/tests/packages/simple_pyproject_script_with_flags/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_script_with_flags/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simple_pyproject_source_dir/src/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_source_dir/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simple_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/simple_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/toml_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/toml_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/wrapper_setuptools_install_dir/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_install_dir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.26)
+cmake_minimum_required(VERSION 3.15...4.3)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Closes #932.

### README example clarity (#932)
- Explain that `install(DESTINATION ...)` is relative to site-packages, so the example `_module` lands at `scikit_build_simplest/_module.*` on `pip install`.
- Add the `install(FILES src/__init__.py DESTINATION ...)` tip the reporter asked for (so the extension is importable).
- Link to the [Getting started guide](https://scikit-build-core.readthedocs.io/en/latest/guide/getting_started.html) right next to the example.

### Consistent `cmake_minimum_required`
- Normalize ranges to `3.15...4.3` across the README and all `tests/packages/**/CMakeLists.txt` (previously a mix of `3.19`/`3.25`/`3.26`/`3.27`/`3.29`/`3.30` upper bounds, plus a few bare `3.15`).
- `fortran_example` keeps its required `3.17.2` lower bound (`3.17.2...4.3`).
- `docs/examples/**` were already at `...4.3`.
- The CMake parser-test fixtures (`test_cmake_ast.py`, `test_auto.py`, `test_skbuild_settings.py`) are intentionally left untouched since their specific versions exercise auto-detection/AST logic.

## Test plan
- `prek -a --quiet` passes (prettier re-wrapped the new prose).
- Docs-only / fixture-only changes; no behavior change.