### PR TITLE
chore: drop the empty `pyproject` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dependencies = [
 # present (user controllable) - but a system version is fine.
 
 [project.optional-dependencies]
-pyproject = [
-]
 wheels = [
     "cmake",
     "ninja; sys_platform!='win32'",


### PR DESCRIPTION
Trying out Claude Sonnet 5.

:robot: _AI text below_ :robot:

## Summary

- Drops the `pyproject` extra from `[project.optional-dependencies]` — it has had no dependencies for a while and is unused.
- Verified both pip and uv emit a non-fatal warning (not an error) when an unknown extra is requested, so this is safe for anyone still specifying `scikit-build-core[pyproject]`.

Closes #882

## Test plan

- [x] Built a wheel locally and confirmed `pip install scikit_build_core-*.whl[pyproject]` succeeds with `WARNING: ... does not provide the extra 'pyproject'` (exit code 0)
- [x] Confirmed `uv pip install ...[pyproject]` succeeds with `warning: ... does not have an extra named 'pyproject'` (exit code 0)
- [x] `prek -a --quiet` passes