### PR TITLE
feat: error on renamed config fields without old minimum-version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -225,7 +225,7 @@ def _build_and_test_example(session: nox.Session) -> None:
     session.install(
         ".",
         "--no-build-isolation",
-        "--config-settings=cmake.verbose=true",
+        "--config-settings=build.verbose=true",
         env={"PYTHONWARNINGS": "error"},
     )
     session.run("pip", "list")

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -76,12 +76,12 @@ def _handle_minimum_version(
             f"Cannot set {name}.version if minimum-version is set to less than 0.8 (which is where it was introduced)"
         )
 
-    # Backwards compatibility for minimum_version
+    # Backwards compatibility for minimum_version. It is only honored when an
+    # old minimum-version (< 0.8) explicitly opts back into it; unset (latest)
+    # or >= 0.8 is an error.
     if dc.minimum_version is not None:
         msg = f"Use {name}.version instead of {name}.minimum-version with scikit-build-core >= 0.8"
-        if minimum_version is None:
-            rich_warning(msg)
-        elif minimum_version >= Version("0.8"):
+        if minimum_version is None or minimum_version >= Version("0.8"):
             rich_error(msg)
 
         if dc.version is not None and dc.version != version_default:
@@ -135,8 +135,10 @@ def _handle_move(
     if before is None:
         return after
 
+    # The renamed field is only honored when an old minimum-version (<
+    # introduced_in) explicitly opts back into it; unset (latest) is an error.
     if minimum_version is None:
-        rich_warning(
+        rich_error(
             f"Use {after_name} instead of {before_name} for scikit-build-core >= {introduced_in}"
         )
 

--- a/tests/test_pyproject_pep517.py
+++ b/tests/test_pyproject_pep517.py
@@ -182,7 +182,7 @@ def test_passing_cxx_flags(monkeypatch, env_var, setting, tmp_path: Path):
     # Note: This is sensitive to the types of quotes for SKBUILD_CMAKE_ARGS
     monkeypatch.setenv(env_var, setting)
     dist = tmp_path / "dist"
-    build_wheel(str(dist), {"cmake.targets": ["cmake_example"]})  # Could leave empty
+    build_wheel(str(dist), {"build.targets": ["cmake_example"]})  # Could leave empty
     (wheel,) = dist.glob("cmake_example-0.0.1-py3-none-*.whl")
     wheel = wheel.resolve()  # Windows mingw64 and UCRT now requires this
     wheel = wheel.resolve()  # Windows mingw64 and UCRT now requires this
@@ -206,7 +206,7 @@ def test_passing_cxx_flags(monkeypatch, env_var, setting, tmp_path: Path):
 def test_pep517_wheel(virtualenv, tmp_path: Path):
     dist = tmp_path / "dist"
     out = build_wheel(
-        str(dist), {"cmake.targets": ["cmake_example"]}
+        str(dist), {"build.targets": ["cmake_example"]}
     )  # Could leave empty
     (wheel,) = dist.glob("cmake_example-0.0.1-*.whl")
     wheel = wheel.resolve()  # Windows mingw64 and UCRT now requires this

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -630,7 +630,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
             f"""\
             [tool.scikit-build]
             cmake.args = ["a", "b"]
-            cmake.targets = ["a", "b"]
+            build.targets = ["a", "b"]
             wheel.packages = ["a", "b"]
             wheel.license-files = ["a.txt", "b.txt"]
             wheel.exclude = ["x", "y"]
@@ -640,14 +640,14 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
             [[tool.scikit-build.overrides]]
             if.state = "wheel"
             inherit.cmake.args = "{inherit}"
-            inherit.cmake.targets = "{inherit}"
+            inherit.build.targets = "{inherit}"
             inherit.wheel.packages = "{inherit}"
             inherit.wheel.license-files = "{inherit}"
             inherit.wheel.exclude = "{inherit}"
             inherit.install.components = "{inherit}"
             inherit.cmake.define = "{inherit}"
             cmake.args = ["c", "d"]
-            cmake.targets = ["c", "d"]
+            build.targets = ["c", "d"]
             wheel.packages = ["c", "d"]
             wheel.license-files = ["c.txt", "d.txt"]
             wheel.exclude = ["xx", "yy"]
@@ -663,7 +663,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
 
     if inherit == "none":
         assert settings.cmake.args == ["c", "d"]
-        assert settings.cmake.targets == ["c", "d"]
+        assert settings.build.targets == ["c", "d"]
         assert settings.wheel.packages == ["c", "d"]
         assert settings.wheel.license_files == ["c.txt", "d.txt"]
         assert settings.wheel.exclude == ["xx", "yy"]
@@ -671,7 +671,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.define == {"b": "X", "c": "C"}
     elif inherit == "append":
         assert settings.cmake.args == ["a", "b", "c", "d"]
-        assert settings.cmake.targets == ["a", "b", "c", "d"]
+        assert settings.build.targets == ["a", "b", "c", "d"]
         assert settings.wheel.packages == ["a", "b", "c", "d"]
         assert settings.wheel.license_files == ["a.txt", "b.txt", "c.txt", "d.txt"]
         assert settings.wheel.exclude == ["x", "y", "xx", "yy"]
@@ -679,7 +679,7 @@ def test_skbuild_overrides_inherit(inherit: str, tmp_path: Path):
         assert settings.cmake.define == {"a": "A", "b": "X", "c": "C"}
     elif inherit == "prepend":
         assert settings.cmake.args == ["c", "d", "a", "b"]
-        assert settings.cmake.targets == ["c", "d", "a", "b"]
+        assert settings.build.targets == ["c", "d", "a", "b"]
         assert settings.wheel.packages == ["c", "d", "a", "b"]
         assert settings.wheel.license_files == ["c.txt", "d.txt", "a.txt", "b.txt"]
         assert settings.wheel.exclude == ["xx", "yy", "x", "y"]

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -758,9 +758,9 @@ def test_skbuild_settings_min_version_versions(
     cmakelists = tmp_path / "CMakeLists.txt"
     cmakelists.write_text("cmake_minimum_required(VERSION 3.20)", encoding="utf-8")
 
-    settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    settings = settings_reader.settings
-    assert settings.cmake.version == SpecifierSet(">=3.21")
+    # Unset minimum-version (latest) no longer honors the deprecated field.
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml, {})
 
     settings_reader = SettingsReader.from_file(
         pyproject_toml, {"minimum-version": "0.7"}
@@ -875,6 +875,65 @@ def test_backcompat_cmake_build_env(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
     assert settings_reader.settings.build.verbose
     assert settings_reader.settings.build.targets == ["a", "b"]
+
+
+# The deprecated fields keep working only when an old minimum-version explicitly
+# opts back into the legacy behavior; unset (latest) or 1.0+ is an error.
+@pytest.mark.parametrize(
+    "field",
+    [
+        "cmake.minimum-version = '3.21'",
+        "ninja.minimum-version = '1.11'",
+        "cmake.verbose = true",
+        "cmake.targets = ['a', 'b']",
+    ],
+)
+@pytest.mark.parametrize("min_version", [None, "1.0"])
+def test_deprecated_field_errors(
+    field: str,
+    min_version: str | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.0.0"
+    )
+    lines = ["[tool.scikit-build]", field]
+    if min_version is not None:
+        lines.insert(1, f'minimum-version = "{min_version}"')
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("\n".join(lines), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml)
+
+
+@pytest.mark.parametrize(
+    ("field", "min_version"),
+    [
+        ("cmake.minimum-version = '3.21'", "0.7"),
+        ("ninja.minimum-version = '1.11'", "0.7"),
+        ("cmake.verbose = true", "0.9"),
+        ("cmake.targets = ['a', 'b']", "0.9"),
+    ],
+)
+def test_deprecated_field_old_pin_allowed(
+    field: str,
+    min_version: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "1.0.0"
+    )
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        f'[tool.scikit-build]\nminimum-version = "{min_version}"\n{field}\n',
+        encoding="utf-8",
+    )
+
+    # Old pins keep the legacy behavior without raising.
+    SettingsReader.from_file(pyproject_toml)
 
 
 def test_auto_minimum_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1148.

We have a few config fields that were renamed but kept around as deprecated aliases. Rather than removing them outright, this makes using them an **error** when `minimum-version` is unset (i.e. latest) or `>= 1.0`, while still honoring them for users who explicitly pin an old `minimum-version`. This gives a clear, actionable failure ahead of the planned 1.0 removal, and matches what the docs already describe (`minimum-version` "0.8+ (or unset)" / "0.10+ (or unset)" are *replaced*).

### Fields affected

| Field | → Replacement | Deprecated in |
|---|---|---|
| `cmake.minimum-version` | `cmake.version` | 0.8 |
| `ninja.minimum-version` | `ninja.version` | 0.8 |
| `cmake.verbose` | `build.verbose` | 0.10 |
| `cmake.targets` | `build.targets` | 0.10 |

(The `tool.scikit-build.metadata` table is a separate, brand-new 1.0 deprecation that already warns — left as a warning since it hasn't had a deprecation cycle yet.)

### Behavior

Two helpers in `skbuild_read_settings.py` had a `minimum_version is None` branch that only **warned**; both now **error**:

- `_handle_minimum_version`: unset or `>= 0.8` → error (was: warn when unset).
- `_handle_move`: unset → error (was: warn); already errored at `>= 0.10`.

Net rule: **error when `minimum-version` is unset or `>= 1.0`**; an explicit old pin (`< 0.8` / `< 0.10`) keeps the legacy behavior, so the fields remain functional for back-compat.

### Tests

- Added `test_deprecated_field_errors` (all four fields × `{unset, "1.0"}` → `SystemExit`) and `test_deprecated_field_old_pin_allowed` (old pins still work). The error tests were confirmed to fail first on the unset cases, then pass after the change.
- Updated existing incidental users of the old warn-only behavior: `test_skbuild_settings_min_version_versions` (unset now raises), and migrated `cmake.targets` → `build.targets` in `test_pyproject_pep517.py` and the override-inherit test in `test_settings_overrides.py`.