### PR TITLE
feat: allow wheel.packages to point at a single module file

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -904,6 +904,9 @@ print(mk_skbuild_docs())
   ``<package>`` if they exist.  The prefix(s) will be stripped from the
   package name inside the wheel.
 
+  An entry may also point at a single module file (e.g. ``hello.py``), which is
+  copied in as a top-level module rather than a package directory.
+
   If a dict, provides a mapping of package name to source directory.
 ```
 

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -75,6 +75,20 @@ def packages_to_file_mapping(
         package_dir = Path(package_str)
         source_dir = Path(source_str)
 
+        # A package may point at a single module file (e.g. ``hello.py``), not
+        # just a directory (#888). It installs as one file at ``package_dir``,
+        # which already carries the module's name.
+        if source_dir.is_file():
+            if not exclude_spec.match_file(package_dir):
+                target_path = platlib_dir / package_dir
+                if not target_path.is_file():
+                    mapping[str(source_dir)] = str(target_path)
+            continue
+
+        if not source_dir.is_dir():
+            msg = f"Package source {source_str!r} is neither a file nor a directory"
+            raise FileNotFoundError(msg)
+
         for filepath in each_unignored_file(
             source_dir,
             include=include,

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -418,6 +418,9 @@ class WheelSettings:
     ``<package>`` if they exist.  The prefix(s) will be stripped from the
     package name inside the wheel.
 
+    An entry may also point at a single module file (e.g. ``hello.py``), which is
+    copied in as a top-level module rather than a package directory.
+
     If a dict, provides a mapping of package name to source directory.
     """
 

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -311,6 +311,68 @@ def test_navigate_editable_remapped_namespace(
     assert virtualenv.execute(read_data) == "payload"
 
 
+def test_packages_to_file_mapping_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A wheel.packages entry may point at a single module file, not just a
+    # directory (#888). It is installed as one top-level file.
+    (tmp_path / "hello.py").write_text("def run(): ...\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    mapping = packages_to_file_mapping(
+        packages={"hello.py": "hello.py"},
+        platlib_dir=tmp_path / "out",
+        include=[],
+        src_exclude=[],
+        target_exclude=[],
+        build_dir="",
+        mode="classic",
+    )
+    assert mapping == {"hello.py": str(tmp_path / "out" / "hello.py")}
+
+
+def test_packages_to_file_mapping_module_nested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The table form may place a module under a subpackage path.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "hello.py").write_text("def run(): ...\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    mapping = packages_to_file_mapping(
+        packages={"pkg/hello.py": str(Path("src/hello.py"))},
+        platlib_dir=tmp_path / "out",
+        include=[],
+        src_exclude=[],
+        target_exclude=[],
+        build_dir="",
+        mode="classic",
+    )
+    assert mapping == {
+        str(Path("src/hello.py")): str(tmp_path / "out" / "pkg" / "hello.py")
+    }
+
+
+def test_packages_to_file_mapping_missing_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A source that is neither a file nor a directory used to be silently
+    # dropped; it must now raise instead (#888).
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="nope"):
+        packages_to_file_mapping(
+            packages={"nope": "nope"},
+            platlib_dir=tmp_path / "out",
+            include=[],
+            src_exclude=[],
+            target_exclude=[],
+            build_dir="",
+            mode="classic",
+        )
+
+
 def test_editable_redirect_files_legacy_pth(tmp_path: Path):
     files = editable_redirect_files(
         libdir=tmp_path,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #888.

## What

`wheel.packages` entries can now point at a single module **file** (e.g. `hello.py`), not just a package directory. The file is copied into the wheel as a top-level module. Both forms work:

```toml
[tool.scikit-build]
wheel.packages = ["hello.py"]                       # -> hello.py at the wheel root
# or
wheel.packages = {"pkg/hello.py" = "src/hello.py"}  # -> pkg/hello.py
```

Previously such an entry was **silently dropped**: `packages_to_file_mapping` fed every source into the directory-only `os.walk`, which yields nothing for a file, so the module just vanished from the wheel with no error.

## Hardening

`packages_to_file_mapping` now raises `FileNotFoundError` when a source is neither a file nor a directory, instead of silently producing an empty mapping. This is the other half of the bad experience in #888 — a typo'd or missing package source used to disappear without a word.

## Notes

- Requires the extension (`hello.py`, not bare `hello`) — this keeps `get_packages` untouched and avoids dir-vs-file ambiguity.
- The list form keys off the final path component and the table-form last-component validation already accepts these, so no settings-layer changes were needed.
- Editable installs work via the existing top-level-module path in the redirect shim.
- **Maintainer call:** the original issue comment leaned toward installing wrappers to `SKBUILD_SCRIPTS_DIR` rather than packaging loose modules. The hardening is uncontroversial; the feature itself is up for discussion.

## Tests

Added regression tests in `tests/test_editable_unit.py` (top-level module, nested module via table form, missing-source raises) — written first and confirmed failing before the fix. Verified end-to-end with a real `python -m build` producing a wheel containing `hello.py`.