### PR TITLE
feat(editable): expose rebuild() on redirected module loaders

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -828,11 +828,10 @@ location, so changes there are picked up on import, regardless of the
 
 ### Triggering a rebuild manually
 
-You don't have to enable `editable.rebuild` to rebuild on demand. The
-redirecting finder installs a loader for each redirected module, and that loader
-exposes a `rebuild()` method, so you can run the same
-`cmake --build`/`--install` cycle whenever you like using only the standard
-library:
+You don't have to enable `editable.rebuild` to rebuild on demand for the
+redirect mode. The redirecting finder installs a loader for each redirected
+module, and that loader exposes a `rebuild()` method, so you can run the same
+`cmake --build`/`--install` cycle whenever you like:
 
 ```python
 import some_package
@@ -849,9 +848,7 @@ $ pip install --no-build-isolation -Cbuild-dir=build -ve .
 ```
 
 If the editable install was built without a persistent `build-dir`, there is
-nothing to rebuild and the call raises `RuntimeError`. This only comes up for
-manual calls: enabling `editable.rebuild` already requires a `build-dir`, so the
-automatic rebuild-on-import path always has one.
+nothing to rebuild and the call raises `RuntimeError`.
 
 If you don't have a handle on a redirected module, the finder itself is on
 `sys.meta_path` and carries the same method:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -826,6 +826,44 @@ added via scikit-build-core's package discovery will be found in the original
 location, so changes there are picked up on import, regardless of the
 `editable.rebuild` setting.
 
+### Triggering a rebuild manually
+
+You don't have to enable `editable.rebuild` to rebuild on demand. The
+redirecting finder installs a loader for each redirected module, and that loader
+exposes a `rebuild()` method, so you can run the same
+`cmake --build`/`--install` cycle whenever you like using only the standard
+library:
+
+```python
+import some_package
+
+some_package.__loader__.rebuild()
+```
+
+This works for any importable object the editable install provides -- a package,
+a plain module, or a compiled extension. A rebuild needs a persistent build
+directory to run in, so install with a `build-dir` set:
+
+```console
+$ pip install --no-build-isolation -Cbuild-dir=build -ve .
+```
+
+If the editable install was built without a persistent `build-dir`, there is
+nothing to rebuild and the call raises `RuntimeError`. (The automatic
+rebuild-on-import path, by contrast, silently does nothing in that case.)
+
+If you don't have a handle on a redirected module, the finder itself is on
+`sys.meta_path` and carries the same method:
+
+```python
+import sys
+
+finder = next(
+    f for f in sys.meta_path if type(f).__name__ == "ScikitBuildRedirectingFinder"
+)
+finder.rebuild()
+```
+
 The redirecting finder is installed at interpreter startup. On Python 3.15+,
 this uses a [PEP 829][] `.start` file (the slightly safer, structured
 replacement for the deprecated `import` line in a `.pth` file); on older Pythons

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -826,42 +826,6 @@ added via scikit-build-core's package discovery will be found in the original
 location, so changes there are picked up on import, regardless of the
 `editable.rebuild` setting.
 
-### Triggering a rebuild manually
-
-You don't have to enable `editable.rebuild` to rebuild on demand for the
-redirect mode. The redirecting finder installs a loader for each redirected
-module, and that loader exposes a `rebuild()` method, so you can run the same
-`cmake --build`/`--install` cycle whenever you like:
-
-```python
-import some_package
-
-some_package.__loader__.rebuild()
-```
-
-This works for any importable object the editable install provides -- a package,
-a plain module, or a compiled extension. A rebuild needs a persistent build
-directory to run in, so install with a `build-dir` set:
-
-```console
-$ pip install --no-build-isolation -Cbuild-dir=build -ve .
-```
-
-If the editable install was built without a persistent `build-dir`, there is
-nothing to rebuild and the call raises `RuntimeError`.
-
-If you don't have a handle on a redirected module, the finder itself is on
-`sys.meta_path` and carries the same method:
-
-```python
-import sys
-
-finder = next(
-    f for f in sys.meta_path if type(f).__name__ == "ScikitBuildRedirectingFinder"
-)
-finder.rebuild()
-```
-
 The redirecting finder is installed at interpreter startup. On Python 3.15+,
 this uses a [PEP 829][] `.start` file (the slightly safer, structured
 replacement for the deprecated `import` line in a `.pth` file); on older Pythons
@@ -897,6 +861,42 @@ CMake build.
 On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
 
 :::
+
+### Triggering a rebuild manually
+
+You don't have to enable `editable.rebuild` to rebuild on demand for the
+redirect mode. The redirecting finder installs a loader for each redirected
+module, and that loader exposes a `rebuild()` method, so you can run the same
+`cmake --build`/`--install` cycle whenever you like:
+
+```python
+import some_package
+
+some_package.__loader__.rebuild()
+```
+
+This works for any importable object the editable install provides -- a package,
+a plain module, or a compiled extension. A rebuild needs a persistent build
+directory to run in, so install with a `build-dir` set:
+
+```console
+$ pip install --no-build-isolation -Cbuild-dir=build -ve .
+```
+
+If the editable install was built without a persistent `build-dir`, there is
+nothing to rebuild and the call raises `RuntimeError`.
+
+If you don't have a handle on a redirected module, the finder itself is on
+`sys.meta_path` and carries the same method:
+
+```python
+import sys
+
+finder = next(
+    f for f in sys.meta_path if type(f).__name__ == "ScikitBuildRedirectingFinder"
+)
+finder.rebuild()
+```
 
 ## Messages
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -849,8 +849,9 @@ $ pip install --no-build-isolation -Cbuild-dir=build -ve .
 ```
 
 If the editable install was built without a persistent `build-dir`, there is
-nothing to rebuild and the call raises `RuntimeError`. (The automatic
-rebuild-on-import path, by contrast, silently does nothing in that case.)
+nothing to rebuild and the call raises `RuntimeError`. This only comes up for
+manual calls: enabling `editable.rebuild` already requires a `build-dir`, so the
+automatic rebuild-on-import path always has one.
 
 If you don't have a handle on a redirected module, the finder itself is on
 `sys.meta_path` and carries the same method:

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -199,21 +199,46 @@ class _ScikitBuildEditableReader:
         return (item.name for item in self.files().iterdir())  # type: ignore[attr-defined]
 
 
-class _ScikitBuildResourceLoaderWrapper:
+class _ScikitBuildLoaderWrapper:
     """
-    Thin wrapper around a module loader that provides multi-path resource reading.
+    Thin wrapper around a module loader that adds an on-demand ``rebuild()`` hook.
 
-    Delegates all loader functionality to the wrapped loader, overriding only
+    Delegates all loader functionality to the wrapped loader, adding only a
+    ``rebuild()`` method that runs the same CMake build/install the import-time
+    auto-rebuild uses. This lets a user trigger a rebuild explicitly via
+    ``module.__loader__.rebuild()`` without enabling ``editable.rebuild``.
+    """
+
+    def __init__(self, loader: object, finder: ScikitBuildRedirectingFinder) -> None:
+        self._skbuild_loader = loader
+        self._skbuild_finder = finder
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._skbuild_loader, name)
+
+    def rebuild(self) -> None:
+        # User-initiated, so a missing build directory is an error rather than
+        # the silent no-op the import-time auto-rebuild uses.
+        self._skbuild_finder.rebuild(required=True)
+
+
+class _ScikitBuildResourceLoaderWrapper(_ScikitBuildLoaderWrapper):
+    """
+    Loader wrapper that also provides multi-path resource reading.
+
+    Extends the rebuild hook of the base wrapper, additionally overriding
     get_resource_reader() to return a reader covering all search paths (both
     source and CMake install trees).
     """
 
-    def __init__(self, loader: object, search_paths: list[str]) -> None:
-        self._skbuild_loader = loader
+    def __init__(
+        self,
+        loader: object,
+        finder: ScikitBuildRedirectingFinder,
+        search_paths: list[str],
+    ) -> None:
+        super().__init__(loader, finder)
         self._skbuild_paths = search_paths
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._skbuild_loader, name)
 
     def get_resource_reader(self, module_name: str) -> _ScikitBuildEditableReader:
         return _ScikitBuildEditableReader(self._skbuild_paths)
@@ -232,8 +257,11 @@ class _ScikitBuildNamespaceLoader:
     _NamespacePath, which cannot be constructed from remapped directories.
     """
 
-    def __init__(self, search_paths: list[str]) -> None:
+    def __init__(
+        self, search_paths: list[str], finder: ScikitBuildRedirectingFinder
+    ) -> None:
         self._skbuild_paths = search_paths
+        self._skbuild_finder = finder
 
     def create_module(self, spec: object) -> object:
         return None
@@ -243,6 +271,11 @@ class _ScikitBuildNamespaceLoader:
 
     def get_resource_reader(self, module_name: str) -> _ScikitBuildEditableReader:
         return _ScikitBuildEditableReader(self._skbuild_paths)
+
+    def rebuild(self) -> None:
+        # User-initiated, so a missing build directory is an error rather than
+        # the silent no-op the import-time auto-rebuild uses.
+        self._skbuild_finder.rebuild(required=True)
 
 
 def _patch_importlib_resources_for_python39() -> None:
@@ -370,7 +403,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         # A tracked package directory without an importable __init__ is a
         # namespace package.
         if submodule_search_locations is not None:
-            loader = _ScikitBuildNamespaceLoader(submodule_search_locations)
+            loader = _ScikitBuildNamespaceLoader(submodule_search_locations, self)
             spec = importlib.util.spec_from_loader(
                 fullname,
                 loader,  # type: ignore[arg-type]
@@ -393,18 +426,37 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
             origin,
             submodule_search_locations=submodule_search_locations if is_pkg else None,
         )
-        # For packages with multiple search locations (e.g. a source tree and a
-        # CMake install tree), wrap the loader so importlib.resources.files()
-        # can see resources from every location, not just origin's directory.
-        if spec is not None and is_pkg and submodule_search_locations:
-            spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
-                spec.loader, submodule_search_locations
-            )
+        # Wrap the loader so it exposes a rebuild() hook (reachable as
+        # module.__loader__.rebuild()). Packages with more than one search
+        # location (e.g. a source tree and a CMake install tree) additionally get
+        # a resource reader so importlib.resources.files() can see resources from
+        # every location, not just origin's directory.
+        if spec is not None and spec.loader is not None:
+            if (
+                is_pkg
+                and submodule_search_locations
+                and len(submodule_search_locations) > 1
+            ):
+                spec.loader = _ScikitBuildResourceLoaderWrapper(  # type: ignore[assignment]
+                    spec.loader, self, submodule_search_locations
+                )
+            else:
+                spec.loader = _ScikitBuildLoaderWrapper(spec.loader, self)  # type: ignore[assignment]
         return spec
 
-    def rebuild(self) -> None:
-        # Don't rebuild if not set to a local path
+    def rebuild(self, *, required: bool = False) -> None:
+        # Without a persistent build directory there is nothing to rebuild. The
+        # import-time auto-rebuild treats this as a silent no-op; an explicit
+        # caller (module.__loader__.rebuild()) sets required=True to get an error
+        # instead.
         if not self.path:
+            if required:
+                msg = (
+                    "Cannot rebuild: this editable install has no persistent "
+                    "build directory. Reinstall with a 'build-dir' set (e.g. "
+                    "-Cbuild-dir=build) to enable on-demand rebuilds."
+                )
+                raise RuntimeError(msg)
             return
 
         env = os.environ.copy()

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -217,9 +217,7 @@ class _ScikitBuildLoaderWrapper:
         return getattr(self._skbuild_loader, name)
 
     def rebuild(self) -> None:
-        # User-initiated, so a missing build directory is an error rather than
-        # the silent no-op the import-time auto-rebuild uses.
-        self._skbuild_finder.rebuild(required=True)
+        self._skbuild_finder.rebuild()
 
 
 class _ScikitBuildResourceLoaderWrapper(_ScikitBuildLoaderWrapper):
@@ -273,9 +271,7 @@ class _ScikitBuildNamespaceLoader:
         return _ScikitBuildEditableReader(self._skbuild_paths)
 
     def rebuild(self) -> None:
-        # User-initiated, so a missing build directory is an error rather than
-        # the silent no-op the import-time auto-rebuild uses.
-        self._skbuild_finder.rebuild(required=True)
+        self._skbuild_finder.rebuild()
 
 
 def _patch_importlib_resources_for_python39() -> None:
@@ -444,21 +440,18 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
                 spec.loader = _ScikitBuildLoaderWrapper(spec.loader, self)  # type: ignore[assignment]
         return spec
 
-    def rebuild(self, *, required: bool = False) -> None:
+    def rebuild(self) -> None:
         # Without a persistent build directory there is nothing to rebuild.
         # Enabling auto-rebuild already requires a build-dir, so the import-time
-        # path never reaches this with path unset; the lenient no-op is just
-        # defensive (don't crash imports). An explicit caller
-        # (module.__loader__.rebuild()) sets required=True to get an error.
+        # path never reaches this with path unset; only a manual
+        # module.__loader__.rebuild() on a non-rebuildable editable can.
         if not self.path:
-            if required:
-                msg = (
-                    "Cannot rebuild: this editable install has no persistent "
-                    "build directory. Reinstall with a 'build-dir' set (e.g. "
-                    "-Cbuild-dir=build) to enable on-demand rebuilds."
-                )
-                raise RuntimeError(msg)
-            return
+            msg = (
+                "Cannot rebuild: this editable install has no persistent build "
+                "directory. Reinstall with a 'build-dir' set (e.g. "
+                "-Cbuild-dir=build) to enable on-demand rebuilds."
+            )
+            raise RuntimeError(msg)
 
         env = os.environ.copy()
         # Protect against recursion

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -445,10 +445,11 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         return spec
 
     def rebuild(self, *, required: bool = False) -> None:
-        # Without a persistent build directory there is nothing to rebuild. The
-        # import-time auto-rebuild treats this as a silent no-op; an explicit
-        # caller (module.__loader__.rebuild()) sets required=True to get an error
-        # instead.
+        # Without a persistent build directory there is nothing to rebuild.
+        # Enabling auto-rebuild already requires a build-dir, so the import-time
+        # path never reaches this with path unset; the lenient no-op is just
+        # defensive (don't crash imports). An explicit caller
+        # (module.__loader__.rebuild()) sets required=True to get an error.
         if not self.path:
             if required:
                 msg = (

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -226,7 +226,7 @@ def test_rebuild_runs_once_per_process(tmp_path: Path):
 
     calls = 0
 
-    def fake_rebuild(*, required: bool = False) -> None:  # noqa: ARG001
+    def fake_rebuild() -> None:
         nonlocal calls
         calls += 1
 
@@ -278,9 +278,8 @@ def test_loader_exposes_rebuild(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
     calls = 0
 
-    def fake_rebuild(*, required: bool = False) -> None:
+    def fake_rebuild() -> None:
         nonlocal calls
-        assert required  # loader hooks must request the strict (error-on-fail) mode
         calls += 1
 
     monkeypatch.setattr(finder, "rebuild", fake_rebuild)
@@ -308,11 +307,12 @@ def test_loader_exposes_rebuild(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
 
 def test_loader_rebuild_without_build_dir_errors(tmp_path: Path):
-    """module.__loader__.rebuild() errors when there is no build dir to rebuild.
+    """rebuild() errors when there is no build dir to rebuild.
 
-    The import-time auto-rebuild silently no-ops without a persistent build-dir
-    (path=None); an explicit user call must instead raise so the missing
-    configuration is visible.
+    A non-rebuildable editable (no persistent build-dir, path=None) still
+    installs the finder and exposes the loader hook, so a rebuild request must
+    raise to make the missing configuration visible. Enabling auto-rebuild
+    already requires a build-dir, so the import-time path never hits this.
     """
     init = tmp_path / "pkg" / "__init__.py"
     init.parent.mkdir()
@@ -332,8 +332,8 @@ def test_loader_rebuild_without_build_dir_errors(tmp_path: Path):
         install_dir="",
     )
 
-    # Import-time path stays a silent no-op.
-    finder.rebuild()
+    with pytest.raises(RuntimeError, match="no persistent build directory"):
+        finder.rebuild()
 
     spec = finder.find_spec("pkg")
     assert spec is not None

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -226,7 +226,7 @@ def test_rebuild_runs_once_per_process(tmp_path: Path):
 
     calls = 0
 
-    def fake_rebuild() -> None:
+    def fake_rebuild(*, required: bool = False) -> None:  # noqa: ARG001
         nonlocal calls
         calls += 1
 
@@ -237,6 +237,109 @@ def test_rebuild_runs_once_per_process(tmp_path: Path):
     finder.find_spec("pkg._mod_b")
 
     assert calls == 1
+
+
+def test_loader_exposes_rebuild(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A redirected module's loader exposes rebuild() (module.__loader__.rebuild()).
+
+    Covers the three loader kinds the finder produces: a single-location package
+    (simple wrapper), a compiled module resolved via known_wheel_files (simple
+    wrapper, not a package), and a namespace package. Each must delegate to the
+    finder's rebuild while still delegating other loader attributes.
+    """
+    import importlib.machinery
+
+    pkg_dir = tmp_path / "src" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    init = pkg_dir / "__init__.py"
+    init.touch()
+
+    ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+    so = tmp_path / "build" / "pkg" / f"_ext{ext}"
+    so.parent.mkdir(parents=True)
+    so.touch()
+
+    ns_dir = tmp_path / "src" / "ns"
+    ns_dir.mkdir()
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"pkg": str(init)},
+        known_wheel_files={"pkg._ext": str(so)},
+        known_directories={"pkg": [str(pkg_dir)], "ns": [str(ns_dir)]},
+        known_packages=["pkg"],
+        path=str(tmp_path / "build"),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path / "site-packages"),
+        install_dir="",
+    )
+
+    calls = 0
+
+    def fake_rebuild(*, required: bool = False) -> None:
+        nonlocal calls
+        assert required  # loader hooks must request the strict (error-on-fail) mode
+        calls += 1
+
+    monkeypatch.setattr(finder, "rebuild", fake_rebuild)
+
+    # Single-location package: simple wrapper, get_filename still delegates.
+    pkg_spec = finder.find_spec("pkg")
+    assert pkg_spec is not None
+    assert pkg_spec.loader is not None
+    pkg_spec.loader.rebuild()  # type: ignore[attr-defined]
+    assert pkg_spec.loader.get_filename("pkg") == str(init)  # type: ignore[attr-defined]
+
+    # Compiled (non-package) module resolved via known_wheel_files.
+    ext_spec = finder.find_spec("pkg._ext")
+    assert ext_spec is not None
+    assert ext_spec.loader is not None
+    ext_spec.loader.rebuild()  # type: ignore[attr-defined]
+
+    # Namespace package.
+    ns_spec = finder.find_spec("ns")
+    assert ns_spec is not None
+    assert ns_spec.loader is not None
+    ns_spec.loader.rebuild()  # type: ignore[attr-defined]
+
+    assert calls == 3
+
+
+def test_loader_rebuild_without_build_dir_errors(tmp_path: Path):
+    """module.__loader__.rebuild() errors when there is no build dir to rebuild.
+
+    The import-time auto-rebuild silently no-ops without a persistent build-dir
+    (path=None); an explicit user call must instead raise so the missing
+    configuration is visible.
+    """
+    init = tmp_path / "pkg" / "__init__.py"
+    init.parent.mkdir()
+    init.touch()
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"pkg": str(init)},
+        known_wheel_files={},
+        known_directories={"pkg": [str(init.parent)]},
+        known_packages=["pkg"],
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path),
+        install_dir="",
+    )
+
+    # Import-time path stays a silent no-op.
+    finder.rebuild()
+
+    spec = finder.find_spec("pkg")
+    assert spec is not None
+    assert spec.loader is not None
+    with pytest.raises(RuntimeError, match="no persistent build directory"):
+        spec.loader.rebuild()  # type: ignore[attr-defined]
 
 
 def test_mapping_to_modules_prefers_py():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Lets a user trigger an editable rebuild on demand using only the standard library, by calling `rebuild()` on the loader of any redirected import:

```python
import some_package

some_package.__loader__.rebuild()
```

This runs the same `cmake --build`/`--install` cycle that the optional import-time auto-rebuild uses, but under user control — without needing to enable `editable.rebuild`.

## How

The redirecting finder (`resources/_editable_redirect.py`) now wraps **every** spec it returns in a loader exposing a `rebuild()` hook:

- New `_ScikitBuildLoaderWrapper` — a thin delegating wrapper that adds only `rebuild()`. Used for single-location packages, plain modules, and compiled extension modules (the previously-bare cases).
- `_ScikitBuildResourceLoaderWrapper` now extends it, so multi-location packages keep their cross-tree resource reader **and** gain `rebuild()`.
- `_ScikitBuildNamespaceLoader` gains `rebuild()` too.

`find_spec` only needs the heavier resource wrapper when a package has more than one search location; everything else gets the simple wrapper.

### Errors when it can't rebuild

`finder.rebuild()` gained a `required` flag:

- The import-time auto-rebuild calls it leniently → still a silent no-op when there's no persistent build directory.
- The user-facing loader hooks call `rebuild(required=True)` → raises `RuntimeError` pointing at `-Cbuild-dir=build` when no build dir is configured.

cmake build/install failures continue to raise `CalledProcessError` as before.

## Notes

- A rebuild needs a persistent build directory, so install with `-Cbuild-dir=build`.
- Single-location packages were already wrapped (a 1-element search-location list is truthy); switching them to the lean wrapper is behavior-preserving for resources, since their single search location always equals the origin's directory.

## Docs

Added a "Triggering a rebuild manually" subsection under Editable installs in `docs/configuration/index.md`, including the `sys.meta_path` fallback for grabbing the finder directly.

## Tests

- `test_loader_exposes_rebuild` — covers all three loader kinds (single-location package, compiled module, namespace package) and confirms non-rebuild attributes still delegate.
- `test_loader_rebuild_without_build_dir_errors` — the loader call raises while the import-time path stays a silent no-op.

`prek` (ruff/mypy) clean; editable test suites pass.