### PR TITLE
feat(setuptools): honor SKBUILD_CONFIGURE_OPTIONS and SKBUILD_BUILD_OPTIONS in wrapper

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -76,6 +76,19 @@ _not_ supported, as setuptools has very poor support for config-settings.
 Eventually, the build hook might pre-process options, but it's tricky to pass
 them through, so it will probably require use cases to be presented.
 
+For classic scikit-build compatibility, two environment variables are honored,
+but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they
+have no effect in the general setuptools plugin or the main build backend):
+
+- `SKBUILD_CONFIGURE_OPTIONS`: extra arguments appended when configuring (the
+  wrapper's analog of the backend's `SKBUILD_CMAKE_ARGS`).
+- `SKBUILD_BUILD_OPTIONS`: extra arguments forwarded to `cmake --build`. Use a
+  leading `--` to pass native build-tool options, e.g.
+  `SKBUILD_BUILD_OPTIONS="-- -l4"`.
+
+Both are split following shell quoting rules, so quoted values with spaces are
+preserved.
+
 ## Editable installs
 
 PEP 660 editable installs (`pip install -e .`) are supported when the active

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -40,8 +40,11 @@ __all__ = [
     "finalize_distribution_options",
 ]
 
-WRAPPER_CMAKE_INSTALL_DIR_COMPAT = "_scikit_build_wrapper_cmake_install_dir_compat"
-WRAPPER_CLASSIC_LAYOUT_COMPAT = "_scikit_build_wrapper_classic_layout_compat"
+# Marker set on the Distribution by the classic scikit-build compatibility shim
+# (scikit_build_core.setuptools.wrapper.setup) to opt into its behaviors:
+# install-dir translation, classic source-layout staging, and the
+# SKBUILD_CONFIGURE_OPTIONS / SKBUILD_BUILD_OPTIONS environment variables.
+WRAPPER_COMPAT = "_scikit_build_wrapper_compat"
 ORIGINAL_DATA_FILES = "_scikit_build_original_data_files"
 
 
@@ -409,7 +412,7 @@ class BuildCMake(setuptools.Command):
         dist_cmake_install_dir = (
             getattr(self.distribution, "cmake_install_dir", "") or ""
         )
-        if getattr(self.distribution, WRAPPER_CMAKE_INSTALL_DIR_COMPAT, False):
+        if self._wrapper_compat_enabled():
             return _translate_wrapper_install_dir(
                 self.distribution, dist_cmake_install_dir
             )
@@ -464,16 +467,13 @@ class BuildCMake(setuptools.Command):
                 if line
             )
 
-    def _wrapper_classic_layout_compat_enabled(self) -> bool:
-        return bool(
-            not self.editable_mode
-            and getattr(self.distribution, WRAPPER_CLASSIC_LAYOUT_COMPAT, False)
-        )
-
     def _wrapper_compat_enabled(self) -> bool:
         # True only when the classic scikit-build compatibility wrapper
         # (scikit_build_core.setuptools.wrapper.setup) created the distribution.
-        return bool(getattr(self.distribution, WRAPPER_CMAKE_INSTALL_DIR_COMPAT, False))
+        return bool(getattr(self.distribution, WRAPPER_COMPAT, False))
+
+    def _wrapper_classic_layout_compat_enabled(self) -> bool:
+        return not self.editable_mode and self._wrapper_compat_enabled()
 
     def _apply_wrapper_classic_layout_compat(
         self, *, staged_install_dir: Path, install_subdir: Path

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import sys
 from collections import defaultdict
@@ -469,6 +470,11 @@ class BuildCMake(setuptools.Command):
             and getattr(self.distribution, WRAPPER_CLASSIC_LAYOUT_COMPAT, False)
         )
 
+    def _wrapper_compat_enabled(self) -> bool:
+        # True only when the classic scikit-build compatibility wrapper
+        # (scikit_build_core.setuptools.wrapper.setup) created the distribution.
+        return bool(getattr(self.distribution, WRAPPER_CMAKE_INSTALL_DIR_COMPAT, False))
+
     def _apply_wrapper_classic_layout_compat(
         self, *, staged_install_dir: Path, install_subdir: Path
     ) -> None:
@@ -556,6 +562,13 @@ class BuildCMake(setuptools.Command):
         configure_args = list(self.cmake_args or [])
         dist_cmake_args = getattr(self.distribution, "cmake_args", None)
         configure_args.extend(dist_cmake_args or [])
+        wrapper_compat = self._wrapper_compat_enabled()
+        if wrapper_compat:
+            # Classic scikit-build compatibility env var (the wrapper's analog of
+            # the backend's SKBUILD_CMAKE_ARGS / cmake.args).
+            configure_args.extend(
+                shlex.split(os.environ.get("SKBUILD_CONFIGURE_OPTIONS", ""))
+            )
 
         bdist_wheel = dist.get_command_obj("bdist_wheel")
         assert bdist_wheel is not None
@@ -625,6 +638,11 @@ class BuildCMake(setuptools.Command):
         # build_ext call, not supported by pip or PyPA-build.
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in builder.config.env and self.parallel:
             build_args.append(f"-j{self.parallel}")
+
+        if wrapper_compat:
+            # Classic scikit-build compatibility env var; forwarded to `cmake
+            # --build` (use a leading `--` to pass native build-tool options).
+            build_args.extend(shlex.split(os.environ.get("SKBUILD_BUILD_OPTIONS", "")))
 
         builder.build(build_args=build_args)
         builder.install(install_dir=cmake_install_prefix)

--- a/src/scikit_build_core/setuptools/wrapper.py
+++ b/src/scikit_build_core/setuptools/wrapper.py
@@ -11,10 +11,7 @@ if TYPE_CHECKING:
 
 from .._compat.setuptools.errors import SetupError
 from .._compat.typing import TypeVar
-from .build_cmake import (
-    WRAPPER_CLASSIC_LAYOUT_COMPAT,
-    WRAPPER_CMAKE_INSTALL_DIR_COMPAT,
-)
+from .build_cmake import WRAPPER_COMPAT
 
 __all__ = ["setup"]
 
@@ -66,10 +63,7 @@ def setup(
         type(
             "DistributionClass",
             (distclass,),
-            {
-                WRAPPER_CLASSIC_LAYOUT_COMPAT: True,
-                WRAPPER_CMAKE_INSTALL_DIR_COMPAT: True,
-            },
+            {WRAPPER_COMPAT: True},
         ),
     )
 

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -447,6 +447,71 @@ def test_manifest_hook_wheel(virtualenv, tmp_path: Path):
     assert add.strip() == "3"
 
 
+@pytest.mark.parametrize("wrapper_compat", [True, False], ids=["wrapper", "plugin"])
+def test_skbuild_configure_and_build_options(
+    wrapper_compat: bool, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    # Classic scikit-build compatibility env vars, honored only by the wrapper
+    # (scikit_build_core.setuptools.wrapper.setup), not the general plugin.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CMakeLists.txt").touch()
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("SKBUILD_CONFIGURE_OPTIONS", "-DFOO=ON -DBAR='a b'")
+    monkeypatch.setenv("SKBUILD_BUILD_OPTIONS", "-- -l4")
+
+    captured: dict[str, list[str]] = {}
+
+    class StopRunError(Exception):
+        pass
+
+    class FakeConfig:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.env: dict[str, str] = {}
+            self.build_type = "Release"
+
+    class FakeBuilder:
+        def __init__(self, *, config: object, **_kwargs: object) -> None:
+            self.config = config
+
+        def get_cmake_args(self) -> list[str]:
+            return []
+
+        def configure(self, *, configure_args: list[str], **_kwargs: object) -> None:
+            captured["configure"] = list(configure_args)
+
+        def build(self, *, build_args: list[str]) -> None:
+            captured["build"] = list(build_args)
+            raise StopRunError
+
+    monkeypatch.setattr(
+        "scikit_build_core.cmake.CMake.default_search",
+        classmethod(lambda *_args, **_kwargs: object()),
+    )
+    monkeypatch.setattr(build_cmake, "CMaker", FakeConfig)
+    monkeypatch.setattr(build_cmake, "Builder", FakeBuilder)
+
+    dist = setuptools.Distribution({"name": "x", "version": "0.0.1"})
+    if wrapper_compat:
+        setattr(dist, build_cmake.WRAPPER_CMAKE_INSTALL_DIR_COMPAT, True)
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.build_lib = str(tmp_path / "build")
+    cmd.build_temp = str(tmp_path / "tmp")
+    cmd.plat_name = "linux-x86_64"
+    cmd.source_dir = "."
+    cmd.cmake_args = ["-DDIST=1"]
+
+    with pytest.raises(StopRunError):
+        cmd.run()
+
+    if wrapper_compat:
+        assert captured["configure"] == ["-DDIST=1", "-DFOO=ON", "-DBAR=a b"]
+        assert captured["build"] == ["--", "-l4"]
+    else:
+        assert captured["configure"] == ["-DDIST=1"]
+        assert captured["build"] == []
+
+
 def test_manifest_hook_must_be_callable():
     with pytest.raises(
         SetupError,

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -492,7 +492,7 @@ def test_skbuild_configure_and_build_options(
 
     dist = setuptools.Distribution({"name": "x", "version": "0.0.1"})
     if wrapper_compat:
-        setattr(dist, build_cmake.WRAPPER_CMAKE_INSTALL_DIR_COMPAT, True)
+        setattr(dist, build_cmake.WRAPPER_COMPAT, True)
     cmd = build_cmake.BuildCMake(dist)
     cmd.initialize_options()
     cmd.build_lib = str(tmp_path / "build")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #380.

## What

Restores classic scikit-build compatibility for two environment variables, **only** in the `scikit_build_core.setuptools.wrapper.setup` shim:

- `SKBUILD_CONFIGURE_OPTIONS` — extra arguments appended when configuring (the wrapper's analog of the backend's `SKBUILD_CMAKE_ARGS`).
- `SKBUILD_BUILD_OPTIONS` — extra arguments forwarded to `cmake --build` (use a leading `--` to pass native build-tool options, e.g. `SKBUILD_BUILD_OPTIONS="-- -l4"`, covering the parallelism/load use cases from the issue thread).

Both are split with `shlex.split`, matching the existing `CMAKE_ARGS` handling, so quoted values with spaces are preserved.

## Scope

The reads are gated on the wrapper's compat marker (`_wrapper_compat_enabled()`), so the general `scikit_build_core.setuptools.build_meta` plugin and the main build backend are unaffected — those continue to use `SKBUILD_CMAKE_ARGS` / `cmake.args`. The migration guide's stance on the main backend is unchanged.

## Tests

`test_skbuild_configure_and_build_options` is parametrized `[wrapper, plugin]`: with the wrapper marker the env vars flow into the configure/build args; without it they're ignored. Confirmed the assertion fails without the implementation.