### PR TITLE
docs: review and refresh documentation for the 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ features over classic Scikit-build:
 - Support for writing out to extra wheel folders (scripts, headers, data)
 - Support for selecting install components and build targets
 - Dedicated entrypoints for module and prefix directories
-- Several integrated dynamic metadata plugins (proposing standardized support
-  soon)
+- Several integrated dynamic metadata plugins, supporting the cross-backend
+  `[[tool.dynamic-metadata]]` standard
 - Editable mode support, with optional experimental auto rebuilds on import and
   optional in-place mode
 - Supports WebAssembly (Emscripten/[Pyodide](https://pyodide.org)).
@@ -75,11 +75,10 @@ The following limitations are present compared to classic scikit-build:
 - The minimum supported CMake is 3.15
 - The minimum supported Python is 3.8 (3.7+ for 0.10.x and older)
 
-Some known missing features that will be developed soon:
+A few limitations remain (covered in detail in the docs):
 
-- Wheels are not fully reproducible yet (nor are they in most others systems,
-  including setuptools)
-- Several editable mode caveats (mentioned in the docs).
+- Wheel reproducibility is opt-in (`wheel.reproducible`)
+- Editable install rebuild mode has some caveats.
 
 Other backends are also available:
 
@@ -94,8 +93,7 @@ scikit-build, and a Hatchling plugin.
 >
 > The setuptools and hatchling backends might move to standalone packages in the
 > future, so depend on them via the `scikit-build-core[setuptools]` and
-> `scikit-build-core[hatchling]` extras to stay protected if they do. The
-> internal API for writing new build extensions is still being solidified.
+> `scikit-build-core[hatchling]` extras to stay protected if they do.
 
 ## Example
 

--- a/docs/about/projects.md
+++ b/docs/about/projects.md
@@ -1,9 +1,9 @@
 # Projects
 
-There are over 600 projects using scikit-build-core on PyPI (as of May 2025).
-This is a selection of some of the projects. Feel free to add your own project
-to `docs/data/projects.toml`. The following selection was primarily constructed
-by looking at the [top 15,000](https://hugovk.dev/top-pypi-packages/) most
+There are well over 600 projects using scikit-build-core on PyPI. This is a
+selection of some of the projects. Feel free to add your own project to
+`docs/data/projects.toml`. The following selection was primarily constructed by
+looking at the [top 15,000](https://hugovk.dev/top-pypi-packages/) most
 downloaded projects on PyPI for top-level pyproject.toml's in SDists that use
 scikit-build-core.
 

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -134,7 +134,8 @@ project(MyPackage VERSION ${PROJECT_VERSION})
 ### Regex
 
 If you want to pull a string-valued expression (usually version) from an
-existing file, you can the integrated `regex` plugin to pull the information.
+existing file, you can use the integrated `regex` plugin to pull the
+information.
 
 ````{tab} `[[tool.dynamic-metadata]]`
 

--- a/docs/configuration/formatted.md
+++ b/docs/configuration/formatted.md
@@ -1,9 +1,10 @@
 # Formattable fields
 
-The following configure keys are formatted as Python f-strings:
+The following configure keys are formatted as Python `str.format` templates:
 
 - `build-dir`
 - `build.requires`
+- `editable.rebuild-dir`
 
 The available variables are documented in the members of
 {py:class}`scikit_build_core.format.PyprojectFormatter` copied here for

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -101,7 +101,7 @@ probably keep in sync with your build-system requirements.
 
 ```toml
 [tool.scikit-build]
-minimum-version = "0.2"
+minimum-version = "0.12"
 ```
 
 In your `pyproject.toml`, you can specify the special string
@@ -111,7 +111,7 @@ automatic feature.
 
 ```toml
 [build-system]
-requires = ["scikit-build-core>=0.10"]
+requires = ["scikit-build-core>=0.12"]
 
 [tool.scikit-build]
 minimum-version = "build-system.requires"
@@ -135,6 +135,9 @@ The following behaviors are affected by `minimum-version`:
   will be detected if not given.
 - `minimum-version` 0.12+ (or unset) uses `"default"` instead of `"classic"` as
   the default for `sdist.include-mode`.
+- `minimum-version` 1.0+ (or unset) deprecates the `tool.scikit-build.metadata`
+  table in favor of the standard top-level `[[tool.dynamic-metadata]]`; see
+  [](./dynamic.md).
 
 :::
 
@@ -174,8 +177,8 @@ ninja.make-fallback = false
 
 You can also control the FindPython backport; by default, a backport of CMake
 3.26.1's FindPython will be used if the CMake version is less than 3.26.1; you
-can turn this down if you'd like ("3.15", scikit-build-core's minimum version,
-would turn it off).
+can turn this down if you'd like ("3.15", scikit-build-core's minimum supported
+CMake version, would turn it off).
 
 ```toml
 [tool.scikit-build]
@@ -209,7 +212,7 @@ sdist.include-mode = "manual"
 ```
 
 There's also a `"classic"` mode, which fully traverses all directories to check
-rules (default is using scikit-build-core less than 0.12).
+rules (this was the default before scikit-build-core 0.12).
 
 By default, scikit-build-core will respect `SOURCE_DATE_EPOCH`, and will lock
 the modification time to a reproducible value if it's not set. You can disable
@@ -469,7 +472,7 @@ newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
 `Development.SABIModule` when targeting ABI3 or ABI3T, and is an empty string
 otherwise. For free-threaded Python (PEP 703), you can use `cp315t` to target
 the free-threaded stable ABI, which sets `Py_TARGET_ABI3T` (if using CMake
-4.4+). The emitted wheel tag is `cp315-abi3t-*` following per PEP 803.
+4.4+). The emitted wheel tag is `cp315-abi3t-*` following [PEP 803][].
 
 You can request both stable ABIs with `cp315.cp315t`. On a free-threaded build
 this emits a combined `cp315-abi3.abi3t-*` tag: `abi3t` is a subset of `abi3`
@@ -831,6 +834,7 @@ the interpreter running the editable install.
 
 [PEP 829]: https://peps.python.org/pep-0829/
 [PEP 817]: https://peps.python.org/pep-0817/
+[PEP 803]: https://peps.python.org/pep-0803/
 
 :::{note}
 
@@ -925,9 +929,12 @@ The following features currently require this flag:
 - **Wheel variants**: [PEP 817][] variant support (`variant`, `variant-name`,
   `variant-label`, and `null-variant`). See
   [](../guide/faqs.md#building-wheel-variants-experimental).
-- **Third-party dynamic-metadata plugins**: dynamic metadata providers not
-  shipped with scikit-build-core (anything using `provider-path` or a provider
-  outside the `scikit_build_core.*` namespace). See [](./dynamic.md).
+- **Legacy `tool.scikit-build.metadata` plugins**: dynamic metadata providers
+  not shipped with scikit-build-core (anything using `provider-path` or a
+  provider outside the `scikit_build_core.*` namespace) used through the
+  deprecated `tool.scikit-build.metadata` table. The standard
+  `[[tool.dynamic-metadata]]` interface supports the same providers without this
+  flag. See [](./dynamic.md).
 - **Leading-slash wheel trees**: the deprecated absolute spelling (`/platlib`,
   `/data`, `/headers`, `/scripts`, `/metadata`) for `wheel.install-dir` and
   `wheel.force-include`, placed one level above the platlib root. The

--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -22,7 +22,7 @@ At least one must be provided. Then you can specify any collection of valid
 options, and those will override if all the items in the `if` are true. They
 will match top to bottom, overriding previous matches.
 
-If an override does not match, it's contents are ignored, including invalid
+If an override does not match, its contents are ignored, including invalid
 options. Combined with the `if.scikit-build-version` override, this allows using
 overrides to support a range of scikit-build-core versions that added settings
 you want to use.
@@ -202,8 +202,8 @@ wheel.cmake = true
 ### `failed` (bool)
 
 This override is a bit special. If a build fails, scikit-build-core will check
-to see if there's a matching `failed = true` override. If there is, the the
-build will be retried once with the new settings. This can be used to build a
+to see if there's a matching `failed = true` override. If there is, the build
+will be retried once with the new settings. This can be used to build a
 pure-Python fallback if a build fails, for example:
 
 ```toml

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -11,7 +11,7 @@ using `find_package`. This variable is populated by the dependent project's
 entry-point `cmake.root`.
 
 To configure the `cmake.root` entry-point to export to other projects, you can
-use the CMake standard install paths in you `CMakeLists.txt` if you use
+use the CMake standard install paths in your `CMakeLists.txt` if you use
 `wheel.install-dir` option, e.g.
 
 ```{code-block} cmake
@@ -66,7 +66,7 @@ search.site-packages = false
 ```
 
 Additionally, scikit-build-core reads the entry-point `cmake.prefix` of the
-dependent projects, which is similarly export as
+dependent projects, which is similarly exported as
 
 ```toml
 [project.entry-points."cmake.prefix"]
@@ -84,5 +84,3 @@ projects, which is similarly exported as
 [project.entry-points."cmake.module"]
 MyProject = "myproject"
 ```
-
-[`CMAKE_PREFIX_PATH`]: #cmake-prefix-path

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -88,7 +88,7 @@ There also is a `PKG-INFO` file with metadata in SDists.
 The wheel is a zip file (ending in `.whl`) with the built code of the project,
 along with required metadata. There is no code that executes on install; it is a
 simple unpack with a few rules about directories. Wheels do not contain
-`pyproject.toml` or other configuration files. To build an wheel, you use the
+`pyproject.toml` or other configuration files. To build a wheel, you use the
 `build` tool with the `--wheel` flag. For example, `pipx run build --wheel`.
 This:
 
@@ -100,7 +100,7 @@ This:
    all the packages requested. This allows a backend to dynamically declare
    dependencies.
 4. Run `.build_wheel(...)` inside the module listed in
-   `build-system.build-backend`. The backend produces an wheel file and returns
+   `build-system.build-backend`. The backend produces a wheel file and returns
    the filename.
 
 Details of the arguments are skipped above, but they allow arbitrary settings

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -169,7 +169,12 @@ support ABI3 either.
 If you are using `nanobind`'s `nanobind_add_module`, the `STABLE_ABI` flag does
 this automatically for you for 3.12+.
 
-## Future additions
+## Language helpers
 
-Scikit-build-core does not include helpers for F2Py or Cython like scikit-build
-classic yet. These will be carefully reimagined soon.
+Helpers for Cython and F2Py are provided as standalone CMake packages rather
+than being built into scikit-build-core: [cython-cmake][] (`include(UseCython)`)
+and [f2py-cmake][] (`include(UseF2Py)`). Add them to your `build.requires` and
+see the [getting started guide](getting_started.md) for full examples.
+
+[cython-cmake]: https://github.com/scikit-build/cython-cmake
+[f2py-cmake]: https://github.com/scikit-build/f2py-cmake

--- a/docs/guide/dynamic_link.md
+++ b/docs/guide/dynamic_link.md
@@ -3,10 +3,10 @@
 If you want to support dynamic linkages between python projects or system
 libraries, you will likely encounter some issues in making sure the compiled
 libraries/python bindings work after the wheel is created and the python project
-is installed on the system. The most common issue are the missing hints pointing
-to where the runtime libraries are located, specifically `RPATH` on Linux and
-MacOS systems, and `PATH`/`os.add_dll_directory` on Windows systems. Here are
-some recommendations on how to address them.
+is installed on the system. The most common issues are the missing hints
+pointing to where the runtime libraries are located, specifically `RPATH` on
+Linux and MacOS systems, and `PATH`/`os.add_dll_directory` on Windows systems.
+Here are some recommendations on how to address them.
 
 ## Link to the static libraries
 
@@ -31,7 +31,7 @@ these tools in its [repair wheel] feature.
 These tools also rename the library with a unique hash to avoid any potential
 name collision if the same library is being bundled by a different package, and
 check if the packages conform to standards like [PEP600] (`manylinux_X_Y`).
-These tools do not allow to have cross wheel library dependency.
+These tools do not allow cross-wheel library dependencies.
 
 ## Manual patching
 

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -4,15 +4,19 @@ This section covers common needs.
 
 ## Starting a new project
 
-The easiest way to get started is to use the [Scientific Python cookie][], which
+The quickest way is the built-in `init` command:
+`scikit-build init --backend pybind11 myproject` scaffolds a ready-to-build
+project (run without `--backend` to pick a binding interactively). See the
+[getting started guide](getting_started.md) for a walkthrough of what it
+generates.
+
+For a fully-featured project layout, use the [Scientific Python cookie][], which
 makes a new project following the [Scientific Python Development Guidelines][].
 Scikit-build-core is one of the backends you can select. The project will have a
 lot of tooling prepared for you as well, including pre-commit checks and a
 noxfile; be sure to read the guidelines to see what is there and how it works.
 
 Another option is the [pybind11 example][].
-
-In the future, a CLI interface with a new project generator is planned.
 
 ## Multithreaded builds
 
@@ -47,12 +51,12 @@ A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
 
 ## Dynamic setup.py options
 
-While we will eventually have some dynamic options, most common needs can be
-moved into your `CMakeLists.txt`. For example, if you had a custom `setup.py`
-option (which setuptools has deprecated as well), you can make it a CMake option
-and then pass it with `-Ccmake.define.<OPTION_NAME>=<value>`. If you need to
-customize configuration options, try `[[tool.scikit-build.overrides]]`. If that
-is missing some value you need, please open an issue and let us know.
+Most common needs can be moved into your `CMakeLists.txt`. For example, if you
+had a custom `setup.py` option (which setuptools has deprecated as well), you
+can make it a CMake option and then pass it with
+`-Ccmake.define.<OPTION_NAME>=<value>`. If you need to customize configuration
+options, try `[[tool.scikit-build.overrides]]`. If that is missing some value
+you need, please open an issue and let us know.
 
 ## Finding Python
 
@@ -138,7 +142,7 @@ requirements:
   host:
     - python
     - pip
-    - scikit-build-core >=0.2.0
+    - scikit-build-core >=0.12
   run:
     - python
 ```

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -352,7 +352,7 @@ The project line can optionally use `SKBUILD_PROJECT_NAME` and
 your `pyproject.toml`. You should specify exactly what language you use to keep
 CMake from searching for both `C` and `CXX` compilers (the default).
 
-If you place find Python first, pybind11 will respect it instead of the classic
+If you place find Python first, pybind11 will respect it instead of the older
 FindPythonInterp/FindPythonLibs mechanisms, which work, but are not as modern.
 Here we set `PYBIND11_FINDPYTHON` to `ON` instead of doing the find Python
 ourselves. Pybind11 places its config file such that CMake can find it from
@@ -543,7 +543,7 @@ That's it for a basic package!
 [nanobind example]:                  https://github.com/wjakob/nanobind_example
 [packaging.python.org's tutorial]:   https://packaging.python.org/en/latest/tutorials/packaging-projects
 [pybind11/scikit_build_example]:     https://github.com/pybind/scikit_build_example
-[scientific python developer guide]: https://github.com/scikit-build/scikit-build-sample-projects
+[scientific python developer guide]: https://learn.scientific-python.org/development
 [scientific-python/cookie]:          https://github.com/scientific-python/cookie
 [scikit-build-sample-projects]:      https://github.com/scikit-build/scikit-build-sample-projects
 [uv]:                                https://docs.astral.sh/uv/

--- a/docs/guide/migration_guide.md
+++ b/docs/guide/migration_guide.md
@@ -1,11 +1,5 @@
 # Migrating from scikit-build
 
-```{warning}
-scikit-build-core is under active development. This guidance will be updated
-on a best-effort basis, but if you are working at the bleeding edge some of it
-may be out of date.
-```
-
 ## Config changes
 
 - The `build-system.build-backend` key in pyproject.toml must be changed to
@@ -57,9 +51,12 @@ find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 python_add_library(${LIBRARY} MODULE WITH_SOABI ${FILENAME})
 ```
 
-- The UseCython CMake module distributed with scikit-build is not currently
-  supported. For examples on how to use Cython, see
-  [our getting started guide](getting_started.md) for now.
+- The UseCython CMake module distributed with scikit-build (classic) is replaced
+  by the standalone [cython-cmake][] package (`include(UseCython)`). See
+  [our getting started guide](getting_started.md) for an example.
+
+[cython-cmake]: https://github.com/scikit-build/cython-cmake
+
 - The `SKBUILD_CONFIGURE_OPTIONS` environment variable is now named
   `SKBUILD_CMAKE_ARGS` for consistency.
 - The `SKBUILD_BUILD_OPTIONS` environment variable is not supported. Some

--- a/docs/man.md
+++ b/docs/man.md
@@ -26,6 +26,7 @@ for inspecting the build environment:
 - **scikit-build builder sysconfig** -- show information from sysconfig.
 - **scikit-build file-api query** -- request the CMake file API.
 - **scikit-build file-api reply** -- process the CMake file API.
+- **scikit-build init** -- generate a starter project for a binding backend.
 
 See the CLI reference for the full set of options.
 

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -48,9 +48,9 @@ supported by hatchling for plugins.
 
 Key limitations:
 
-- You need to leave `cmake.wheel` on. No `wheel.platlib = False` builds.
+- You need to leave `wheel.cmake` on. No `wheel.platlib = false` builds.
 - Using cmake in SDist step is not supported yet.
-- `scikit-build.generate` and `scikit-build.metadata` is not supported.
+- `scikit-build.generate` and `scikit-build.metadata` are not supported.
 - `${SKBUILD_HEADER_DIR}` is not supported, request support in Hatchling if
   needed.
 - Anything in `${SKBUILD_METADATA_DIR}` must be placed in an `extra_metadata`

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -1,6 +1,6 @@
 # Setuptools
 
-A setuptools plugin is being developed for scikit-build-core, primarily to
+Scikit-build-core includes an experimental setuptools plugin, primarily to
 enable scikit-build-core to be the build backend for scikit-build (classic).
 
 :::{warning}
@@ -65,16 +65,16 @@ These options from scikit-build (classic) are not currently supported:
 so has no effect here.
 
 A compatibility shim, `scikit_build_core.setuptools.wrapper.setup` is provided;
-it will eventually behave as close to scikit-build (classic)'s `skbuild.setup`
-as possible.
+it aims to behave as close to scikit-build (classic)'s `skbuild.setup` as
+possible.
 
 ## Configuration
 
 All other configuration is available as normal `tool.scikit-build` in
 `pyproject.toml` or environment variables as applicable. Config-settings is
-_not_ supported, as setuptools has very poor support for config-settings.
-Eventually, the build hook might pre-process options, but it's tricky to pass
-them through, so it will probably require use cases to be presented.
+_not_ supported, as setuptools has very poor support for config-settings. The
+build hook might pre-process options in the future, but it's tricky to pass them
+through, so it will likely require use cases to be presented.
 
 For classic scikit-build compatibility, two environment variables are honored,
 but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,8 +1,7 @@
 # CLI Reference
 
-Scikit-build-core has a few integrated CLI tools. These are not guaranteed to be
-stable between releases yet, but can still be useful to investigate your
-environment.
+Scikit-build-core has a few integrated CLI tools, useful for scaffolding a
+project and investigating your environment.
 
 These are available through the `scikit-build` command (also runnable as
 `python -m scikit_build_core`), with the modules exposed as subcommands.


### PR DESCRIPTION
Close #1401.

:robot: _AI text below_ :robot:

Documentation pass in preparation for the 1.0 release. No source/behavior changes — docs only.

## Correctness
- **`plugins/hatchling.md`**: wrong config key `cmake.wheel` → `wheel.cmake`; `wheel.platlib = False` → `false`; "is not supported" → "are".
- **`configuration/index.md`**: the "experimental features" list claimed *all* third-party dynamic-metadata plugins need `experimental = true`. Verified against `skbuild_read_settings.py` that only the legacy `tool.scikit-build.metadata` table is gated — the standard `[[tool.dynamic-metadata]]` interface is not. Bullet rescoped accordingly.

## Stale "coming soon" promises (already shipped)
- **`guide/cmakelists.md`**: "no Cython/F2Py helpers yet… soon" → a "Language helpers" section pointing at `cython-cmake` / `f2py-cmake`.
- **`guide/faqs.md`**: "Starting a new project" now leads with `scikit-build init` (was "a generator is planned"); dropped "we will eventually have some dynamic options".
- **`guide/migration_guide.md`**: UseCython "not currently supported" → points at `cython-cmake`.
- **`man.md`**: added the `init` subcommand.
- **`README.md`**: dynamic-metadata line cites the shipped `[[tool.dynamic-metadata]]` standard.

## Pre-1.0 language
- Removed the "under active development / bleeding edge" warning (`migration_guide.md`) and "not guaranteed to be stable between releases yet" (`reference/cli.md`).
- **`README.md`**: "missing features that will be developed soon" → "A few limitations remain" (wheel reproducibility is opt-in; editable caveats).
- **`plugins/setuptools.md`**: "is being developed" → "experimental"; softened "eventually" phrasing.

## Links / accuracy / typos
- **`guide/getting_started.md`**: fixed the `Scientific Python Developer Guide` link (was pointing at sample-projects) → `learn.scientific-python.org`.
- **`configuration/index.md`**: bumped `minimum-version` examples to `0.12`; "minimum version" → "minimum supported CMake version"; fixed the garbled `"classic"` parenthetical; added a 1.0 entry to the `minimum-version` behavior list; linked PEP 803.
- **`configuration/formatted.md`**: added `editable.rebuild-dir`; "f-strings" → "`str.format` templates".
- Assorted typos (`overrides.md`, `dynamic.md`, `dynamic_link.md`, `build.md`, `search_paths.md`); conda example → `>=0.12`.

## Deliberately left
- Kept `versionadded/versionchanged 0.x` markers, the editable rebuild-on-import "experimental" labeling, and the Python 3.8 floor.
- `about/projects.md`: kept the still-valid "over 600" lower bound, removed only the stale "(as of May 2025)" — the count + cog list should be refreshed at release.
- Cog/schema-generated blocks (README config table, `configs.md`, `schema.md`) regenerate via `nox -t gen` at release.

Docs build cleanly (`nox -s docs`, no warnings); `prettier`/`typos` pass.