### PR TITLE
docs: add missing versionadded/versionchanged directives for 1.0

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -58,6 +58,13 @@ combined** in one project; use one or the other.
 
 :::
 
+:::{versionchanged} 1.0
+
+The legacy `tool.scikit-build.metadata` table now emits a deprecation warning
+unless `minimum-version` is set below `1.0`.
+
+:::
+
 ## Built-in plugins
 
 We provide some built-in plugins in `scikit_build_core.metadata`. These work in
@@ -303,6 +310,11 @@ static in `[project]`).
 ```
 
 ## Custom plugins
+
+```{versionadded} 1.0
+Writing a custom dynamic-metadata plugin through the standard
+[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.3 interface.
+```
 
 You can write your own plugins. Full details are in the
 [dynamic metadata docs](https://dynamic-metadata.readthedocs.io/en/latest/plugin_authors.html).

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -52,8 +52,7 @@ both static and dynamic.
 
 The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
 rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]`. It
-is deprecated and emits a warning unless `minimum-version` is set below `1.0`.
-It still works and is shown in the examples below, but the two forms **cannot be
+still works and is shown in the examples below, but the two forms **cannot be
 combined** in one project; use one or the other.
 
 :::

--- a/docs/configuration/formatted.md
+++ b/docs/configuration/formatted.md
@@ -6,6 +6,10 @@ The following configure keys are formatted as Python `str.format` templates:
 - `build.requires`
 - `editable.rebuild-dir`
 
+```{versionadded} 1.0
+`editable.rebuild-dir` is formattable.
+```
+
 The available variables are documented in the members of
 {py:class}`scikit_build_core.format.PyprojectFormatter` copied here for
 visibility

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -332,6 +332,12 @@ The available trees are `${SKBUILD_PLATLIB_DIR}` (the default),
 `${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_METADATA_DIR}`, and `${SKBUILD_NULL_DIR}`.
 This matches the cache variables available from within CMake.
 
+:::{versionadded} 1.0
+
+Targeting other wheel trees with the `${SKBUILD_<TREE>_DIR}` prefix.
+
+:::
+
 :::{warning}
 
 When passing this through PEP 517 `config-settings` on a command line, quote it
@@ -379,6 +385,10 @@ assume `wheel.platlib = false` (purelib targeted instead).
 :::
 
 ### Force-including files
+
+:::{versionadded} 1.0
+
+:::
 
 Sometimes you need to place a specific file (or directory) at a specific path in
 a distribution, even if it lives outside your package tree or is produced
@@ -480,6 +490,13 @@ this emits a combined `cp315-abi3.abi3t-*` tag: `abi3t` is a subset of `abi3`
 CPython 3.15+, and the one wheel is installable on every CPython 3.15+. On a GIL
 build only `abi3` can be produced, so it falls back to `cp315-abi3-*`.
 
+:::{versionadded} 1.0
+
+The free-threaded stable ABI (`cp315t`, [PEP 803][]) and the combined
+`cp315.cp315t` tag.
+
+:::
+
 If you are not using CPython at all, you can specify any version of Python is
 fine:
 
@@ -534,6 +551,10 @@ recent compiler and flags like `-ffile-prefix-map`.
 
 ```
 
+:::{versionadded} 1.0
+
+:::
+
 ## Configuring CMake arguments and defines
 
 You can select a different build type, such as `Debug`:
@@ -547,6 +568,13 @@ the environment, that value is used instead. This lets you override the build
 type without editing `pyproject.toml` (for example
 `CMAKE_BUILD_TYPE=RelWithDebInfo`), mirroring CMake's own handling of the
 variable.
+
+:::{versionadded} 1.0
+
+Honoring `CMAKE_BUILD_TYPE` from the environment when `cmake.build-type` is left
+at its default.
+
+:::
 
 You can also pass a _list_ of build types to build and install more than one
 configuration into the same wheel:
@@ -562,6 +590,12 @@ same prefix, so set `CMAKE_<CONFIG>_POSTFIX` (such as `CMAKE_DEBUG_POSTFIX=_d`)
 on your targets to keep the configurations from clobbering each other, and
 select the right module at runtime in your package's `__init__.py`. This is
 currently only supported by the default (native) and Hatchling backends.
+
+:::{versionadded} 1.0
+
+Passing a list of build types.
+
+:::
 
 You can specify CMake defines as strings or bools:
 
@@ -694,6 +728,10 @@ You can pass raw arguments directly to the build tool, as well:
 
 ## Environment variables for the build
 
+:::{versionadded} 1.0
+
+:::
+
 The `[tool.scikit-build.env]` table sets environment variables for the CMake
 configure, build, and install subprocesses. Use it for things CMake or the
 generator read _from the environment_ — `CC`/`CXX`, `CFLAGS`,
@@ -820,6 +858,12 @@ referenced by absolute path on rebuild. This only moves the install tree;
 re-runs. The classic `editable.rebuild` (which installs into a tree inside
 `build-dir`) is left as-is, so the two approaches can be compared.
 
+:::{versionadded} 1.0
+
+`editable.rebuild-dir`, a persistent install tree for editable rebuilds.
+
+:::
+
 The default `editable.mode`, `"redirect"`, uses a custom redirecting finder to
 combine the static CMake install dir with the original source code. Python code
 added via scikit-build-core's package discovery will be found in the original
@@ -831,6 +875,12 @@ this uses a [PEP 829][] `.start` file (the slightly safer, structured
 replacement for the deprecated `import` line in a `.pth` file); on older Pythons
 it uses the classic `.pth` `import` line. This is handled automatically based on
 the interpreter running the editable install.
+
+:::{versionadded} 1.0
+
+[PEP 829][] `.start` file support for the redirecting finder on Python 3.15+.
+
+:::
 
 [PEP 829]: https://peps.python.org/pep-0829/
 [PEP 817]: https://peps.python.org/pep-0817/
@@ -927,7 +977,7 @@ experimental = true
 The following features currently require this flag:
 
 - **Wheel variants**: [PEP 817][] variant support (`variant`, `variant-name`,
-  `variant-label`, and `null-variant`). See
+  `variant-label`, and `null-variant`), added in 1.0. See
   [](../guide/faqs.md#building-wheel-variants-experimental).
 - **Legacy `tool.scikit-build.metadata` plugins**: dynamic metadata providers
   not shipped with scikit-build-core (anything using `provider-path` or a

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -569,9 +569,9 @@ type without editing `pyproject.toml` (for example
 `CMAKE_BUILD_TYPE=RelWithDebInfo`), mirroring CMake's own handling of the
 variable.
 
-:::{versionadded} 1.0
+:::{versionchanged} 1.0
 
-Honoring `CMAKE_BUILD_TYPE` from the environment when `cmake.build-type` is left
+`CMAKE_BUILD_TYPE` is read from the environment when `cmake.build-type` is left
 at its default.
 
 :::
@@ -870,15 +870,10 @@ added via scikit-build-core's package discovery will be found in the original
 location, so changes there are picked up on import, regardless of the
 `editable.rebuild` setting.
 
-The redirecting finder is installed at interpreter startup. On Python 3.15+,
-this uses a [PEP 829][] `.start` file (the slightly safer, structured
-replacement for the deprecated `import` line in a `.pth` file); on older Pythons
-it uses the classic `.pth` `import` line. This is handled automatically based on
-the interpreter running the editable install.
+:::{versionchanged} 1.0
 
-:::{versionadded} 1.0
-
-[PEP 829][] `.start` file support for the redirecting finder on Python 3.15+.
+[PEP 829][] `.start` files are emitted for the redirecting finder on Python
+3.15+. Older interpreters emit only `.pth` files.
 
 :::
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -194,6 +194,10 @@ The three new items here (compared to SDists) are the [compatibility tags][]:
 - `platform tag`: This is the platform the wheel is valid on, such as `any`,
   `linux_x86_64`, or `manylinux_2_17_x86_64`.
 
+```{versionadded} 1.0
+The `abi3t` tag for free-threaded stable ABI wheels.
+```
+
 (repairing-wheels)=
 
 ## Repairing

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -22,6 +22,11 @@ Scikit-build-core provides several useful variables:
 - `${SKBUILD_STATE}`: The run state, one of `sdist`, `wheel`, `metadata_wheel`,
   `editable`, or `metadata_editable`.
 
+```{versionchanged} 1.0
+`${SKBUILD_PROJECT_VERSION}` is now capped to four release components
+(`major.minor.patch.tweak`) so it is always valid for `project(VERSION ...)`.
+```
+
 ## Finding Python
 
 You can directly use FindPython:

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -10,6 +10,10 @@ project (run without `--backend` to pick a binding interactively). See the
 [getting started guide](getting_started.md) for a walkthrough of what it
 generates.
 
+```{versionadded} 1.0
+The `scikit-build init` command.
+```
+
 For a fully-featured project layout, use the [Scientific Python cookie][], which
 makes a new project following the [Scientific Python Development Guidelines][].
 Scikit-build-core is one of the backends you can select. The project will have a
@@ -49,6 +53,10 @@ A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
 [](../configuration/index.md#environment-variables-for-the-build) for the full
 `env` table reference, including selecting a compiler and setting search paths.
 
+```{versionadded} 1.0
+The `[tool.scikit-build.env]` table.
+```
+
 ## Dynamic setup.py options
 
 Most common needs can be moved into your `CMakeLists.txt`. For example, if you
@@ -85,6 +93,11 @@ printout of the current settings using:
 
 ```bash
 scikit-build builder
+```
+
+```{versionchanged} 1.0
+This is now a subcommand of the unified `scikit-build` CLI (previously
+`python -m scikit_build_core.builder`).
 ```
 
 ## A dependency's library ends up in `site-packages/bin` or `lib`
@@ -154,6 +167,10 @@ Windows currently requires a little extra care. You should set the C define
 config files, Python cannot set it for you on the free-threaded variant.
 
 ## Building wheel variants (experimental)
+
+```{versionadded} 1.0
+
+```
 
 ```{warning}
 This is an early preview of [PEP 817][] wheel variant support. The interface may

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -32,6 +32,10 @@ There are several mechanisms to quickly get started with a package:
   `buildgen new myext -r py/pybind11` (see all with `buildgen list`, includes
   pybind11, nanobind, Cython, and C extensions).
 
+```{versionadded} 1.0
+The `scikit-build init` command.
+```
+
 For the rest of this page, however, we will show you how to get set up from
 scratch.
 
@@ -467,6 +471,10 @@ support PyPy).
 ````
 
 ````{tab} ABI3t
+
+```{versionadded} 1.0
+The free-threaded Stable ABI (`abi3t`) and the combined `cp315.cp315t` tag.
+```
 
 ```{literalinclude} ../examples/generated/abi3t/CMakeLists.txt
 :language: cmake

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -14,6 +14,14 @@ separate package in the future.
 
 :::
 
+:::{versionchanged} 1.0
+
+The plugin is no longer experimental (the `experimental = true` toggle is no
+longer required), and the `[hatchling]` extra is the recommended way to depend
+on it.
+
+:::
+
 ## Basic usage
 
 To use the plugin, make sure hatchling and scikit-build-core are in your

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -17,8 +17,8 @@ separate package in the future.
 :::{versionchanged} 1.0
 
 The plugin is no longer experimental (the `experimental = true` toggle is no
-longer required), and the `[hatchling]` extra is the recommended way to depend
-on it.
+longer required), editable installs are supported, and the `[hatchling]` extra
+is the recommended way to depend on it (warning shown if missing).
 
 :::
 

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -12,6 +12,12 @@ version of setuptools (recommended!).
 
 :::
 
+:::{versionadded} 1.0
+
+The `[setuptools]` extra.
+
+:::
+
 ## Basic usage
 
 To use the plugin, make sure you have both setuptools and scikit-build-core in
@@ -59,6 +65,11 @@ These are the currently supported `setup.py` options:
   running `cmake --build --target <value>` (equivalent to setting
   `install.targets`), for projects with an umbrella install target.
 
+```{versionadded} 1.0
+Support for the `cmake_install_dir`, `cmake_process_manifest_hook`, and
+`cmake_install_target` options.
+```
+
 These options from scikit-build (classic) are not currently supported:
 `cmake_with_sdist`. `cmake_languages` has no effect. And
 `cmake_minimum_required_version` is now specified via `pyproject.toml` config,
@@ -89,7 +100,16 @@ have no effect in the general setuptools plugin or the main build backend):
 Both are split following shell quoting rules, so quoted values with spaces are
 preserved.
 
+```{versionadded} 1.0
+The `SKBUILD_CONFIGURE_OPTIONS` and `SKBUILD_BUILD_OPTIONS` environment
+variables (honored by the `wrapper.setup` shim).
+```
+
 ## Editable installs
+
+```{versionadded} 1.0
+
+```
 
 PEP 660 editable installs (`pip install -e .`) are supported when the active
 setuptools version provides `build_editable` (setuptools 63+).

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -85,6 +85,8 @@ print(mk_skbuild_docs())
   another environment variable), ``default``, and ``force``; an entry that
   resolves to nothing is skipped. Independent of the ``if.env`` override
   condition.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -138,6 +140,8 @@ print(mk_skbuild_docs())
   Experimental PEP 817 null-variant selector.
 
   This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -165,6 +169,8 @@ print(mk_skbuild_docs())
   Experimental PEP 817 variant properties.
 
   This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -177,6 +183,8 @@ print(mk_skbuild_docs())
   Experimental PEP 817 wheel variant label override.
 
   This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -189,6 +197,8 @@ print(mk_skbuild_docs())
   Experimental PEP 817 variant properties used for wheel metadata selection.
 
   This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+  .. versionadded:: 1.0
 ```
 
 ## backport
@@ -295,6 +305,9 @@ print(mk_skbuild_docs())
   Ninja Multi-Config) build each ``--config``. Every build type is installed
   to the same prefix, so use ``CMAKE_<CONFIG>_POSTFIX`` to avoid clobbering
   files between configurations.
+
+  .. versionchanged:: 1.0
+     A list of build types can now be given.
 ```
 
 ```{eval-rst}
@@ -449,6 +462,8 @@ print(mk_skbuild_docs())
   such as your source tree is refused to avoid deleting those files. A managed
   tree gets a ``CACHEDIR.TAG`` and a ``.gitignore`` so its compiled artifacts
   stay out of backups and version control.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -563,6 +578,8 @@ print(mk_skbuild_docs())
   by scikit-build-core to the wheel staging directory); the ``--strip`` and
   ``--component`` options of ``cmake --install`` do not apply to these targets.
   ``components`` and ``targets`` may be combined; both will run.
+
+  .. versionadded:: 1.0
 ```
 
 ## logging
@@ -696,6 +713,8 @@ print(mk_skbuild_docs())
   its destination, since naming an exact source is an explicit request. A
   force-included *directory* stays subject to :confval:`sdist.exclude`, so a
   bulk copy can still be trimmed by an exclude pattern.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -730,12 +749,14 @@ print(mk_skbuild_docs())
   * "manual": No extra logic, based on include/exclude only.
   * "explicit": Opt-in only. Nothing is included unless it matches an ``include``
     pattern, and ``exclude`` is applied after, so it can trim included files back
-    out. Like "manual", git ignore files are not read. (1.0+)
+    out. Like "manual", git ignore files are not read.
 
   If you don't set this, it will be "default" unless you set the minimum
   version below 0.12, in which case it will be "classic".
 
-  .. versionadded: 0.12
+  .. versionadded:: 0.12
+  .. versionchanged:: 1.0
+     Added the "explicit" mode.
 ```
 
 ```{eval-rst}
@@ -771,7 +792,7 @@ print(mk_skbuild_docs())
   If you don't set this, it will be "all" unless you set the minimum version
   below 1.0, in which case it will be "none" to preserve backward compatibility.
 
-  .. versionadded: 1.0
+  .. versionadded:: 1.0
 ```
 
 ## search
@@ -872,6 +893,8 @@ print(mk_skbuild_docs())
   directory) and read from that original source instead. This lets a source
   that names an sdist output (vendored via :confval:`sdist.force-include`) build
   from both a source tree and an unpacked sdist.
+
+  .. versionadded:: 1.0
 ```
 
 ```{eval-rst}
@@ -893,6 +916,9 @@ print(mk_skbuild_docs())
   wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake cache
   variables. Available trees: ``PLATLIB``/``PURELIB``, ``DATA``, ``HEADERS``,
   ``SCRIPTS``, ``METADATA``, ``NULL``.
+
+  .. versionchanged:: 1.0
+     Added the ``${SKBUILD_<TREE>_DIR}`` prefix for targeting wheel trees.
 
   .. warning::
      EXPERIMENTAL A leading-slash absolute path (``/platlib``, ``/data``,
@@ -933,6 +959,9 @@ print(mk_skbuild_docs())
   copied in as a top-level module rather than a package directory.
 
   If a dict, provides a mapping of package name to source directory.
+
+  .. versionchanged:: 1.0
+     An entry may point at a single module file.
 ```
 
 ```{eval-rst}
@@ -974,6 +1003,10 @@ print(mk_skbuild_docs())
   The ABI tag is inferred from this tag.
 
   This value is used to construct ``SKBUILD_SABI_COMPONENT`` CMake variable.
+
+  .. versionchanged:: 1.0
+     Added the free-threaded stable ABI ("cp315t") and the combined
+     abi3.abi3t tag ("cp315.cp315t").
 ```
 
 ```{eval-rst}
@@ -992,6 +1025,8 @@ print(mk_skbuild_docs())
   ``SOURCE_DATE_EPOCH`` is exported to the CMake build (if not already set) so
   compilers that honor it can produce deterministic output. ``SOURCE_DATE_EPOCH``
   is used for timestamps if set, or a fixed value if not.
+
+  .. versionadded:: 1.0
 
   .. seealso::
      :confval:`sdist.reproducible`

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -222,6 +222,9 @@ class CMakeSettings:
     Ninja Multi-Config) build each ``--config``. Every build type is installed
     to the same prefix, so use ``CMAKE_<CONFIG>_POSTFIX`` to avoid clobbering
     files between configurations.
+
+    .. versionchanged:: 1.0
+       A list of build types can now be given.
     """
 
     source_dir: Path = Path()
@@ -344,12 +347,14 @@ class SDistSettings:
     * "manual": No extra logic, based on include/exclude only.
     * "explicit": Opt-in only. Nothing is included unless it matches an ``include``
       pattern, and ``exclude`` is applied after, so it can trim included files back
-      out. Like "manual", git ignore files are not read. (1.0+)
+      out. Like "manual", git ignore files are not read.
 
     If you don't set this, it will be "default" unless you set the minimum
     version below 0.12, in which case it will be "classic".
 
-    .. versionadded: 0.12
+    .. versionadded:: 0.12
+    .. versionchanged:: 1.0
+       Added the "explicit" mode.
     """
 
     reproducible: bool = True
@@ -382,6 +387,8 @@ class SDistSettings:
     its destination, since naming an exact source is an explicit request. A
     force-included *directory* stays subject to :confval:`sdist.exclude`, so a
     bulk copy can still be trimmed by an exclude pattern.
+
+    .. versionadded:: 1.0
     """
 
     resolve_symlinks: Optional[Literal["all", "none"]] = dataclasses.field(
@@ -399,7 +406,7 @@ class SDistSettings:
     If you don't set this, it will be "all" unless you set the minimum version
     below 1.0, in which case it will be "none" to preserve backward compatibility.
 
-    .. versionadded: 1.0
+    .. versionadded:: 1.0
     """
 
 
@@ -422,6 +429,9 @@ class WheelSettings:
     copied in as a top-level module rather than a package directory.
 
     If a dict, provides a mapping of package name to source directory.
+
+    .. versionchanged:: 1.0
+       An entry may point at a single module file.
     """
 
     py_api: str = ""
@@ -445,6 +455,10 @@ class WheelSettings:
     The ABI tag is inferred from this tag.
 
     This value is used to construct ``SKBUILD_SABI_COMPONENT`` CMake variable.
+
+    .. versionchanged:: 1.0
+       Added the free-threaded stable ABI ("cp315t") and the combined
+       abi3.abi3t tag ("cp315.cp315t").
     """
 
     expand_macos_universal_tags: bool = False
@@ -469,6 +483,9 @@ class WheelSettings:
     wheel tree instead of the platlib, matching the ``SKBUILD_*_DIR`` CMake cache
     variables. Available trees: ``PLATLIB``/``PURELIB``, ``DATA``, ``HEADERS``,
     ``SCRIPTS``, ``METADATA``, ``NULL``.
+
+    .. versionchanged:: 1.0
+       Added the ``${SKBUILD_<TREE>_DIR}`` prefix for targeting wheel trees.
 
     .. warning::
        EXPERIMENTAL A leading-slash absolute path (``/platlib``, ``/data``,
@@ -557,6 +574,8 @@ class WheelSettings:
     directory) and read from that original source instead. This lets a source
     that names an sdist output (vendored via :confval:`sdist.force-include`) build
     from both a source tree and an unpacked sdist.
+
+    .. versionadded:: 1.0
     """
 
     reproducible: bool = False
@@ -569,6 +588,8 @@ class WheelSettings:
     ``SOURCE_DATE_EPOCH`` is exported to the CMake build (if not already set) so
     compilers that honor it can produce deterministic output. ``SOURCE_DATE_EPOCH``
     is used for timestamps if set, or a fixed value if not.
+
+    .. versionadded:: 1.0
 
     .. seealso::
        :confval:`sdist.reproducible`
@@ -622,6 +643,8 @@ class EditableSettings:
     such as your source tree is refused to avoid deleting those files. A managed
     tree gets a ``CACHEDIR.TAG`` and a ``.gitignore`` so its compiled artifacts
     stay out of backups and version control.
+
+    .. versionadded:: 1.0
     """
 
     @property
@@ -686,6 +709,8 @@ class InstallSettings:
     by scikit-build-core to the wheel staging directory); the ``--strip`` and
     ``--component`` options of ``cmake --install`` do not apply to these targets.
     ``components`` and ``targets`` may be combined; both will run.
+
+    .. versionadded:: 1.0
     """
 
     strip: Optional[bool] = dataclasses.field(
@@ -791,6 +816,8 @@ class ScikitBuildSettings:
     another environment variable), ``default``, and ``force``; an entry that
     resolves to nothing is skipped. Independent of the ``if.env`` override
     condition.
+
+    .. versionadded:: 1.0
     """
 
     strict_config: bool = True
@@ -815,6 +842,8 @@ class ScikitBuildSettings:
     Experimental PEP 817 variant properties.
 
     This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+    .. versionadded:: 1.0
     """
 
     variant_name: List[str] = dataclasses.field(
@@ -825,6 +854,8 @@ class ScikitBuildSettings:
     Experimental PEP 817 variant properties used for wheel metadata selection.
 
     This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+    .. versionadded:: 1.0
     """
 
     variant_label: Optional[str] = dataclasses.field(
@@ -835,6 +866,8 @@ class ScikitBuildSettings:
     Experimental PEP 817 wheel variant label override.
 
     This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+    .. versionadded:: 1.0
     """
 
     null_variant: bool = dataclasses.field(
@@ -845,6 +878,8 @@ class ScikitBuildSettings:
     Experimental PEP 817 null-variant selector.
 
     This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
+
+    .. versionadded:: 1.0
     """
 
     minimum_version: Optional[Version] = dataclasses.field(


### PR DESCRIPTION
Launched a fleet of 15 Sonnet 5 agents looking at each file to hunt these down (managed by Opus 4.8).

:robot: _AI text below_ :robot:

## Summary

Ahead of the **1.0** release, this audits the docs for features that landed since `v0.12.2` and adds the `versionadded`/`versionchanged` directives they were missing. 42 directives across 11 files.

The audit cross-referenced every `feat:` commit since the `v0.12.2` tag against each relevant doc file (and `skbuild_model.py`, the cog source for the config reference).

## What's covered

**Config model (`skbuild_model.py` → regenerated `configs.md`, 13):** `cmake.build-type` list, `sdist.inclusion-mode = "explicit"`, `sdist.force-include`, `wheel.packages` single-module, `wheel.py-api` free-threaded/`abi3.abi3t`, `wheel.install-dir` `${SKBUILD_<TREE>_DIR}` prefix, `wheel.force-include`, `wheel.reproducible`, `editable.rebuild-dir`, `install.targets`, the top-level `env` table, and the PEP 817 `variant*` fields.

**Prose docs:**
- `configuration/index.md` (10), `configuration/dynamic.md` (2), `configuration/formatted.md` (1)
- `guide/getting_started.md` (2), `guide/build.md` (1), `guide/cmakelists.md` (1), `guide/faqs.md` (4)
- `plugins/setuptools.md` (6), `plugins/hatchling.md` (2)

**Also:** fixes the existing single-colon `.. versionadded:` docstrings to the proper double-colon `.. versionadded::` RST directive form, so they render as version boxes instead of being silently parsed as comments (this also corrects two pre-existing entries).

## Notes

- `configs.md` is regenerated by `nox -s generate_config_reference` (cog), not by pre-commit — it has been regenerated here to stay in sync with the model docstrings.
- Files audited but already complete: `configuration/overrides.md`, `configuration/search_paths.md`, `guide/crosscompile.md`, `guide/dynamic_link.md`, `guide/migration_guide.md`.