### PR TITLE
docs: fix RTD version and render GitHub-style admonitions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
+  jobs:
+    post_checkout:
+      # RTD does a shallow clone, hiding the release tag from hatch-vcs and
+      # producing a bogus 0.1.devN version. Fetch full history + tags.
+      - git fetch --unshallow --tags || true
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,6 +189,7 @@ html_css_files = [
 
 # -- Extension configuration -------------------------------------------------
 myst_enable_extensions = [
+    "alert",  # GitHub-style > [!NOTE] blockquote admonitions
     "colon_fence",
     "substitution",
     "deflist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,10 @@ docs = [
     "erbsland-sphinx-ansi <1.2; python_version>='3.10'",
     "furo",
     "hatchling",
-    "myst-parser >=0.13",
+    # 5.1 adds the "alert" extension (GitHub-style admonitions); it needs 3.11+,
+    # and docs only build on modern Python, so keep an older floor elsewhere.
+    "myst-parser >=5.1; python_version>='3.11'",
+    "myst-parser >=0.13; python_version<'3.11'",
     "setuptools",
     "sphinx >=7.0",
     "sphinx-autodoc-typehints != 3.9.6",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two docs fixes.

## 1. Read the Docs shows `0.1.dev50` everywhere

The version comes from hatch-vcs (`version.source = "vcs"`), which reads the last git tag. RTD does a **shallow** clone (default depth 50 — which is exactly why the bogus version is `0.1.dev50`), so the tag isn't reachable and hatch-vcs falls back.

Added a `post_checkout` job to `.readthedocs.yml` to fetch full history + tags:

```yaml
build:
  jobs:
    post_checkout:
      - git fetch --unshallow --tags || true
```

## 2. GitHub-style alerts render as plain blockquotes

`> [!WARNING]` / `> [!NOTE]` from the included `README.md` were showing as blockquotes instead of admonitions. myst-parser 5.1 added an `"alert"` extension that renders these as Sphinx admonitions, keeping the README rendering consistent on both GitHub and the docs site.

- Enabled `"alert"` in `docs/conf.py`.
- Bumped `myst-parser >=5.1` in `pyproject.toml`, gated on `python_version>='3.11'` (5.1 needs 3.11+; the project still supports 3.8, and docs only build on modern Python).

Verified locally by building the docs: no warnings, and the included README warning now renders as `class="admonition warning"`.
