### PR TITLE
fix(macos): warn when CMake will build a mismatched x86_64 extension

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 import os
+import platform
 import re
 import shlex
 import sys
@@ -14,6 +15,7 @@ from .. import __version__
 from .._compat.importlib import metadata, resources
 from .._logging import logger
 from .._reproducible import get_reproducible_epoch
+from ..program_search import _macos_binary_is_x86
 from ..resources import find_python
 from .generator import set_environment_for_gen
 from .sysconfig import (
@@ -83,6 +85,32 @@ def archs_to_tags(archs: list[str]) -> list[str]:
     if sys.platform.startswith("darwin") and set(archs) == {"arm64", "x86_64"}:
         return ["universal2"]
     return archs
+
+
+def _warn_macos_arch_mismatch(cmake_path: Path, *, explicit_arch: bool) -> None:
+    """
+    Warn when CMake is about to build an x86_64 extension that the running
+    arm64 (Apple Silicon) interpreter cannot import (#1167).
+
+    CMake only gained Apple Silicon host detection in 3.19.2, the first release
+    shipped as a universal binary. An older, x86_64-only CMake runs under
+    Rosetta, sees the host as x86_64, and builds x86_64 extensions; importing
+    one under an arm64 interpreter then fails with an "incompatible
+    architecture" error. Skipped if the architecture was pinned explicitly
+    (ARCHFLAGS / CMAKE_OSX_ARCHITECTURES), which is a deliberate cross-compile.
+    """
+    if (
+        not explicit_arch
+        and platform.machine() == "arm64"
+        and _macos_binary_is_x86(cmake_path)
+    ):
+        logger.warning(
+            "CMake ({}) is an x86_64-only binary and will build x86_64 "
+            "extensions, but this is an arm64 (Apple Silicon) interpreter, so "
+            "the result will fail to import. Use CMake >= 3.19.2, or set "
+            "ARCHFLAGS / CMAKE_OSX_ARCHITECTURES to cross-compile on purpose.",
+            cmake_path,
+        )
 
 
 def _filter_env_cmake_args(env_cmake_args: list[str]) -> Generator[str, None, None]:
@@ -395,6 +423,17 @@ class Builder:
             archs = get_archs(self.config.env, self.get_cmake_args())
             if archs:
                 cmake_defines["CMAKE_OSX_ARCHITECTURES"] = ";".join(archs)
+            else:
+                explicit_arch = (
+                    "CMAKE_OSX_ARCHITECTURES" in self.settings.cmake.define
+                    or any(
+                        "CMAKE_OSX_ARCHITECTURES" in arg
+                        for arg in self.get_cmake_args()
+                    )
+                )
+                _warn_macos_arch_mismatch(
+                    self.config.cmake.cmake_path, explicit_arch=explicit_arch
+                )
 
         # Add the pre-defined or passed CMake defines
         cmake_defines.update(self.settings.cmake.define)

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -39,6 +39,7 @@ def __dir__() -> list[str]:
 BASE_TIMEOUT = 5
 
 
+@functools.lru_cache(None)
 def _macos_binary_is_x86(path: Path) -> bool:
     """
     Returns True if the binary is x86. Only run on macOS.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -16,6 +16,7 @@ from packaging.version import Version
 from scikit_build_core.builder.builder import (
     Builder,
     _sanitize_path,
+    _warn_macos_arch_mismatch,
     archs_to_tags,
     get_archs,
 )
@@ -279,6 +280,32 @@ def test_builder_macos_arch_cmake_system_processor(monkeypatch):
     assert get_archs(env, cmake_args) == ["arm64"]
     # Without the cmake arg, ARCHFLAGS wins.
     assert get_archs(env) == ["x86_64"]
+
+
+@pytest.mark.parametrize(
+    ("machine", "cmake_is_x86", "explicit_arch", "warns"),
+    [
+        ("arm64", True, False, True),  # #1167: x86_64 CMake on Apple Silicon
+        ("arm64", True, True, False),  # arch pinned -> deliberate cross-compile
+        ("arm64", False, False, False),  # universal/arm64 CMake builds arm64
+        ("x86_64", True, False, False),  # Rosetta interpreter wants x86_64 too
+    ],
+)
+def test_warn_macos_arch_mismatch(
+    monkeypatch, caplog, machine, cmake_is_x86, explicit_arch, warns
+):
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    monkeypatch.setattr(
+        "scikit_build_core.builder.builder._macos_binary_is_x86",
+        lambda _path: cmake_is_x86,
+    )
+    caplog.set_level("WARNING")
+    _warn_macos_arch_mismatch(Path("/usr/bin/cmake"), explicit_arch=explicit_arch)
+    messages = [str(r.msg) for r in caplog.records]
+    if warns:
+        assert any("fail to import" in m for m in messages)
+    else:
+        assert not messages
 
 
 def test_builder_macos_arch_extra(monkeypatch):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes part of #1167.

## Background

On the arm64 `macos-latest` runner, the `min` CI job (CMake 3.15) builds an x86_64 extension that the arm64 interpreter can't import:

```
ImportError: dlopen(...cmake_example.cpython-38-darwin.so):
  (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
```

CMake gained Apple Silicon host detection only in **3.19.2**, the first release shipped as a universal binary. An older, x86_64-only CMake runs under Rosetta, detects the host as `x86_64`, and builds x86_64 extensions. scikit-build-core defers the architecture to CMake when `ARCHFLAGS` is unset, so the only symptom is a cryptic `dlopen` failure at import time.

The CI side is already worked around (the `min` job runs on `macos-15-intel`). This PR helps **end users** who hit the same combination — an old CMake on Apple Silicon — outside CI.

## Change

`Builder.configure()` now warns, on macOS, when:
- the architecture was **not** pinned (`ARCHFLAGS` / `CMAKE_OSX_ARCHITECTURES`),
- the interpreter is arm64 (`platform.machine() == "arm64"`), and
- the resolved CMake binary is x86_64-only (reusing the existing `_macos_binary_is_x86` Rosetta detector).

It's a warning, not an error, so deliberate cross-compiles are never blocked. The message points at CMake ≥ 3.19.2.

## Tests

Parametrized `test_warn_macos_arch_mismatch` covers all four cases: arm64 + x86_64 CMake warns; pinned arch, native/universal CMake, and an x86_64 interpreter all stay silent.
