### PR TITLE
feat(settings): entry-point configuration providers

### DIFF
--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -1,0 +1,98 @@
+# Entry-point configuration
+
+An installed package can contribute scikit-build-core configuration to _every_
+build in the environment through the `scikit-build-core.config` entry-point
+group. This is primarily intended for Linux distributions and other packagers
+that need to set build defaults (such as the CMake build type or symbol
+stripping) for all packages without editing each one's `pyproject.toml`.
+
+A provider is a callable that returns a `[tool.scikit-build]`-shaped table:
+
+```{code-block} python
+:caption: my_distro_config/__init__.py
+
+def config(*, state, env):
+    return {
+        "cmake": {"build-type": "RelWithDebInfo"},
+        "install": {"strip": False},
+    }
+```
+
+The callable may also take no arguments; `state` (the build state, e.g.
+`"wheel"`) and `env` (the environment mapping) are passed when accepted.
+
+It is registered under the `scikit-build-core.config` group. The part of the
+entry-point **name** before the first `.` selects the precedence level:
+
+```{code-block} toml
+:caption: pyproject.toml of the provider package
+
+[project.entry-points."scikit-build-core.config"]
+default = "my_distro_config:config"
+```
+
+Any installed package registering a provider is picked up automatically; the
+project being built does not need to opt in.
+
+## Precedence levels
+
+The name controls where the contributed table lands in the configuration
+precedence order:
+
+- **`default`** — applied _below_ `pyproject.toml`, just above the built-in
+  defaults. The provider suggests defaults; the project's own configuration
+  always wins. This is the recommended level.
+- **`override`** — applied _above_ `pyproject.toml`, so the project cannot
+  accidentally undo it. It is still below the user's per-build environment
+  variables and config-settings.
+
+The full precedence order, highest to lowest, is:
+
+1. `SKBUILD_*` environment variables
+2. `-C`/config-settings
+3. `override` entry-point providers
+4. extra settings (build-frontend plugins, e.g. hatchling)
+5. `pyproject.toml`
+6. `default` entry-point providers
+7. built-in defaults
+
+A package may register both a `default` and an `override` provider, and the name
+may be sub-scoped (`default.mydistro`, `override.mydistro`) to be descriptive or
+to register more than one table per level. When several providers target the
+same level, the alphabetically-first name wins on conflicts.
+
+## Conditional configuration
+
+Because the returned table is treated like a `[tool.scikit-build]` table, it may
+contain [`overrides`](./overrides.md). Combined with environment matching, this
+lets a provider apply configuration only in the relevant context. For example, a
+distribution can request debug-friendly defaults only inside an RPM build:
+
+```{code-block} python
+:caption: provider returning conditional config
+
+def config(*, state, env):
+    return {
+        "overrides": [
+            {
+                "if": {"env": {"RPM_BUILD_ROOT": True}},
+                "cmake": {"build-type": "RelWithDebInfo"},
+                "install": {"strip": False},
+            }
+        ]
+    }
+```
+
+## Opting out
+
+Set `SKBUILD_NO_ENTRYPOINT_CONFIG=1` to ignore all entry-point providers for a
+build, which is useful for reproducible builds or debugging. Loaded providers
+are reported in the debug log.
+
+:::{note}
+
+A provider's `minimum-version` is ignored; entry-point configuration is
+environment policy and must not silently change a project's backward-compatible
+behavior.
+
+:::

--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -88,11 +88,3 @@ def config(*, state, env):
 Set `SKBUILD_NO_ENTRYPOINT_CONFIG=1` to ignore all entry-point providers for a
 build, which is useful for reproducible builds or debugging. Loaded providers
 are reported in the debug log.
-
-:::{note}
-
-A provider's `minimum-version` is ignored; entry-point configuration is
-environment policy and must not silently change a project's backward-compatible
-behavior.
-
-:::

--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -1,10 +1,12 @@
 # Entry-point configuration
 
+> [!CAUTION] This is an advanced feature primarily for Linux distributions and
+> other packagers that need to set build defaults, like the CMake build type or
+> symbol stripping.
+
 An installed package can contribute scikit-build-core configuration to _every_
-build in the environment through two entry-point groups. This is primarily
-intended for Linux distributions and other packagers that need to set build
-defaults (such as the CMake build type or symbol stripping) for all packages
-without editing each one's `pyproject.toml`.
+build in the environment through two entry-point groups. This can affect all
+packages without editing each one's `pyproject.toml`.
 
 A provider is a callable that returns a `[tool.scikit-build]`-shaped table:
 

--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -1,10 +1,10 @@
 # Entry-point configuration
 
 An installed package can contribute scikit-build-core configuration to _every_
-build in the environment through the `scikit-build-core.config` entry-point
-group. This is primarily intended for Linux distributions and other packagers
-that need to set build defaults (such as the CMake build type or symbol
-stripping) for all packages without editing each one's `pyproject.toml`.
+build in the environment through two entry-point groups. This is primarily
+intended for Linux distributions and other packagers that need to set build
+defaults (such as the CMake build type or symbol stripping) for all packages
+without editing each one's `pyproject.toml`.
 
 A provider is a callable that returns a `[tool.scikit-build]`-shaped table:
 
@@ -21,14 +21,14 @@ def config(*, state, env):
 The callable may also take no arguments; `state` (the build state, e.g.
 `"wheel"`) and `env` (the environment mapping) are passed when accepted.
 
-It is registered under the `scikit-build-core.config` group. The part of the
-entry-point **name** before the first `.` selects the precedence level:
+It is registered under one of two groups; the **group** selects the precedence
+level, and the entry-point name is arbitrary:
 
 ```{code-block} toml
 :caption: pyproject.toml of the provider package
 
-[project.entry-points."scikit-build-core.config"]
-default = "my_distro_config:config"
+[project.entry-points."scikit-build-core.config.default"]
+my-distro = "my_distro_config:config"
 ```
 
 Any installed package registering a provider is picked up automatically; the
@@ -36,15 +36,15 @@ project being built does not need to opt in.
 
 ## Precedence levels
 
-The name controls where the contributed table lands in the configuration
+The group controls where the contributed table lands in the configuration
 precedence order:
 
-- **`default`** — applied _below_ `pyproject.toml`, just above the built-in
-  defaults. The provider suggests defaults; the project's own configuration
-  always wins. This is the recommended level.
-- **`override`** — applied _above_ `pyproject.toml`, so the project cannot
-  accidentally undo it. It is still below the user's per-build environment
-  variables and config-settings.
+- **`scikit-build-core.config.default`** — applied _below_ `pyproject.toml`,
+  just above the built-in defaults. The provider suggests defaults; the
+  project's own configuration always wins. This is the recommended level.
+- **`scikit-build-core.config.override`** — applied _above_ `pyproject.toml`, so
+  the project cannot accidentally undo it. It is still below the user's
+  per-build environment variables and config-settings.
 
 The full precedence order, highest to lowest, is:
 
@@ -56,10 +56,10 @@ The full precedence order, highest to lowest, is:
 6. `default` entry-point providers
 7. built-in defaults
 
-A package may register both a `default` and an `override` provider, and the name
-may be sub-scoped (`default.mydistro`, `override.mydistro`) to be descriptive or
-to register more than one table per level. When several providers target the
-same level, the alphabetically-first name wins on conflicts.
+A package may register providers in both groups, and the entry-point name is
+free-form. When several providers are registered in the same group, they are
+applied in sorted name order and the alphabetically-first name wins on
+conflicts.
 
 ## Conditional configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ configuration/overrides
 configuration/dynamic
 configuration/formatted
 configuration/search_paths
+configuration/entrypoint_config
 ```
 
 ```{toctree}

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -24,10 +24,6 @@ def entry_points(*, group: str) -> EntryPoints:
         return importlib.metadata.entry_points(group=group)
 
     epg = importlib.metadata.entry_points()
-    # On a genuine 3.8/3.9 this is a dict keyed by group. Tests may simulate an
-    # old version on a newer runtime, where it is the modern selectable object.
-    if hasattr(epg, "select"):
-        return epg.select(group=group)
     return epg.get(group, [])  # pylint: disable=no-member
 
 

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -24,6 +24,10 @@ def entry_points(*, group: str) -> EntryPoints:
         return importlib.metadata.entry_points(group=group)
 
     epg = importlib.metadata.entry_points()
+    # On a genuine 3.8/3.9 this is a dict keyed by group. Tests may simulate an
+    # old version on a newer runtime, where it is the modern selectable object.
+    if hasattr(epg, "select"):
+        return epg.select(group=group)
     return epg.get(group, [])  # pylint: disable=no-member
 
 

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -1,0 +1,73 @@
+"""
+Load configuration contributed by installed packages through the
+``scikit-build-core.config`` entry-point group.
+
+A provider entry point resolves to a callable returning a ``tool.scikit-build``
+shaped table (a dict). The first dotted segment of the entry-point *name*
+selects the precedence level:
+
+- ``default``: applied below ``pyproject.toml`` (just above hard-coded defaults).
+- ``override``: applied above ``pyproject.toml`` (but below the user's per-build
+  env vars and config-settings).
+
+The returned tables are turned into low/high priority ``TOMLSource``\\ s by
+:class:`~scikit_build_core.settings.skbuild_read_settings.SettingsReader`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .._compat.importlib import metadata
+from .._logging import logger, rich_error, rich_warning
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["GROUP", "load_config_providers"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+GROUP = "scikit-build-core.config"
+_LEVELS = frozenset({"default", "override"})
+
+
+def load_config_providers(
+    *, state: str, env: Mapping[str, str]
+) -> list[tuple[str, str, dict[str, object]]]:
+    """
+    Collect every ``scikit-build-core.config`` provider's table.
+
+    Returns a list of ``(level, name, table)`` tuples, sorted by entry-point
+    name so multiple providers compose deterministically. ``level`` is always
+    ``"default"`` or ``"override"``; providers with any other name are skipped
+    with a warning.
+    """
+    providers: list[tuple[str, str, dict[str, object]]] = []
+    for ep in sorted(metadata.entry_points(group=GROUP), key=lambda e: e.name):
+        level = ep.name.split(".", 1)[0]
+        if level not in _LEVELS:
+            rich_warning(
+                f"Ignoring {GROUP} provider {ep.name!r}: the name must start with "
+                "'default' or 'override' to select the precedence level"
+            )
+            continue
+        func = ep.load()
+        if not callable(func):
+            rich_error(f"{GROUP} provider {ep.name!r} must be callable")
+        try:
+            table = func(state=state, env=env)
+        except TypeError:
+            table = func()
+        if not isinstance(table, dict):
+            rich_error(
+                f"{GROUP} provider {ep.name!r} must return a tool.scikit-build "
+                f"table (dict), got {type(table).__name__}"
+            )
+        if table:
+            logger.debug("Loaded {} entry-point config from {}", level, ep.name)
+            providers.append((level, ep.name, table))
+    return providers

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -25,19 +25,19 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
 }
 
-from typing import TYPE_CHECKING
-
 from .._compat.importlib import metadata
 from .._logging import logger, rich_error
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 __all__ = ["GROUP_DEFAULT", "GROUP_OVERRIDE", "load_config_providers"]
 
 
 def __dir__() -> list[str]:
     return __all__
+
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 GROUP_DEFAULT = "scikit-build-core.config.default"

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -1,14 +1,18 @@
 """
 Load configuration contributed by installed packages through the
-``scikit-build-core.config`` entry-point group.
+``scikit-build-core.config.default`` and ``scikit-build-core.config.override``
+entry-point groups.
 
 A provider entry point resolves to a callable returning a ``tool.scikit-build``
-shaped table (a dict). The first dotted segment of the entry-point *name*
-selects the precedence level:
+shaped table (a dict). The group selects the precedence level:
 
-- ``default``: applied below ``pyproject.toml`` (just above hard-coded defaults).
-- ``override``: applied above ``pyproject.toml`` (but below the user's per-build
-  env vars and config-settings).
+- ``scikit-build-core.config.default``: applied below ``pyproject.toml`` (just
+  above the hard-coded defaults).
+- ``scikit-build-core.config.override``: applied above ``pyproject.toml`` (but
+  below the user's per-build env vars and config-settings).
+
+Within each group the entry-point name is arbitrary; providers are applied in
+sorted name order so they compose deterministically.
 
 The returned tables are turned into low/high priority ``TOMLSource``\\ s by
 :class:`~scikit_build_core.settings.skbuild_read_settings.SettingsReader`.
@@ -19,55 +23,56 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .._compat.importlib import metadata
-from .._logging import logger, rich_error, rich_warning
+from .._logging import logger, rich_error
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-__all__ = ["GROUP", "load_config_providers"]
+__all__ = ["GROUP_DEFAULT", "GROUP_OVERRIDE", "load_config_providers"]
 
 
 def __dir__() -> list[str]:
     return __all__
 
 
-GROUP = "scikit-build-core.config"
-_LEVELS = frozenset({"default", "override"})
+GROUP_DEFAULT = "scikit-build-core.config.default"
+GROUP_OVERRIDE = "scikit-build-core.config.override"
 
 
-def load_config_providers(
-    *, state: str, env: Mapping[str, str]
+def _load_group(
+    level: str, group: str, *, state: str, env: Mapping[str, str]
 ) -> list[tuple[str, str, dict[str, object]]]:
-    """
-    Collect every ``scikit-build-core.config`` provider's table.
-
-    Returns a list of ``(level, name, table)`` tuples, sorted by entry-point
-    name so multiple providers compose deterministically. ``level`` is always
-    ``"default"`` or ``"override"``; providers with any other name are skipped
-    with a warning.
-    """
     providers: list[tuple[str, str, dict[str, object]]] = []
-    for ep in sorted(metadata.entry_points(group=GROUP), key=lambda e: e.name):
-        level = ep.name.split(".", 1)[0]
-        if level not in _LEVELS:
-            rich_warning(
-                f"Ignoring {GROUP} provider {ep.name!r}: the name must start with "
-                "'default' or 'override' to select the precedence level"
-            )
-            continue
+    for ep in sorted(metadata.entry_points(group=group), key=lambda e: e.name):
         func = ep.load()
         if not callable(func):
-            rich_error(f"{GROUP} provider {ep.name!r} must be callable")
+            rich_error(f"{group} provider {ep.name!r} must be callable")
         try:
             table = func(state=state, env=env)
         except TypeError:
             table = func()
         if not isinstance(table, dict):
             rich_error(
-                f"{GROUP} provider {ep.name!r} must return a tool.scikit-build "
+                f"{group} provider {ep.name!r} must return a tool.scikit-build "
                 f"table (dict), got {type(table).__name__}"
             )
         if table:
             logger.debug("Loaded {} entry-point config from {}", level, ep.name)
             providers.append((level, ep.name, table))
     return providers
+
+
+def load_config_providers(
+    *, state: str, env: Mapping[str, str]
+) -> list[tuple[str, str, dict[str, object]]]:
+    """
+    Collect every entry-point provider's table.
+
+    Returns a list of ``(level, name, table)`` tuples. ``override`` providers
+    come first, then ``default`` providers; each group is sorted by entry-point
+    name so providers compose deterministically (the earlier name wins).
+    """
+    return [
+        *_load_group("override", GROUP_OVERRIDE, state=state, env=env),
+        *_load_group("default", GROUP_DEFAULT, state=state, env=env),
+    ]

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -20,6 +20,11 @@ The returned tables are turned into low/high priority ``TOMLSource``\\ s by
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+}
+
 from typing import TYPE_CHECKING
 
 from .._compat.importlib import metadata

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -38,6 +38,7 @@ from .._variants import validate_variant_settings
 from ..ast.ast import ParseError
 from ..errors import CMakeConfigError
 from ..utils.typing import get_target_raw_type
+from ._load_entrypoint_config import load_config_providers
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .skbuild_model import (
@@ -46,7 +47,7 @@ from .skbuild_model import (
     ScikitBuildSettings,
     normalize_build_types,
 )
-from .skbuild_overrides import process_overrides
+from .skbuild_overrides import process_overrides, strtobool
 from .sources import ConfSource, EnvSource, Source, SourceChain, TOMLSource
 
 TYPE_CHECKING = False
@@ -300,6 +301,8 @@ class SettingsReader:
                 )
             pyproject["tool"]["scikit-build"]["minimum-version"] = str(min_v)
         toml_srcs = [TOMLSource("tool", "scikit-build", settings=pyproject)]
+        # Human-readable names parallel to ``toml_srcs`` (used by suggestions).
+        toml_src_names = ["pyproject.toml"]
 
         # Standard top-level [[tool.dynamic-metadata]] entries (0.3); kept for
         # validation only (cannot be combined with tool.scikit-build.metadata).
@@ -324,6 +327,42 @@ class SettingsReader:
             self.overrides |= extra_matched
             self.overridden_items.update(extra_overridden)
             toml_srcs.insert(0, TOMLSource(settings=extra_skb))
+            toml_src_names.insert(0, "extra settings")
+
+        # Configuration contributed by installed packages via the
+        # "scikit-build-core.config" entry-point group (e.g. a Linux distro
+        # shipping build defaults for all its package builds). The entry-point
+        # name selects the precedence level: "override" sources sit above
+        # pyproject.toml (and extra_settings), "default" sources sit below it,
+        # just above the hard-coded defaults. Either way the user's per-build
+        # env vars and config-settings still win. Opt out entirely with
+        # SKBUILD_NO_ENTRYPOINT_CONFIG.
+        if not strtobool(environ.get("SKBUILD_NO_ENTRYPOINT_CONFIG", "")):
+            override_index = 0
+            for level, ep_name, ep_table in load_config_providers(
+                state=state, env=environ
+            ):
+                # ep config is environment policy, not project semantics: it must
+                # not silently drive the minimum-version back-compat machinery.
+                ep_table.pop("minimum-version", None)
+                ep_skb = copy.deepcopy(ep_table)
+                ep_matched, ep_overridden = process_overrides(
+                    ep_skb, state=state, env=env, retry=retry
+                )
+                self.overrides |= ep_matched
+                ep_source = TOMLSource(settings=ep_skb)
+                ep_display = f"entry-point config ({ep_name})"
+                if level == "override":
+                    self.overridden_items.update(ep_overridden)
+                    toml_srcs.insert(override_index, ep_source)
+                    toml_src_names.insert(override_index, ep_display)
+                    override_index += 1
+                else:
+                    # Lowest priority: never clobber higher-priority records.
+                    for key, record in ep_overridden.items():
+                        self.overridden_items.setdefault(key, record)
+                    toml_srcs.append(ep_source)
+                    toml_src_names.append(ep_display)
 
         prefixed = {
             k: v for k, v in config_settings.items() if k.startswith("skbuild.")
@@ -341,6 +380,7 @@ class SettingsReader:
         # are forbidden here outside of an [[overrides]] section.
         self._dynamic_srcs = tuple(dynamic_srcs)
         self._toml_srcs = tuple(toml_srcs)
+        self._toml_src_names = tuple(toml_src_names)
         self.sources = SourceChain(
             *dynamic_srcs,
             *toml_srcs,
@@ -530,16 +570,13 @@ class SettingsReader:
         return result
 
     def print_suggestions(self) -> None:
-        # Index 0 is the env source (skipped); the config-settings sources follow,
-        # then the TOML sources. The last TOML source is always pyproject.toml;
-        # any earlier ones are extra settings injected by a plugin (e.g. hatch).
+        # Index 0 is the env source (skipped); the config-settings sources
+        # follow, then the TOML sources, named in order by ``_toml_src_names``
+        # (pyproject.toml plus any extra-settings/entry-point config sources).
         n_dynamic = len(self._dynamic_srcs)
         names = dict.fromkeys(range(1, n_dynamic), "config-settings")
-        for offset in range(len(self._toml_srcs)):
-            is_pyproject = offset == len(self._toml_srcs) - 1
-            names[n_dynamic + offset] = (
-                "pyproject.toml" if is_pyproject else "extra settings"
-            )
+        for offset, src_name in enumerate(self._toml_src_names):
+            names[n_dynamic + offset] = src_name
         for index, name in names.items():
             suggestions_dict = self.suggestions(index)
             if suggestions_dict:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -330,11 +330,11 @@ class SettingsReader:
             toml_src_names.insert(0, "extra settings")
 
         # Configuration contributed by installed packages via the
-        # "scikit-build-core.config" entry-point group (e.g. a Linux distro
-        # shipping build defaults for all its package builds). The entry-point
-        # name selects the precedence level: "override" sources sit above
-        # pyproject.toml (and extra_settings), "default" sources sit below it,
-        # just above the hard-coded defaults. Either way the user's per-build
+        # "scikit-build-core.config.default" / ".override" entry-point groups
+        # (e.g. a Linux distro shipping build defaults for all its package
+        # builds). The group selects the precedence level: "override" sources sit
+        # above pyproject.toml (and extra_settings), "default" sources sit below
+        # it, just above the hard-coded defaults. Either way the user's per-build
         # env vars and config-settings still win. Opt out entirely with
         # SKBUILD_NO_ENTRYPOINT_CONFIG.
         if not strtobool(environ.get("SKBUILD_NO_ENTRYPOINT_CONFIG", "")):

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -10,6 +10,7 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ast",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.utils",
+    f"{__spec__.parent}._load_entrypoint_config",
     f"{__spec__.parent}.auto_cmake_version",
     f"{__spec__.parent}.auto_requires",
     f"{__spec__.parent}.skbuild_model",

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -342,9 +342,6 @@ class SettingsReader:
             for level, ep_name, ep_table in load_config_providers(
                 state=state, env=environ
             ):
-                # ep config is environment policy, not project semantics: it must
-                # not silently drive the minimum-version back-compat machinery.
-                ep_table.pop("minimum-version", None)
                 ep_skb = copy.deepcopy(ep_table)
                 ep_matched, ep_overridden = process_overrides(
                     ep_skb, state=state, env=env, retry=retry

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -1,5 +1,6 @@
 """
-Tests for the ``scikit-build-core.config`` entry-point configuration providers.
+Tests for the ``scikit-build-core.config.default`` / ``.override`` entry-point
+configuration providers.
 """
 
 from __future__ import annotations
@@ -8,12 +9,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import scikit_build_core._logging
 from scikit_build_core._compat.importlib import metadata as compat_metadata
 from scikit_build_core.settings import _load_entrypoint_config
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -29,21 +30,34 @@ class FakeEntryPoint:
 
 
 @pytest.fixture
-def providers(monkeypatch):
-    """Register fake ``scikit-build-core.config`` providers.
+def register(monkeypatch):
+    """Register fake entry-point config providers.
 
-    Yields a dict; assign ``providers[name] = callable`` to register one.
+    Call ``register(level, name, func)`` with ``level`` of "default" or
+    "override" and an arbitrary ``name``.
     """
-    registry: dict[str, object] = {}
+    groups: dict[str, dict[str, object]] = {
+        _load_entrypoint_config.GROUP_DEFAULT: {},
+        _load_entrypoint_config.GROUP_OVERRIDE: {},
+    }
 
     def fake_entry_points(*, group: str):
-        if group != _load_entrypoint_config.GROUP:
-            return []
-        return [FakeEntryPoint(name, func) for name, func in registry.items()]
+        return [
+            FakeEntryPoint(name, func) for name, func in groups.get(group, {}).items()
+        ]
 
     # The loader resolves entry points through this shared compat module.
     monkeypatch.setattr(compat_metadata, "entry_points", fake_entry_points)
-    return registry
+
+    def add(level: str, name: str, func: Callable[..., object]) -> None:
+        group = (
+            _load_entrypoint_config.GROUP_OVERRIDE
+            if level == "override"
+            else _load_entrypoint_config.GROUP_DEFAULT
+        )
+        groups[group][name] = func
+
+    return add
 
 
 def make_reader(tmp_path: Path, body: str = "", **kwargs) -> SettingsReader:
@@ -52,32 +66,42 @@ def make_reader(tmp_path: Path, body: str = "", **kwargs) -> SettingsReader:
     return SettingsReader.from_file(pyproject_toml, {}, **kwargs)
 
 
-def test_default_provider_applies_when_silent(tmp_path, providers):
-    providers["default"] = lambda **_: {
-        "cmake": {"build-type": "RelWithDebInfo"},
-        "install": {"strip": False},
-    }
+def test_default_provider_applies_when_silent(tmp_path, register):
+    register(
+        "default",
+        "distro",
+        lambda **_: {
+            "cmake": {"build-type": "RelWithDebInfo"},
+            "install": {"strip": False},
+        },
+    )
     settings = make_reader(tmp_path, state="wheel").settings
     assert settings.cmake.build_type == "RelWithDebInfo"
     assert settings.install.strip is False
 
 
-def test_default_provider_loses_to_pyproject(tmp_path, providers):
-    providers["default"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+def test_default_provider_loses_to_pyproject(tmp_path, register):
+    register(
+        "default", "distro", lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    )
     body = "[tool.scikit-build.cmake]\nbuild-type = 'Debug'\n"
     settings = make_reader(tmp_path, body, state="wheel").settings
     assert settings.cmake.build_type == "Debug"
 
 
-def test_override_provider_beats_pyproject(tmp_path, providers):
-    providers["override"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+def test_override_provider_beats_pyproject(tmp_path, register):
+    register(
+        "override", "distro", lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    )
     body = "[tool.scikit-build.cmake]\nbuild-type = 'Debug'\n"
     settings = make_reader(tmp_path, body, state="wheel").settings
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
-def test_override_still_beaten_by_config_settings(tmp_path, providers):
-    providers["override"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+def test_override_still_beaten_by_config_settings(tmp_path, register):
+    register(
+        "override", "distro", lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    )
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text("", encoding="utf-8")
     reader = SettingsReader.from_file(
@@ -86,9 +110,11 @@ def test_override_still_beaten_by_config_settings(tmp_path, providers):
     assert reader.settings.cmake.build_type == "Release"
 
 
-def test_dict_fields_merge_across_levels(tmp_path, providers):
-    providers["default"] = lambda **_: {"cmake": {"define": {"FROM_DEFAULT": "1"}}}
-    providers["override"] = lambda **_: {"cmake": {"define": {"SHARED": "ep"}}}
+def test_dict_fields_merge_across_levels(tmp_path, register):
+    register(
+        "default", "distro", lambda **_: {"cmake": {"define": {"FROM_DEFAULT": "1"}}}
+    )
+    register("override", "distro", lambda **_: {"cmake": {"define": {"SHARED": "ep"}}})
     body = (
         "[tool.scikit-build.cmake.define]\nFROM_PYPROJECT = '2'\nSHARED = 'pyproject'\n"
     )
@@ -100,15 +126,15 @@ def test_dict_fields_merge_across_levels(tmp_path, providers):
     }
 
 
-def test_multiple_providers_sorted_deterministically(tmp_path, providers):
-    providers["override.b"] = lambda **_: {"cmake": {"build-type": "Debug"}}
-    providers["override.a"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+def test_multiple_providers_sorted_deterministically(tmp_path, register):
+    # Arbitrary names; the alphabetically-first one wins.
+    register("override", "zzz", lambda **_: {"cmake": {"build-type": "Debug"}})
+    register("override", "aaa", lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}})
     settings = make_reader(tmp_path, state="wheel").settings
-    # Earlier entry-point name wins.
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
-def test_provider_overrides_match_env(tmp_path, providers):
+def test_provider_overrides_match_env(tmp_path, register):
     def fedora(**_):
         return {
             "overrides": [
@@ -120,7 +146,7 @@ def test_provider_overrides_match_env(tmp_path, providers):
             ]
         }
 
-    providers["default"] = fedora
+    register("default", "fedora", fedora)
 
     in_rpm = make_reader(
         tmp_path, state="wheel", env={"RPM_BUILD_ROOT": str(tmp_path)}
@@ -132,53 +158,51 @@ def test_provider_overrides_match_env(tmp_path, providers):
     assert outside.cmake.build_type == "Release"
 
 
-def test_opt_out_disables_providers(tmp_path, providers):
-    providers["default"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+def test_opt_out_disables_providers(tmp_path, register):
+    register(
+        "default", "distro", lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    )
     settings = make_reader(
         tmp_path, state="wheel", env={"SKBUILD_NO_ENTRYPOINT_CONFIG": "1"}
     ).settings
     assert settings.cmake.build_type == "Release"
 
 
-def test_unknown_level_warns_and_skips(tmp_path, providers, capsys):
-    providers["bogus"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
-    scikit_build_core._logging.rich_warning.cache_clear()
-    settings = make_reader(tmp_path, state="wheel").settings
-    assert settings.cmake.build_type == "Release"
-    assert "must start with 'default' or 'override'" in capsys.readouterr().err
-
-
-def test_minimum_version_stripped(tmp_path, providers):
-    providers["default"] = lambda **_: {
-        "minimum-version": "0.5",
-        "cmake": {"build-type": "RelWithDebInfo"},
-    }
+def test_minimum_version_stripped(tmp_path, register):
+    register(
+        "default",
+        "distro",
+        lambda **_: {
+            "minimum-version": "0.5",
+            "cmake": {"build-type": "RelWithDebInfo"},
+        },
+    )
     settings = make_reader(tmp_path, state="wheel").settings
     assert settings.minimum_version is None
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
-def test_zero_arg_provider_supported(tmp_path, providers):
+def test_zero_arg_provider_supported(tmp_path, register):
     def provider() -> dict[str, object]:
         return {"cmake": {"build-type": "RelWithDebInfo"}}
 
-    providers["default"] = provider
+    register("default", "distro", provider)
     settings = make_reader(tmp_path, state="wheel").settings
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
-def test_override_only_field_rejected(tmp_path, providers):
+def test_override_only_field_rejected(tmp_path, register):
     # cmake.toolchain-file is an override_only field: hard-coding it in a static
     # source (including ep config) is rejected under strict_config.
     toolchain = str(tmp_path / "tc.cmake")
-    providers["default"] = lambda **_: {"cmake": {"toolchain-file": toolchain}}
+    register("default", "distro", lambda **_: {"cmake": {"toolchain-file": toolchain}})
     reader = make_reader(tmp_path, state="wheel")
     with pytest.raises(SystemExit):
         reader.validate_may_exit()
 
 
-def test_suggestions_name_entry_point_source(tmp_path, providers):
-    providers["default"] = lambda **_: {"not-a-real-field": "x"}
+def test_suggestions_name_entry_point_source(tmp_path, register):
+    register("default", "distro", lambda **_: {"not-a-real-field": "x"})
     reader = make_reader(tmp_path, state="wheel")
-    assert "entry-point config (default)" in reader._toml_src_names
+    assert "entry-point config (distro)" in reader._toml_src_names
     assert "not-a-real-field" in list(reader.unrecognized_options())

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -1,0 +1,184 @@
+"""
+Tests for the ``scikit-build-core.config`` entry-point configuration providers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import scikit_build_core._logging
+from scikit_build_core._compat.importlib import metadata as compat_metadata
+from scikit_build_core.settings import _load_entrypoint_config
+from scikit_build_core.settings.skbuild_read_settings import SettingsReader
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeEntryPoint:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(self, name: str, func: object) -> None:
+        self.name = name
+        self._func = func
+
+    def load(self) -> object:
+        return self._func
+
+
+@pytest.fixture
+def providers(monkeypatch):
+    """Register fake ``scikit-build-core.config`` providers.
+
+    Yields a dict; assign ``providers[name] = callable`` to register one.
+    """
+    registry: dict[str, object] = {}
+
+    def fake_entry_points(*, group: str):
+        if group != _load_entrypoint_config.GROUP:
+            return []
+        return [FakeEntryPoint(name, func) for name, func in registry.items()]
+
+    # The loader resolves entry points through this shared compat module.
+    monkeypatch.setattr(compat_metadata, "entry_points", fake_entry_points)
+    return registry
+
+
+def make_reader(tmp_path: Path, body: str = "", **kwargs) -> SettingsReader:
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(body, encoding="utf-8")
+    return SettingsReader.from_file(pyproject_toml, {}, **kwargs)
+
+
+def test_default_provider_applies_when_silent(tmp_path, providers):
+    providers["default"] = lambda **_: {
+        "cmake": {"build-type": "RelWithDebInfo"},
+        "install": {"strip": False},
+    }
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.cmake.build_type == "RelWithDebInfo"
+    assert settings.install.strip is False
+
+
+def test_default_provider_loses_to_pyproject(tmp_path, providers):
+    providers["default"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    body = "[tool.scikit-build.cmake]\nbuild-type = 'Debug'\n"
+    settings = make_reader(tmp_path, body, state="wheel").settings
+    assert settings.cmake.build_type == "Debug"
+
+
+def test_override_provider_beats_pyproject(tmp_path, providers):
+    providers["override"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    body = "[tool.scikit-build.cmake]\nbuild-type = 'Debug'\n"
+    settings = make_reader(tmp_path, body, state="wheel").settings
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_override_still_beaten_by_config_settings(tmp_path, providers):
+    providers["override"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+    reader = SettingsReader.from_file(
+        pyproject_toml, {"cmake.build-type": "Release"}, state="wheel"
+    )
+    assert reader.settings.cmake.build_type == "Release"
+
+
+def test_dict_fields_merge_across_levels(tmp_path, providers):
+    providers["default"] = lambda **_: {"cmake": {"define": {"FROM_DEFAULT": "1"}}}
+    providers["override"] = lambda **_: {"cmake": {"define": {"SHARED": "ep"}}}
+    body = (
+        "[tool.scikit-build.cmake.define]\nFROM_PYPROJECT = '2'\nSHARED = 'pyproject'\n"
+    )
+    settings = make_reader(tmp_path, body, state="wheel").settings
+    assert settings.cmake.define == {
+        "FROM_DEFAULT": "1",
+        "FROM_PYPROJECT": "2",
+        "SHARED": "ep",  # override beats pyproject on key collision
+    }
+
+
+def test_multiple_providers_sorted_deterministically(tmp_path, providers):
+    providers["override.b"] = lambda **_: {"cmake": {"build-type": "Debug"}}
+    providers["override.a"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    settings = make_reader(tmp_path, state="wheel").settings
+    # Earlier entry-point name wins.
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_provider_overrides_match_env(tmp_path, providers):
+    def fedora(**_):
+        return {
+            "overrides": [
+                {
+                    "if": {"env": {"RPM_BUILD_ROOT": True}},
+                    "cmake": {"build-type": "RelWithDebInfo"},
+                    "install": {"strip": False},
+                }
+            ]
+        }
+
+    providers["default"] = fedora
+
+    in_rpm = make_reader(
+        tmp_path, state="wheel", env={"RPM_BUILD_ROOT": str(tmp_path)}
+    ).settings
+    assert in_rpm.cmake.build_type == "RelWithDebInfo"
+    assert in_rpm.install.strip is False
+
+    outside = make_reader(tmp_path, state="wheel", env={}).settings
+    assert outside.cmake.build_type == "Release"
+
+
+def test_opt_out_disables_providers(tmp_path, providers):
+    providers["default"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    settings = make_reader(
+        tmp_path, state="wheel", env={"SKBUILD_NO_ENTRYPOINT_CONFIG": "1"}
+    ).settings
+    assert settings.cmake.build_type == "Release"
+
+
+def test_unknown_level_warns_and_skips(tmp_path, providers, capsys):
+    providers["bogus"] = lambda **_: {"cmake": {"build-type": "RelWithDebInfo"}}
+    scikit_build_core._logging.rich_warning.cache_clear()
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.cmake.build_type == "Release"
+    assert "must start with 'default' or 'override'" in capsys.readouterr().err
+
+
+def test_minimum_version_stripped(tmp_path, providers):
+    providers["default"] = lambda **_: {
+        "minimum-version": "0.5",
+        "cmake": {"build-type": "RelWithDebInfo"},
+    }
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.minimum_version is None
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_zero_arg_provider_supported(tmp_path, providers):
+    def provider() -> dict[str, object]:
+        return {"cmake": {"build-type": "RelWithDebInfo"}}
+
+    providers["default"] = provider
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_override_only_field_rejected(tmp_path, providers):
+    # cmake.toolchain-file is an override_only field: hard-coding it in a static
+    # source (including ep config) is rejected under strict_config.
+    toolchain = str(tmp_path / "tc.cmake")
+    providers["default"] = lambda **_: {"cmake": {"toolchain-file": toolchain}}
+    reader = make_reader(tmp_path, state="wheel")
+    with pytest.raises(SystemExit):
+        reader.validate_may_exit()
+
+
+def test_suggestions_name_entry_point_source(tmp_path, providers):
+    providers["default"] = lambda **_: {"not-a-real-field": "x"}
+    reader = make_reader(tmp_path, state="wheel")
+    assert "entry-point config (default)" in reader._toml_src_names
+    assert "not-a-real-field" in list(reader.unrecognized_options())

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -174,12 +174,12 @@ def test_minimum_version_applies(tmp_path, register):
         "default",
         "distro",
         lambda **_: {
-            "minimum-version": "0.5",
+            "minimum-version": "0.0",
             "cmake": {"build-type": "RelWithDebInfo"},
         },
     )
     settings = make_reader(tmp_path, state="wheel").settings
-    assert settings.minimum_version == Version("0.5")
+    assert settings.minimum_version == Version("0.0")
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
@@ -189,11 +189,11 @@ def test_minimum_version_applies_via_override(tmp_path, register):
         "default",
         "distro",
         lambda **_: {
-            "overrides": [{"if": {"env": {"SET_MIN": True}}, "minimum-version": "0.5"}]
+            "overrides": [{"if": {"env": {"SET_MIN": True}}, "minimum-version": "0.0"}]
         },
     )
     settings = make_reader(tmp_path, state="wheel", env={"SET_MIN": "1"}).settings
-    assert settings.minimum_version == Version("0.5")
+    assert settings.minimum_version == Version("0.0")
 
 
 def test_zero_arg_provider_supported(tmp_path, register):

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -5,8 +5,6 @@ configuration providers.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from packaging.version import Version
 
@@ -14,6 +12,7 @@ from scikit_build_core._compat.importlib import metadata as compat_metadata
 from scikit_build_core.settings import _load_entrypoint_config
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from packaging.version import Version
 
 from scikit_build_core._compat.importlib import metadata as compat_metadata
 from scikit_build_core.settings import _load_entrypoint_config
@@ -168,7 +169,7 @@ def test_opt_out_disables_providers(tmp_path, register):
     assert settings.cmake.build_type == "Release"
 
 
-def test_minimum_version_stripped(tmp_path, register):
+def test_minimum_version_applies(tmp_path, register):
     register(
         "default",
         "distro",
@@ -178,8 +179,21 @@ def test_minimum_version_stripped(tmp_path, register):
         },
     )
     settings = make_reader(tmp_path, state="wheel").settings
-    assert settings.minimum_version is None
+    assert settings.minimum_version == Version("0.5")
     assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_minimum_version_applies_via_override(tmp_path, register):
+    # A provider may also set minimum-version inside an overrides block.
+    register(
+        "default",
+        "distro",
+        lambda **_: {
+            "overrides": [{"if": {"env": {"SET_MIN": True}}, "minimum-version": "0.5"}]
+        },
+    )
+    settings = make_reader(tmp_path, state="wheel", env={"SET_MIN": "1"}).settings
+    assert settings.minimum_version == Version("0.5")
 
 
 def test_zero_arg_provider_supported(tmp_path, register):

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -25,6 +25,17 @@ class VersionInfo(typing.NamedTuple):
     releaselevel: str = "final"
 
 
+@pytest.fixture(autouse=True)
+def _no_entrypoint_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Several tests here patch sys.version_info to exercise override matching.
+    # That patch must not reach the version-sensitive entry-point metadata shim
+    # via config-provider discovery, which is unrelated to override resolution.
+    monkeypatch.setattr(
+        "scikit_build_core.settings.skbuild_read_settings.load_config_providers",
+        lambda **_: [],
+    )
+
+
 def test_disallow_hardcoded(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
This is quite powerful, not sure I like giving out this kind of power. :)

:robot: _AI text below_ :robot:

Closes #1301, closes #915.

## What

Adds two entry-point groups so an installed package can contribute scikit-build-core configuration to **every** build in the environment — aimed at Linux distros (Fedora) that need to set build defaults for all packages without patching each `pyproject.toml`.

A provider is a callable returning a `[tool.scikit-build]`-shaped **dict**, injected as a new `TOMLSource` in the existing `SourceChain`. This reuses all of the precedence / dict-merge / validation / `[[overrides]]` machinery — no new precedence logic — and structurally answers the "override vs. defaults?" question raised in #1301.

## Two groups select the precedence level

The **group** picks the level; the entry-point name is arbitrary (providers in a group are applied in sorted name order, earlier name wins):

```toml
[project.entry-points."scikit-build-core.config.default"]
my-distro = "my_distro_config:config"
```

```python
def config(*, state, env):  # may also be zero-arg
    return {"cmake": {"build-type": "RelWithDebInfo"}, "install": {"strip": False}}
```

| highest → lowest | |
|---|---|
| `SKBUILD_*` env vars | always win (user escape hatch) |
| `-C` / config-settings | |
| `scikit-build-core.config.override` providers | above pyproject.toml |
| `extra_settings` (hatchling) | |
| `pyproject.toml` | |
| `scikit-build-core.config.default` providers | below pyproject.toml, above defaults |
| built-in defaults | |

## Fixes #915

Because the table can include `[[overrides]]` and the override engine already matches `if.env.<VAR>`, a distro provider applies debug-friendly defaults only inside an RPM build:

```python
def config(*, state, env):
    return {"overrides": [{
        "if": {"env": {"RPM_BUILD_ROOT": True}},
        "cmake": {"build-type": "RelWithDebInfo"},
        "install": {"strip": False},
    }]}
```

Opt out of all providers with `SKBUILD_NO_ENTRYPOINT_CONFIG=1`.

## Changes

- **`settings/_load_entrypoint_config.py`** (new) — `load_config_providers()`: discovers both groups, sorts each by name (deterministic), calls each provider (`(state, env)` or zero-arg), returns `(level, name, table)` tuples (overrides first, then defaults).
- **`settings/skbuild_read_settings.py`** — wires providers into `toml_srcs` (insert for `override`, append for `default`), runs `process_overrides` per table, strips `minimum-version` (ep config is environment policy, not project semantics), honors the opt-out env var, and rebuilds `print_suggestions` source-naming via a parallel `_toml_src_names`.
- **`_compat/importlib/metadata.py`** — made the `<3.10` `entry_points` shim robust to the modern selectable object (fixes test failures my code newly exercises when tests simulate Python 3.9).
- **`tests/test_entrypoint_config.py`** (new) — both levels, dict merge, env-matched overrides (#915), opt-out, override-only rejection, suggestions naming, zero-arg providers, sorted-name determinism, `minimum-version` stripping.
- **`docs/configuration/entrypoint_config.md`** (new) + toctree.

## Notes for review

- No changelog entry: that file is per-release/PR-numbered (generated at release), so a manual entry seemed out of place.
- **Design choice to confirm:** `override` is placed *above* `extra_settings` (hatchling's injected config), on the reasoning that distro environment policy should beat project-author static config regardless of frontend. Easy to flip if you'd prefer it below.