### PR TITLE
fix(editable): refuse to wipe a populated rebuild-dir

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -443,6 +443,10 @@ print(mk_skbuild_docs())
   the same template substitutions as :confval:`build-dir`. This relocates only
   the install tree; :confval:`build-dir` is still required and still hosts the
   CMake build that the rebuild re-runs.
+
+  The tree is wiped and recreated on each build, so it must be a fresh or
+  scikit-build-core-managed directory -- pointing it at a populated directory
+  such as your source tree is refused to avoid deleting those files.
 ```
 
 ```{eval-rst}

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -446,7 +446,9 @@ print(mk_skbuild_docs())
 
   The tree is wiped and recreated on each build, so it must be a fresh or
   scikit-build-core-managed directory -- pointing it at a populated directory
-  such as your source tree is refused to avoid deleting those files.
+  such as your source tree is refused to avoid deleting those files. A managed
+  tree gets a ``CACHEDIR.TAG`` and a ``.gitignore`` so its compiled artifacts
+  stay out of backups and version control.
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -52,9 +52,17 @@ __all__ = [
     "prepare_wheel_dirs",
 ]
 
-# Dropped into a user-chosen editable.rebuild-dir so a later build knows the tree
-# is ours and is safe to wipe and refresh.
-REBUILD_DIR_MARKER = ".skbuild-editable"
+# A cache-directory tag (https://bford.info/cachedir/) dropped into a user-chosen
+# editable.rebuild-dir. The standard first line opts the tree out of backups; the
+# scikit-build-core line doubles as our ownership marker, so a later build knows
+# the tree is ours and is safe to wipe and refresh.
+CACHEDIR_TAG_NAME = "CACHEDIR.TAG"
+CACHEDIR_TAG_CONTENT = (
+    "Signature: 8a477f597d28d172789f06886806bc55\n"
+    "# This file marks a scikit-build-core editable rebuild-dir install tree.\n"
+    "# It is wiped and refreshed on every build; do not store anything here.\n"
+    "# For information about cache directory tags see https://bford.info/cachedir/\n"
+)
 
 WheelState = Literal[
     "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
@@ -142,6 +150,12 @@ def get_editable_rebuild_dir(
     return (build_dir / "install" / targetlib).resolve()
 
 
+def _is_owned_rebuild_dir(targetlib_dir: Path) -> bool:
+    """True if ``targetlib_dir`` carries our cache-tag, i.e. we created it."""
+    tag = targetlib_dir / CACHEDIR_TAG_NAME
+    return tag.is_file() and "scikit-build-core" in tag.read_text(encoding="utf-8")
+
+
 def prepare_editable_rebuild_dir(targetlib_dir: Path, *, guard: bool) -> None:
     """
     Clean and (re)create the persistent install tree for a rebuildable editable.
@@ -154,11 +168,16 @@ def prepare_editable_rebuild_dir(targetlib_dir: Path, *, guard: bool) -> None:
     A user-chosen ``editable.rebuild-dir`` (``guard=True``) may accidentally
     point at a populated directory -- e.g. the package's own source tree. Wiping
     that would delete the user's source (#1135), so refuse unless the directory
-    is empty or carries the marker we drop on a tree we created ourselves.
+    is empty or carries the cache-tag we drop on a tree we created ourselves. A
+    guarded tree also gets a ``.gitignore`` so its compiled artifacts stay out of
+    version control.
     """
     if targetlib_dir.exists():
-        marker = targetlib_dir / REBUILD_DIR_MARKER
-        if guard and not marker.is_file() and any(targetlib_dir.iterdir()):
+        if (
+            guard
+            and not _is_owned_rebuild_dir(targetlib_dir)
+            and any(targetlib_dir.iterdir())
+        ):
             msg = (
                 f"editable.rebuild-dir {targetlib_dir} is not empty and was not "
                 "created by scikit-build-core; refusing to delete it. Point "
@@ -168,7 +187,13 @@ def prepare_editable_rebuild_dir(targetlib_dir: Path, *, guard: bool) -> None:
         shutil.rmtree(targetlib_dir)
     targetlib_dir.mkdir(parents=True)
     if guard:
-        (targetlib_dir / REBUILD_DIR_MARKER).touch()
+        (targetlib_dir / CACHEDIR_TAG_NAME).write_text(
+            CACHEDIR_TAG_CONTENT, encoding="utf-8"
+        )
+        (targetlib_dir / ".gitignore").write_text(
+            "# Created by scikit-build-core; an editable rebuild install tree.\n*\n",
+            encoding="utf-8",
+        )
 
 
 def prepare_wheel_dirs(wheel_root: Path, *, targetlib: TargetLib) -> dict[str, Path]:

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -11,6 +11,7 @@ configure/build/install. The wheel-assembly side (WheelWriter vs hatchling
 from __future__ import annotations
 
 import os
+import shutil
 import sysconfig
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -47,8 +48,13 @@ __all__ = [
     "get_targetlib",
     "get_wheel_tag",
     "install_wheel",
+    "prepare_editable_rebuild_dir",
     "prepare_wheel_dirs",
 ]
+
+# Dropped into a user-chosen editable.rebuild-dir so a later build knows the tree
+# is ours and is safe to wipe and refresh.
+REBUILD_DIR_MARKER = ".skbuild-editable"
 
 WheelState = Literal[
     "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
@@ -134,6 +140,35 @@ def get_editable_rebuild_dir(
             )
         ).resolve()
     return (build_dir / "install" / targetlib).resolve()
+
+
+def prepare_editable_rebuild_dir(targetlib_dir: Path, *, guard: bool) -> None:
+    """
+    Clean and (re)create the persistent install tree for a rebuildable editable.
+
+    The tree is wiped so stale artifacts from a previous build don't linger (a
+    ``cmake --install`` only ever adds files). The default tree lives inside
+    ``build-dir`` and is fully owned by scikit-build-core, so wiping is always
+    safe (``guard=False``).
+
+    A user-chosen ``editable.rebuild-dir`` (``guard=True``) may accidentally
+    point at a populated directory -- e.g. the package's own source tree. Wiping
+    that would delete the user's source (#1135), so refuse unless the directory
+    is empty or carries the marker we drop on a tree we created ourselves.
+    """
+    if targetlib_dir.exists():
+        marker = targetlib_dir / REBUILD_DIR_MARKER
+        if guard and not marker.is_file() and any(targetlib_dir.iterdir()):
+            msg = (
+                f"editable.rebuild-dir {targetlib_dir} is not empty and was not "
+                "created by scikit-build-core; refusing to delete it. Point "
+                "rebuild-dir at a new or empty directory -- not at a source tree."
+            )
+            raise FileExistsError(msg)
+        shutil.rmtree(targetlib_dir)
+    targetlib_dir.mkdir(parents=True)
+    if guard:
+        (targetlib_dir / REBUILD_DIR_MARKER).touch()
 
 
 def prepare_wheel_dirs(wheel_root: Path, *, targetlib: TargetLib) -> dict[str, Path]:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -42,6 +42,7 @@ from .common_wheel_helpers import (
     get_targetlib,
     get_wheel_tag,
     install_wheel,
+    prepare_editable_rebuild_dir,
     prepare_wheel_dirs,
 )
 from .generate import generate_file_contents
@@ -328,9 +329,9 @@ def _build_wheel_impl_impl(
                 tags=tags,
                 state=state,
             )
-            if targetlib_dir.exists():
-                shutil.rmtree(targetlib_dir)
-            targetlib_dir.mkdir(parents=True)
+            prepare_editable_rebuild_dir(
+                targetlib_dir, guard=bool(settings.editable.rebuild_dir)
+            )
         else:
             targetlib_dir = wheel_dirs[targetlib]
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -613,7 +613,9 @@ class EditableSettings:
 
     The tree is wiped and recreated on each build, so it must be a fresh or
     scikit-build-core-managed directory -- pointing it at a populated directory
-    such as your source tree is refused to avoid deleting those files.
+    such as your source tree is refused to avoid deleting those files. A managed
+    tree gets a ``CACHEDIR.TAG`` and a ``.gitignore`` so its compiled artifacts
+    stay out of backups and version control.
     """
 
     @property

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -610,6 +610,10 @@ class EditableSettings:
     the same template substitutions as :confval:`build-dir`. This relocates only
     the install tree; :confval:`build-dir` is still required and still hosts the
     CMake build that the rebuild re-runs.
+
+    The tree is wiped and recreated on each build, so it must be a fresh or
+    scikit-build-core-managed directory -- pointing it at a populated directory
+    such as your source tree is refused to avoid deleting those files.
     """
 
     @property

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -674,40 +674,44 @@ def test_prepare_editable_rebuild_dir_refuses_populated(tmp_path: Path):
 
 def test_prepare_editable_rebuild_dir_refreshes_own_tree(tmp_path: Path):
     from scikit_build_core.build.common_wheel_helpers import (
-        REBUILD_DIR_MARKER,
+        CACHEDIR_TAG_NAME,
         prepare_editable_rebuild_dir,
     )
 
     tree = tmp_path / "rebuild_tree"
 
-    # First build creates and marks the tree.
+    # First build creates the tree with a cache-tag and a .gitignore.
     prepare_editable_rebuild_dir(tree, guard=True)
-    assert (tree / REBUILD_DIR_MARKER).is_file()
+    tag = tree / CACHEDIR_TAG_NAME
+    assert tag.read_text().startswith("Signature: 8a477f597d28d172789f06886806bc55")
+    assert (tree / ".gitignore").read_text().endswith("*\n")
 
     # Stale artifacts from a prior build are wiped on the next build because the
-    # marker proves the tree is ours.
+    # cache-tag proves the tree is ours.
     stale = tree / "_module.so"
     stale.write_text("stale\n")
     prepare_editable_rebuild_dir(tree, guard=True)
     assert not stale.exists()
-    assert (tree / REBUILD_DIR_MARKER).is_file()
+    assert tag.is_file()
 
 
 def test_prepare_editable_rebuild_dir_default_tree_unguarded(tmp_path: Path):
     from scikit_build_core.build.common_wheel_helpers import (
-        REBUILD_DIR_MARKER,
+        CACHEDIR_TAG_NAME,
         prepare_editable_rebuild_dir,
     )
 
     # The default install/<targetlib> tree lives inside build-dir and is fully
-    # owned by scikit-build-core, so it is wiped without the marker guard.
+    # owned by scikit-build-core, so it is wiped without the cache-tag guard and
+    # no tag/.gitignore is written.
     tree = tmp_path / "build" / "install" / "platlib"
     tree.mkdir(parents=True)
     (tree / "old.so").write_text("old\n")
 
     prepare_editable_rebuild_dir(tree, guard=False)
     assert not (tree / "old.so").exists()
-    assert not (tree / REBUILD_DIR_MARKER).exists()
+    assert not (tree / CACHEDIR_TAG_NAME).exists()
+    assert not (tree / ".gitignore").exists()
 
 
 def test_is_trackable():

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -655,6 +655,61 @@ def test_editable_redirect_files_rebuild_dir_implies_rebuild(tmp_path: Path):
         )
 
 
+def test_prepare_editable_rebuild_dir_refuses_populated(tmp_path: Path):
+    from scikit_build_core.build.common_wheel_helpers import (
+        prepare_editable_rebuild_dir,
+    )
+
+    # A user-chosen rebuild-dir pointing at populated source must not be wiped.
+    source = tmp_path / "python" / "src" / "mypackage"
+    source.mkdir(parents=True)
+    keep = source / "__init__.py"
+    keep.write_text("x = 1\n")
+
+    with pytest.raises(FileExistsError, match="refusing to delete"):
+        prepare_editable_rebuild_dir(source, guard=True)
+
+    assert keep.read_text() == "x = 1\n"
+
+
+def test_prepare_editable_rebuild_dir_refreshes_own_tree(tmp_path: Path):
+    from scikit_build_core.build.common_wheel_helpers import (
+        REBUILD_DIR_MARKER,
+        prepare_editable_rebuild_dir,
+    )
+
+    tree = tmp_path / "rebuild_tree"
+
+    # First build creates and marks the tree.
+    prepare_editable_rebuild_dir(tree, guard=True)
+    assert (tree / REBUILD_DIR_MARKER).is_file()
+
+    # Stale artifacts from a prior build are wiped on the next build because the
+    # marker proves the tree is ours.
+    stale = tree / "_module.so"
+    stale.write_text("stale\n")
+    prepare_editable_rebuild_dir(tree, guard=True)
+    assert not stale.exists()
+    assert (tree / REBUILD_DIR_MARKER).is_file()
+
+
+def test_prepare_editable_rebuild_dir_default_tree_unguarded(tmp_path: Path):
+    from scikit_build_core.build.common_wheel_helpers import (
+        REBUILD_DIR_MARKER,
+        prepare_editable_rebuild_dir,
+    )
+
+    # The default install/<targetlib> tree lives inside build-dir and is fully
+    # owned by scikit-build-core, so it is wiped without the marker guard.
+    tree = tmp_path / "build" / "install" / "platlib"
+    tree.mkdir(parents=True)
+    (tree / "old.so").write_text("old\n")
+
+    prepare_editable_rebuild_dir(tree, guard=False)
+    assert not (tree / "old.so").exists()
+    assert not (tree / REBUILD_DIR_MARKER).exists()
+
+
 def test_is_trackable():
     # Importable modules and data/resource files are both tracked, so the
     # redirect registers their directories for importlib.resources.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Follow-up to #1375. As [reported there](https://github.com/scikit-build/scikit-build-core/pull/1375#issuecomment-4847019134), setting `editable.rebuild-dir` to a populated directory (e.g. `python/src` where the `.py` source lives) deleted the user's entire source folder, because the rebuild install tree is unconditionally `shutil.rmtree`'d on each build.

We can't really make rebuild-dir overlap a source tree *work* — the tree must be wiped each build since `cmake --install` only ever adds files, so stale artifacts would otherwise linger. But we can stop destroying source.

## Change

- New `prepare_editable_rebuild_dir` helper drops a `CACHEDIR.TAG` into any tree we create for a user-chosen `rebuild-dir`. The standard signature line opts the tree out of backup tools; the `scikit-build-core` line in it doubles as our ownership marker.
- It also writes a `.gitignore` (`*`) so the compiled artifacts stay out of version control. This mirrors what tools like Cargo do for their `target/` build trees.
- Before wiping a user-chosen `rebuild-dir`, refuse (raise `FileExistsError` with a clear message) when the directory is **non-empty and does not carry our cache-tag** — i.e. something we didn't create.
- Empty / non-existent / previously-managed trees are still wiped and refreshed as before, so reinstalls and import-triggered rebuilds keep working.
- The default `build-dir/install/<targetlib>` tree is fully owned by us, so it stays unguarded (`guard=False`) — no behavior change, no tag/gitignore written, and no risk to existing `editable.rebuild = true` users.

Instead of silently deleting `python/src/mypackage`, the user now gets:

> `editable.rebuild-dir … is not empty and was not created by scikit-build-core; refusing to delete it. Point rebuild-dir at a new or empty directory -- not at a source tree.`

## Tests

- 3 new unit tests: refuses a populated dir (source preserved), refreshes its own tagged tree (and writes `CACHEDIR.TAG` + `.gitignore`), default tree wiped unguarded with no tag/gitignore.
- Existing `test_editable_rebuild_dir` integration test still passes (the new files don't interfere with import resolution).
- Docstring updated; `nox -t gen` regenerated `docs/reference/configs.md`.