### PR TITLE
chore: support uvx too

### DIFF
--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -79,6 +79,7 @@ export HATCH_METADATA_CLASSIFIERS_NO_VERIFY=1
 %license LICENSE LICENSE-pyproject-metadata
 %doc README.md
 %{_bindir}/scikit-build
+%{_bindir}/scikit-build-core
 
 
 %changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ Homepage = "https://github.com/scikit-build/scikit-build-core"
 Issues = "https://github.com/scikit-build/scikit-build-core/issues"
 
 [project.scripts]
+# Recommended entry point
 scikit-build = "scikit_build_core.__main__:main"
+# This is to make `uvx scikit-build-core` work
+scikit-build-core = "scikit_build_core.__main__:main"
 
 [project.entry-points]
 "distutils.commands".build_cmake = "scikit_build_core.setuptools.build_cmake:BuildCMake"


### PR DESCRIPTION
uvx requires matching names.
