### PR TITLE
docs: add FAQ for dependency library in site-packages/bin or lib

### DIFF
--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -90,9 +90,9 @@ If you build a shared dependency as part of your project (for example via
 installed to `site-packages/bin` (Windows) or `site-packages/lib` (Linux/macOS)
 instead of next to your extension module. The `install(TARGETS ...)` command
 sends its artifacts to the [GNUInstallDirs][] defaults — `bin` for Windows DLLs
-(a `RUNTIME` artifact) and `lib` for `.so`/`.dylib` (a `LIBRARY` artifact) —
-and scikit-build-core copies the whole install tree into the wheel. A library
-placed there generally will not be found at import time, either.
+(a `RUNTIME` artifact) and `lib` for `.so`/`.dylib` (a `LIBRARY` artifact) — and
+scikit-build-core copies the whole install tree into the wheel. A library placed
+there generally will not be found at import time, either.
 
 The cleanest fix is usually to link the dependency statically so there is no
 runtime library to place. If you need it shared, you can redirect the install

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -83,6 +83,24 @@ printout of the current settings using:
 scikit-build builder
 ```
 
+## A dependency's library ends up in `site-packages/bin` or `lib`
+
+If you build a shared dependency as part of your project (for example via
+`add_subdirectory(...)` on a vendored library), you may find its library
+installed to `site-packages/bin` (Windows) or `site-packages/lib` (Linux/macOS)
+instead of next to your extension module. The `install(TARGETS ...)` command
+sends its artifacts to the [GNUInstallDirs][] defaults — `bin` for Windows DLLs
+(a `RUNTIME` artifact) and `lib` for `.so`/`.dylib` (a `LIBRARY` artifact) —
+and scikit-build-core copies the whole install tree into the wheel. A library
+placed there generally will not be found at import time, either.
+
+The cleanest fix is usually to link the dependency statically so there is no
+runtime library to place. If you need it shared, you can redirect the install
+into your package directory and add the runtime hints yourself, or run a
+wheel-repair tool. See [](#dynamic-linking) for all of the options.
+
+[GNUInstallDirs]: inv:cmake:cmake:module#module:GNUInstallDirs
+
 ## Repairing wheels
 
 Like most other backends[^1], scikit-build-core produces `linux` wheels, which


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a FAQ entry for a recurring confusion (e.g. #883): a vendored shared dependency pulled in via `add_subdirectory(...)` has its library installed to `site-packages/bin` (Windows DLL, a `RUNTIME` artifact) or `site-packages/lib` (`.so`/`.dylib`, a `LIBRARY` artifact), rather than next to the extension module. The entry explains this comes from the dependency's own `install(TARGETS ...)` using the GNUInstallDirs defaults, notes the library will not be found at import time there anyway, and points to the existing [dynamic linking guide](https://github.com/scikit-build/scikit-build-core/blob/main/docs/guide/dynamic_link.md) for the fixes (static link, install redirection, wheel repair).

Docs build is clean (`nox --non-interactive -s docs`); the new `#dynamic-linking` and `GNUInstallDirs` intersphinx references resolve without warnings.