### PR TITLE
feat: warn on deprecated tool.scikit-build.metadata table

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -51,10 +51,10 @@ both static and dynamic.
 :::{warning}
 
 The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
-rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]` and
-is expected to be deprecated in a future release. It still works and is shown in
-the examples below, but the two forms **cannot be combined** in one project; use
-one or the other.
+rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]`. It
+is deprecated and emits a warning unless `minimum-version` is set below `1.0`.
+It still works and is shown in the examples below, but the two forms **cannot be
+combined** in one project; use one or the other.
 
 :::
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -549,6 +549,15 @@ class SettingsReader:
                 "top-level [[tool.dynamic-metadata]]; use only one"
             )
 
+        if self.settings.metadata and (
+            self.settings.minimum_version is None
+            or self.settings.minimum_version >= Version("1.0")
+        ):
+            rich_warning(
+                "tool.scikit-build.metadata is deprecated; use the standard "
+                "top-level [[tool.dynamic-metadata]] instead"
+            )
+
         for key, value in self.settings.metadata.items():
             if "provider" not in value:
                 sys.stdout.flush()

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -587,8 +587,15 @@ def test_legacy_metadata_table_deprecation_warning(
 
 @pytest.mark.parametrize("minimum_version", ["0.10", "0.11"])
 def test_legacy_metadata_table_no_warning_below_1(
-    minimum_version: str, capsys: pytest.CaptureFixture[str]
+    minimum_version: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pin a stable version so minimum-version doesn't trip the too-old guard
+    # (the installed dev version is unknown and may be below minimum-version).
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.1.0"
+    )
     scikit_build_core._logging.rich_warning.cache_clear()
     pyproject = {
         "project": {"name": "t", "dynamic": ["version"]},

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -14,6 +14,8 @@ import pytest
 from packaging.requirements import Requirement
 from packaging.version import Version
 
+import scikit_build_core._logging
+import scikit_build_core.settings.skbuild_read_settings
 from scikit_build_core._compat import tomllib
 from scikit_build_core._vendor import pyproject_metadata
 from scikit_build_core.build import build_wheel
@@ -550,6 +552,60 @@ def test_mixing_metadata_forms_rejected() -> None:
     reader = SettingsReader(pyproject, {}, state="metadata_wheel")
     with pytest.raises(SystemExit):
         reader.validate_may_exit()
+
+
+@pytest.mark.parametrize("minimum_version", [None, "1.0", "1.1"])
+def test_legacy_metadata_table_deprecation_warning(
+    minimum_version: str | None,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The current version is < 1.0, so pin a higher one to reach the >=1.0 branch.
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.1.0"
+    )
+    # rich_warning is memoized; clear so the warning is re-emitted for this test.
+    scikit_build_core._logging.rich_warning.cache_clear()
+
+    skbuild: dict[str, object] = {
+        "metadata": {
+            "version": {"provider": "scikit_build_core.metadata.setuptools_scm"}
+        }
+    }
+    if minimum_version is not None:
+        skbuild["minimum-version"] = minimum_version
+    pyproject = {
+        "project": {"name": "t", "dynamic": ["version"]},
+        "tool": {"scikit-build": skbuild},
+    }
+    reader = SettingsReader(pyproject, {}, state="metadata_wheel")
+    reader.validate_may_exit()
+
+    err = capsys.readouterr().err
+    assert "tool.scikit-build.metadata is deprecated" in err
+
+
+@pytest.mark.parametrize("minimum_version", ["0.10", "0.11"])
+def test_legacy_metadata_table_no_warning_below_1(
+    minimum_version: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scikit_build_core._logging.rich_warning.cache_clear()
+    pyproject = {
+        "project": {"name": "t", "dynamic": ["version"]},
+        "tool": {
+            "scikit-build": {
+                "minimum-version": minimum_version,
+                "metadata": {
+                    "version": {"provider": "scikit_build_core.metadata.setuptools_scm"}
+                },
+            }
+        },
+    }
+    reader = SettingsReader(pyproject, {}, state="metadata_wheel")
+    reader.validate_may_exit()
+
+    err = capsys.readouterr().err
+    assert "deprecated" not in err
 
 
 @pytest.mark.parametrize("override", [None, "env", "sdist"])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1390. Emits a deprecation warning when the legacy `tool.scikit-build.metadata` table is used, gated on `minimum-version`.

## Behavior
- Warns when `tool.scikit-build.metadata` is present **and** `minimum-version` is unset or `>= 1.0`.
- Stays silent when `minimum-version < 1.0`, so projects pinning an older target opt into the old behavior without nagging.

Warning text:

> `tool.scikit-build.metadata is deprecated; use the standard top-level [[tool.dynamic-metadata]] instead`

## Changes
- `settings/skbuild_read_settings.py` — `rich_warning` in `validate_may_exit`, right after the existing "cannot be combined with `[[tool.dynamic-metadata]]`" check.
- `tests/test_dynamic_metadata.py` — parametrized regression tests for both the warning (`None`, `1.0`, `1.1`) and the no-warning case (`0.10`, `0.11`). Reaching the `>= 1.0` branch monkeypatches `__version__` to `1.1.0` (the version-too-old guard otherwise rejects `minimum-version = 1.0`), mirroring `test_skbuild_settings_auto_cmake_warning`. Tests call `rich_warning.cache_clear()` first since `rich_warning` is memoized.
- `docs/configuration/dynamic.md` — note that the legacy table is now deprecated and warns unless `minimum-version < 1.0`.

## Testing
- Confirmed the new tests fail without the source change and pass with it.
- `tests/test_dynamic_metadata.py`, `tests/test_skbuild_settings.py`, `tests/test_build_cli.py` green.
- `mypy`, `ruff check`, `ruff format` clean.