### PR TITLE
feat(editable): expose rebuild() on inplace editable loaders

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -908,10 +908,10 @@ etc. Also, to make your binaries importable, you should set
 `$<0:>` for multi-config generator support, like MSVC, so you don't have to set
 all possible `*_<CONFIG>` variations) to make sure they are placed inside your
 source directory inside the Python packages; this will be run from the build
-directory, rather than installed. This will also not support automatic rebuilds.
-The build directory setting will be ignored if you use this and perform an
-editable install. You can detect this mode by checking for an in-place build and
-checking `SKBUILD` being set.
+directory, rather than installed. The build directory setting will be ignored if
+you use this and perform an editable install (the source directory doubles as
+the build directory). You can detect this mode by checking for an in-place build
+and checking `SKBUILD` being set.
 
 With all the caveats, this is very logically simple (one directory) and a near
 identical replacement for `python setup.py build_ext --inplace`. Some third
@@ -920,6 +920,9 @@ install a `.pth` file that points at your source package(s) and do an inplace
 CMake build.
 
 On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
+Inplace installs support both automatic (`editable.rebuild`) and manual rebuilds
+(see below); since the source directory doubles as the build directory, no
+separate `build-dir` is needed.
 
 :::
 
@@ -927,10 +930,9 @@ On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
 
 ### Triggering a rebuild manually
 
-You don't have to enable `editable.rebuild` to rebuild on demand for the
-redirect mode. The redirecting finder installs a loader for each redirected
-module, and that loader exposes a `rebuild()` method, so you can run the same
-`cmake --build`/`--install` cycle whenever you like:
+You don't have to enable `editable.rebuild` to rebuild on demand. Both editable
+modes install a loader that exposes a `rebuild()` method, so you can recompile
+whenever you like:
 
 ```python
 import some_package
@@ -938,28 +940,43 @@ import some_package
 some_package.__loader__.rebuild()
 ```
 
-This works for any importable object the editable install provides -- a package,
-a plain module, or a compiled extension. A rebuild needs a persistent build
-directory to run in, so install with a `build-dir` set:
+For redirect installs this runs the same `cmake --build`/`--install` cycle used
+by the automatic rebuild, and works for any importable object the install
+provides -- a package, a plain module, or a compiled extension. A redirect
+rebuild needs a persistent build directory, so install with a `build-dir` set:
 
 ```console
 $ pip install --no-build-isolation -Cbuild-dir=build -ve .
 ```
 
-If the editable install was built without a persistent `build-dir`, there is
+If a redirect editable was built without a persistent `build-dir`, there is
 nothing to rebuild and the call raises `RuntimeError`.
 
+For inplace installs, `rebuild()` runs `cmake --build` in the source tree (there
+is no install step); the source directory is always the build directory, so no
+`build-dir` is required.
+
 If you don't have a handle on a redirected module, the finder itself is on
-`sys.meta_path` and carries the same method:
+`sys.meta_path` and carries the same method (`ScikitBuildRedirectingFinder` for
+redirect installs, `ScikitBuildInplaceFinder` for inplace):
 
 ```python
 import sys
 
 finder = next(
-    f for f in sys.meta_path if type(f).__name__ == "ScikitBuildRedirectingFinder"
+    f
+    for f in sys.meta_path
+    if type(f).__name__ in {"ScikitBuildRedirectingFinder", "ScikitBuildInplaceFinder"}
 )
 finder.rebuild()
 ```
+
+:::{versionadded} 1.0
+
+Manual `__loader__.rebuild()` for redirect installs, and both manual and
+automatic (`editable.rebuild`) rebuilds for inplace installs.
+
+:::
 
 ## Messages
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -436,7 +436,8 @@ print(mk_skbuild_docs())
 
   Rebuild the project when the package is imported.
 
-  :confval:`build-dir` must be set.
+  :confval:`build-dir` must be set, except in ``inplace`` mode (where the source
+  directory is the build directory).
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "collect_search_locations",
+    "editable_inplace",
     "editable_inplace_files",
     "editable_redirect",
     "editable_redirect_files",
@@ -165,8 +166,92 @@ def editable_redirect_files(
     return files
 
 
-def editable_inplace_files(*, name: str, packages: Iterable[str]) -> dict[str, bytes]:
-    return {f"_editable_skbc_{name}.pth": "\n".join(packages).encode()}
+def editable_inplace(
+    *,
+    known_packages: Sequence[str],
+    search_paths: Sequence[str],
+    path: str | None,
+    rebuild: bool,
+    verbose: bool,
+    build_options: Sequence[str],
+    as_entrypoint: bool = False,
+) -> str:
+    """
+    Prepare the contents of the inplace editable shim.
+
+    Like :func:`editable_redirect` but appends an ``install_inplace(...)`` call
+    (or an ``entrypoint()`` wrapper for PEP 829 ``.start`` files). The finder it
+    installs leaves import resolution to Python and only adds
+    ``module.__loader__.rebuild()`` to the inplace-built packages.
+    """
+    editable_py = resources / "_editable_redirect.py"
+    editable_txt: str = editable_py.read_text(encoding="utf-8")
+
+    arguments = (
+        list(known_packages),
+        list(search_paths),
+        path,
+        rebuild,
+        verbose,
+        list(build_options),
+    )
+    arguments_str = ", ".join(repr(x) for x in arguments)
+    if as_entrypoint:
+        editable_txt += (
+            f"\n\ndef entrypoint() -> None:\n    install_inplace({arguments_str})\n"
+        )
+    else:
+        editable_txt += f"\n\ninstall_inplace({arguments_str})\n"
+    return editable_txt
+
+
+def editable_inplace_files(
+    *,
+    name: str,
+    packages: Mapping[str, str],
+    package_paths: Sequence[str],
+    source_dir: Path | None,
+    build_options: Sequence[str] = (),
+    settings: ScikitBuildSettings,
+    use_start: bool | None = None,
+) -> dict[str, bytes]:
+    """
+    Build the inplace editable files for a package.
+
+    Emits a shim that installs a finder exposing ``module.__loader__.rebuild()``
+    (and, when :confval:`editable.rebuild` is on, rebuilds on first import), plus
+    a ``.pth`` adding the package source directories to ``sys.path``. Mirrors the
+    file/``use_start`` layout of :func:`editable_redirect_files`.
+    """
+    if use_start is None:
+        use_start = sys.version_info >= (3, 15)
+    known_packages = sorted({Path(v).name for v in packages.values()})
+    editable_txt = editable_inplace(
+        known_packages=known_packages,
+        search_paths=list(package_paths),
+        path=os.fspath(source_dir) if source_dir else None,
+        rebuild=settings.editable.rebuild_enabled,
+        verbose=settings.editable.verbose,
+        build_options=build_options,
+        as_entrypoint=use_start,
+    )
+    package_lines = list(package_paths)
+    files = {f"_editable_skbc_{name}.py": editable_txt.encode()}
+    if use_start:
+        # PEP 829: the import callable lives in a UTF-8-sig encoded .start file,
+        # and the .pth carries only sys.path entries (if any).
+        files[f"_editable_skbc_{name}.start"] = (
+            f"_editable_skbc_{name}:entrypoint".encode("utf-8-sig")
+        )
+        if package_lines:
+            files[f"_editable_skbc_{name}.pth"] = "\n".join(
+                [*package_lines, ""]
+            ).encode()
+    else:
+        files[f"_editable_skbc_{name}.pth"] = "\n".join(
+            [f"import _editable_skbc_{name}", *package_lines, ""]
+        ).encode()
+    return files
 
 
 def get_packages(

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -225,7 +225,11 @@ def editable_inplace_files(
     """
     if use_start is None:
         use_start = sys.version_info >= (3, 15)
-    known_packages = sorted({Path(v).name for v in packages.values()})
+    # The importable top-level name is the entry's leaf with any module suffix
+    # stripped -- a package dir keeps its name (``mypkg``), a single-module entry
+    # drops the extension (``hello.py`` -> ``hello``, #888) so it matches the
+    # finder's ``fullname.partition(".")[0]`` check.
+    known_packages = sorted({Path(v).name.partition(".")[0] for v in packages.values()})
     editable_txt = editable_inplace(
         known_packages=known_packages,
         search_paths=list(package_paths),

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -545,7 +545,11 @@ def _build_wheel_impl_impl(
 
                 for filename, editable_contents in editable_inplace_files(
                     name=normalized_name,
-                    packages=str_pkgs,
+                    packages=packages,
+                    package_paths=list(str_pkgs),
+                    source_dir=build_dir.resolve(),
+                    build_options=build_options,
+                    settings=settings,
                 ).items():
                     wheel.writestr(filename, editable_contents)
 

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -280,7 +280,11 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                     raise AssertionError(msg)
                 editable_files = editable_inplace_files(
                     name=normalized_name,
-                    packages=package_paths,
+                    packages=packages,
+                    package_paths=package_paths,
+                    source_dir=build_dir.resolve(),
+                    build_options=build_options,
+                    settings=settings,
                 )
 
             editable_dir = self.__tmp_dir / "editable"

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -331,11 +331,19 @@ def _run_editable_rebuild(
     # path never reaches this with path unset; only a manual
     # module.__loader__.rebuild() on a non-rebuildable editable can.
     if not path:
-        msg = (
-            "Cannot rebuild: this editable install has no persistent build "
-            "directory. Reinstall with a 'build-dir' set (e.g. "
-            "-Cbuild-dir=build) to enable on-demand rebuilds."
-        )
+        if install_dir is None:
+            # Inplace: the source tree is the build dir, so 'build-dir' does not
+            # apply -- a missing path just means we have no source directory.
+            msg = (
+                "Cannot rebuild: this inplace editable install has no known "
+                "source directory to rebuild in."
+            )
+        else:
+            msg = (
+                "Cannot rebuild: this editable install has no persistent build "
+                "directory. Reinstall with a 'build-dir' set (e.g. "
+                "-Cbuild-dir=build) to enable on-demand rebuilds."
+            )
         raise RuntimeError(msg)
 
     env = os.environ.copy()
@@ -688,6 +696,7 @@ def install_inplace(
     :param rebuild: Whether to rebuild on first import
     :param verbose: Whether to print the cmake commands (also controlled by the
                     SKBUILD_EDITABLE_VERBOSE environment variable)
+    :param build_options: Extra options passed to ``cmake --build``
     """
     # Dedupe as install() does (PEP 829 .start files may run twice), keyed to
     # this package's own maps so several inplace editables can share an env.

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -17,7 +17,7 @@ DIR = os.path.abspath(os.path.dirname(__file__))
 MARKER = "SKBUILD_EDITABLE_SKIP"
 VERBOSE = "SKBUILD_EDITABLE_VERBOSE"
 
-__all__ = ["install"]
+__all__ = ["install", "install_inplace"]
 
 
 def __dir__() -> list[str]:
@@ -209,7 +209,11 @@ class _ScikitBuildLoaderWrapper:
     ``module.__loader__.rebuild()`` without enabling ``editable.rebuild``.
     """
 
-    def __init__(self, loader: object, finder: ScikitBuildRedirectingFinder) -> None:
+    def __init__(
+        self,
+        loader: object,
+        finder: ScikitBuildRedirectingFinder | ScikitBuildInplaceFinder,
+    ) -> None:
         self._skbuild_loader = loader
         self._skbuild_finder = finder
 
@@ -304,6 +308,87 @@ def _patch_importlib_resources_for_python39() -> None:
 
     _common.fallback_resources = fallback_resources
     _common._skbuild_editable_patched = True  # pylint: disable=protected-access
+
+
+def _run_editable_rebuild(
+    *,
+    path: str | None,
+    verbose: bool,
+    build_options: list[str],
+    install_options: list[str],
+    install_dir: str | None,
+) -> None:
+    """
+    Run the CMake build (and, unless ``install_dir`` is None, install) that
+    refreshes an editable install.
+
+    ``install_dir`` is None for inplace editables, which compile directly into
+    the source tree and have no separate install step -- they run ``cmake
+    --build`` only.
+    """
+    # Without a persistent build directory there is nothing to rebuild.
+    # Enabling auto-rebuild already requires a build-dir, so the import-time
+    # path never reaches this with path unset; only a manual
+    # module.__loader__.rebuild() on a non-rebuildable editable can.
+    if not path:
+        msg = (
+            "Cannot rebuild: this editable install has no persistent build "
+            "directory. Reinstall with a 'build-dir' set (e.g. "
+            "-Cbuild-dir=build) to enable on-demand rebuilds."
+        )
+        raise RuntimeError(msg)
+
+    env = os.environ.copy()
+    # Protect against recursion
+    if path in env.get(MARKER, "").split(os.pathsep):
+        return
+
+    env[MARKER] = os.pathsep.join((env.get(MARKER, ""), path))
+
+    verbose = verbose or bool(env.get(VERBOSE, ""))
+    if env.get(VERBOSE, "") == "0":
+        verbose = False
+    if verbose:
+        action = "cmake --build" if install_dir is None else "cmake --build & --install"
+        print(f"Running {action} in {path}")  # noqa: T201
+
+    def run_checked(command: list[str]) -> None:
+        result = subprocess.run(
+            command,
+            cwd=path,
+            stdout=sys.stderr if verbose else subprocess.PIPE,
+            env=env,
+            check=False,
+            text=True,
+        )
+        # When verbose, output was already streamed live to stderr. When not
+        # verbose, stdout was captured, so surface it here so build errors
+        # (e.g. from MSBuild, which writes to stdout) are not lost.
+        if result.returncode and not verbose:
+            print(  # noqa: T201
+                f"ERROR: {result.stdout}",
+                file=sys.stderr,
+            )
+        result.check_returncode()
+
+    lock = FileLockIfUnix(os.path.join(path, "editable_rebuild.lock"))
+
+    try:
+        lock.acquire()
+        run_checked(["cmake", "--build", ".", *build_options])
+        if install_dir is not None:
+            run_checked(
+                [
+                    "cmake",
+                    "--install",
+                    ".",
+                    "--prefix",
+                    install_dir,
+                    *install_options,
+                ]
+            )
+    finally:
+        lock.release()
 
 
 class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
@@ -441,67 +526,83 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         return spec
 
     def rebuild(self) -> None:
-        # Without a persistent build directory there is nothing to rebuild.
-        # Enabling auto-rebuild already requires a build-dir, so the import-time
-        # path never reaches this with path unset; only a manual
-        # module.__loader__.rebuild() on a non-rebuildable editable can.
-        if not self.path:
-            msg = (
-                "Cannot rebuild: this editable install has no persistent build "
-                "directory. Reinstall with a 'build-dir' set (e.g. "
-                "-Cbuild-dir=build) to enable on-demand rebuilds."
-            )
-            raise RuntimeError(msg)
+        _run_editable_rebuild(
+            path=self.path,
+            verbose=self.verbose,
+            build_options=self.build_options,
+            install_options=self.install_options,
+            install_dir=self.install_dir,
+        )
 
-        env = os.environ.copy()
-        # Protect against recursion
-        if self.path in env.get(MARKER, "").split(os.pathsep):
-            return
 
-        env[MARKER] = os.pathsep.join((env.get(MARKER, ""), self.path))
+class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
+    """
+    Meta path finder for inplace editable installs.
 
-        verbose = self.verbose or bool(env.get(VERBOSE, ""))
-        if env.get(VERBOSE, "") == "0":
-            verbose = False
-        if verbose:
-            print(f"Running cmake --build & --install in {self.path}")  # noqa: T201
+    Inplace editables compile extensions directly into the source tree and rely
+    on a plain ``.pth`` for import resolution. This finder does not change how
+    imports resolve -- it delegates to the standard ``PathFinder`` against the
+    same search locations -- but wraps the resolved loader so
+    ``module.__loader__.rebuild()`` can trigger a ``cmake --build`` in the source
+    tree (which is also the CMake build directory for inplace builds). Namespace
+    packages and imports outside the installed packages are left entirely to
+    native resolution.
+    """
 
-        def run_checked(command: list[str]) -> None:
-            result = subprocess.run(
-                command,
-                cwd=self.path,
-                stdout=sys.stderr if verbose else subprocess.PIPE,
-                env=env,
-                check=False,
-                text=True,
-            )
-            # When verbose, output was already streamed live to stderr. When not
-            # verbose, stdout was captured, so surface it here so build errors
-            # (e.g. from MSBuild, which writes to stdout) are not lost.
-            if result.returncode and not verbose:
-                print(  # noqa: T201
-                    f"ERROR: {result.stdout}",
-                    file=sys.stderr,
-                )
-            result.check_returncode()
+    def __init__(
+        self,
+        known_packages: list[str],
+        search_paths: list[str],
+        path: str | None,
+        rebuild: bool,
+        verbose: bool,
+        build_options: list[str],
+    ) -> None:
+        self.known_packages = frozenset(known_packages)
+        self.search_paths = search_paths
+        self.path = path
+        self.rebuild_flag = rebuild
+        self.rebuilt = False
+        self.verbose = verbose
+        self.build_options = build_options
 
-        lock = FileLockIfUnix(os.path.join(self.path, "editable_rebuild.lock"))
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: object = None,
+    ) -> ModuleSpec | None:
+        if fullname.partition(".")[0] not in self.known_packages:
+            return None
 
-        try:
-            lock.acquire()
-            run_checked(["cmake", "--build", ".", *self.build_options])
-            run_checked(
-                [
-                    "cmake",
-                    "--install",
-                    ".",
-                    "--prefix",
-                    self.install_dir,
-                    *self.install_options,
-                ]
-            )
-        finally:
-            lock.release()
+        # Debounce to once per process, like the redirect finder: importing a
+        # package resolves many submodules, but a single build covers them all.
+        if self.rebuild_flag and not self.rebuilt:
+            self.rebuilt = True
+            self.rebuild()
+
+        import importlib.machinery
+
+        # ``path`` is the parent package's __path__ for submodules, None for a
+        # top-level import; fall back to our recorded search locations.
+        search = self.search_paths if path is None else path
+        spec = importlib.machinery.PathFinder.find_spec(fullname, search)  # type: ignore[arg-type]
+        # Namespace packages have no concrete loader to wrap; leaving them to
+        # native resolution also avoids truncating a namespace whose parts span
+        # locations beyond our search paths.
+        if spec is None or spec.loader is None:
+            return None
+        spec.loader = _ScikitBuildLoaderWrapper(spec.loader, self)  # type: ignore[assignment]
+        return spec
+
+    def rebuild(self) -> None:
+        _run_editable_rebuild(
+            path=self.path,
+            verbose=self.verbose,
+            build_options=self.build_options,
+            install_options=[],
+            install_dir=None,
+        )
 
 
 def install(
@@ -562,5 +663,49 @@ def install(
             install_options or [],
             DIR,
             install_dir,
+        ),
+    )
+
+
+def install_inplace(
+    known_packages: list[str],
+    search_paths: list[str],
+    path: str | None = None,
+    rebuild: bool = False,
+    verbose: bool = False,
+    build_options: list[str] | None = None,
+) -> None:
+    """
+    Install a meta path finder for an inplace editable install.
+
+    Imports resolve natively (the finder delegates to PathFinder); the finder
+    only wraps the loader so ``module.__loader__.rebuild()`` runs ``cmake
+    --build`` in the source tree, and optionally rebuilds on first import.
+
+    :param known_packages: The top-level importable names to wrap
+    :param search_paths: The package parent directories (as added to sys.path)
+    :param path: The source directory (also the CMake build directory), or None
+    :param rebuild: Whether to rebuild on first import
+    :param verbose: Whether to print the cmake commands (also controlled by the
+                    SKBUILD_EDITABLE_VERBOSE environment variable)
+    """
+    # Dedupe as install() does (PEP 829 .start files may run twice), keyed to
+    # this package's own maps so several inplace editables can share an env.
+    for finder in sys.meta_path:
+        if (
+            isinstance(finder, ScikitBuildInplaceFinder)
+            and finder.known_packages == frozenset(known_packages)
+            and finder.search_paths == search_paths
+        ):
+            return
+    sys.meta_path.insert(
+        0,
+        ScikitBuildInplaceFinder(
+            known_packages,
+            search_paths,
+            path,
+            rebuild,
+            verbose,
+            build_options or [],
         ),
     )

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -581,12 +581,12 @@ class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
             self.rebuilt = True
             self.rebuild()
 
-        import importlib.machinery
+        from importlib.machinery import PathFinder
 
         # ``path`` is the parent package's __path__ for submodules, None for a
         # top-level import; fall back to our recorded search locations.
         search = self.search_paths if path is None else path
-        spec = importlib.machinery.PathFinder.find_spec(fullname, search)  # type: ignore[arg-type]
+        spec = PathFinder.find_spec(fullname, search)  # type: ignore[arg-type]
         # Namespace packages have no concrete loader to wrap; leaving them to
         # native resolution also avoids truncating a namespace whose parts span
         # locations beyond our search paths.

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -622,7 +622,8 @@ class EditableSettings:
     """
     Rebuild the project when the package is imported.
 
-    :confval:`build-dir` must be set.
+    :confval:`build-dir` must be set, except in ``inplace`` mode (where the source
+    directory is the build directory).
     """
 
     rebuild_dir: str = ""

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -362,9 +362,12 @@ class SettingsReader:
 
         if self.settings.editable.rebuild_enabled:
             if self.settings.editable.mode == "inplace":
-                rich_error("editable rebuild is incompatible with inplace mode")
-
-            if not self.settings.build_dir:
+                # Inplace builds in the source tree, which serves as the
+                # persistent build dir, so no separate build-dir is required.
+                # rebuild-dir relocates the install tree, which inplace lacks.
+                if self.settings.editable.rebuild_dir:
+                    rich_error("editable rebuild-dir is incompatible with inplace mode")
+            elif not self.settings.build_dir:
                 rich_error("editable mode with rebuild requires build-dir")
 
         install_policy = (

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -183,6 +183,31 @@ def test_editable_rebuild_dir(isolated, isolate):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.integration
+@pytest.mark.parametrize("package", ["simplest_c"], indirect=True)
+@pytest.mark.parametrize("isolate", {False}, indirect=True)
+@pytest.mark.usefixtures("package")
+def test_inplace_loader_rebuild(isolated, isolate):
+    # Inplace editables expose module.__loader__.rebuild(), which runs
+    # cmake --build in the source tree (editable verbose is on by default).
+    isolated.install(
+        "-v",
+        "--config-settings=editable.mode=inplace",
+        *isolate.flags,
+        "-e",
+        ".",
+        installer="pip",
+    )
+
+    out = isolated.execute(
+        "import simplest; simplest.__loader__.rebuild(); print('rebuilt')"
+    )
+    assert "Running cmake --build" in out
+    assert out.splitlines()[-1] == "rebuilt"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.integration
 @pytest.mark.parametrize("package", ["importlib_editable"], indirect=True)
 @pytest.mark.usefixtures("package")
 def test_direct_import(editable, isolated):
@@ -200,6 +225,14 @@ def test_direct_import(editable, isolated):
     isolated.execute("import pkg")
     isolated.execute("import pmod")
     isolated.execute("import emod")
+
+    if editable.mode:
+        # Both editable modes wrap the loader so module.__loader__.rebuild() is
+        # available on demand (redirect via #1403, inplace via its finder).
+        out = isolated.execute(
+            "import pkg; print(callable(getattr(pkg.__loader__, 'rebuild', None)))"
+        )
+        assert out.splitlines()[-1] == "True"
 
 
 @pytest.mark.compile

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -610,7 +610,7 @@ def test_inplace_rebuild_without_path_errors(tmp_path: Path):
         verbose=False,
         build_options=[],
     )
-    with pytest.raises(RuntimeError, match="no persistent build directory"):
+    with pytest.raises(RuntimeError, match="no known source directory"):
         finder.rebuild()
 
 

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import pytest
 
 from scikit_build_core.resources._editable_redirect import (
+    ScikitBuildInplaceFinder,
     ScikitBuildRedirectingFinder,
     install,
+    install_inplace,
 )
 
 
@@ -468,3 +470,162 @@ def test_mapping_to_modules_keeps_symlink_in_package_dir(tmp_path: Path):
     # into pkg.__path__ and make shared/unrelated.py importable as pkg.unrelated.
     assert Path(result["pkg.shared_mod"]).parent == pkg_src
     assert Path(result["pkg.shared_mod"]).parent != shared.resolve()
+
+
+def test_inplace_finder_rebuild_runs_build_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The inplace finder rebuilds with cmake --build only -- no cmake --install.
+
+    Inplace editables compile straight into the source tree, so there is no
+    install step (unlike the redirect finder, which runs both).
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,  # noqa: ARG001
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
+    )
+
+    finder = ScikitBuildInplaceFinder(
+        known_packages=["pkg"],
+        search_paths=[str(tmp_path / "src")],
+        path=str(tmp_path),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+    )
+    finder.rebuild()
+
+    assert len(calls) == 1
+    assert calls[0][:2] == ["cmake", "--build"]
+
+
+def test_inplace_loader_exposes_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An inplace-built module's loader exposes rebuild() and delegates the rest.
+
+    The finder does not change resolution (it delegates to PathFinder), it only
+    wraps the loader so module.__loader__.rebuild() works. Both the top-level
+    package and a submodule get wrapped.
+    """
+    import importlib
+
+    src = tmp_path / "src"
+    pkg_dir = src / "pkg"
+    pkg_dir.mkdir(parents=True)
+    init = pkg_dir / "__init__.py"
+    init.touch()
+    mod = pkg_dir / "mod.py"
+    mod.touch()
+    importlib.invalidate_caches()
+
+    finder = ScikitBuildInplaceFinder(
+        known_packages=["pkg"],
+        search_paths=[str(src)],
+        path=str(tmp_path),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+    )
+
+    calls = 0
+
+    def fake_rebuild() -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(finder, "rebuild", fake_rebuild)
+
+    pkg_spec = finder.find_spec("pkg")
+    assert pkg_spec is not None
+    assert pkg_spec.loader is not None
+    pkg_spec.loader.rebuild()  # type: ignore[attr-defined]
+    # Non-rebuild attributes still delegate to the real loader.
+    assert pkg_spec.loader.get_filename("pkg") == str(init)  # type: ignore[attr-defined]
+
+    # A submodule is resolved against the package __path__ and also wrapped.
+    mod_spec = finder.find_spec("pkg.mod", [str(pkg_dir)])
+    assert mod_spec is not None
+    assert mod_spec.loader is not None
+    mod_spec.loader.rebuild()  # type: ignore[attr-defined]
+
+    assert calls == 2
+
+
+def test_inplace_finder_ignores_unknown(tmp_path: Path):
+    """Imports outside the known packages fall through to native resolution."""
+    finder = ScikitBuildInplaceFinder(
+        known_packages=["pkg"],
+        search_paths=[str(tmp_path)],
+        path=str(tmp_path),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+    )
+    assert finder.find_spec("othermod") is None
+
+
+def test_inplace_import_time_rebuild_debounced(tmp_path: Path):
+    """With rebuild=True, importing a known package rebuilds once per process."""
+    finder = ScikitBuildInplaceFinder(
+        known_packages=["pkg"],
+        search_paths=[str(tmp_path)],
+        path=str(tmp_path),
+        rebuild=True,
+        verbose=False,
+        build_options=[],
+    )
+
+    calls = 0
+
+    def fake_rebuild() -> None:
+        nonlocal calls
+        calls += 1
+
+    finder.rebuild = fake_rebuild  # type: ignore[method-assign]
+
+    finder.find_spec("pkg")
+    finder.find_spec("pkg")
+    finder.find_spec("pkg.sub", [str(tmp_path)])
+
+    assert calls == 1
+
+
+def test_inplace_rebuild_without_path_errors(tmp_path: Path):
+    """rebuild() errors when there is no source/build dir (path=None)."""
+    finder = ScikitBuildInplaceFinder(
+        known_packages=["pkg"],
+        search_paths=[str(tmp_path)],
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+    )
+    with pytest.raises(RuntimeError, match="no persistent build directory"):
+        finder.rebuild()
+
+
+@pytest.mark.usefixtures("_restore_meta_path")
+def test_install_inplace_is_idempotent():
+    """install_inplace dedups its own finder (PEP 829 .start may run twice)."""
+
+    def count_finders() -> int:
+        return sum(isinstance(f, ScikitBuildInplaceFinder) for f in sys.meta_path)
+
+    assert count_finders() == 0
+    install_inplace(["pkg_a"], ["/src"])
+    assert count_finders() == 1
+    install_inplace(["pkg_a"], ["/src"])
+    assert count_finders() == 1
+    # A different package still registers its own finder.
+    install_inplace(["pkg_b"], ["/src"])
+    assert count_finders() == 2

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -10,6 +10,7 @@ import pytest
 
 from scikit_build_core.build._editable import (
     collect_search_locations,
+    editable_inplace_files,
     editable_redirect,
     editable_redirect_files,
     get_packages,
@@ -477,6 +478,79 @@ def test_editable_redirect_files_pep829_no_paths(tmp_path: Path):
     )
 
     assert set(files) == {"_editable_skbc_pkg.py", "_editable_skbc_pkg.start"}
+
+
+def test_editable_inplace_files_legacy_pth(tmp_path: Path):
+    files = editable_inplace_files(
+        name="pkg",
+        packages={"pkg": "src/pkg"},
+        package_paths=[str(tmp_path / "src")],
+        source_dir=tmp_path / "build",
+        settings=ScikitBuildSettings(),
+        use_start=False,
+    )
+
+    assert set(files) == {"_editable_skbc_pkg.py", "_editable_skbc_pkg.pth"}
+
+    pth = files["_editable_skbc_pkg.pth"].decode()
+    assert pth.splitlines()[0] == "import _editable_skbc_pkg"
+    assert str(tmp_path / "src") in pth
+
+    py = files["_editable_skbc_pkg.py"].decode()
+    # Inplace installs the rebuild-only finder, not the redirect one.
+    assert "\ninstall_inplace(" in py
+    assert "def entrypoint()" not in py
+    # The package leaf name is wrapped and the source dir is the rebuild path.
+    assert "'pkg'" in py
+    assert repr(str(tmp_path / "build")) in py
+
+
+def test_editable_inplace_files_pep829_start(tmp_path: Path):
+    files = editable_inplace_files(
+        name="pkg",
+        packages={"pkg": "src/pkg"},
+        package_paths=[str(tmp_path / "src")],
+        source_dir=tmp_path / "build",
+        settings=ScikitBuildSettings(),
+        use_start=True,
+    )
+
+    assert set(files) == {
+        "_editable_skbc_pkg.py",
+        "_editable_skbc_pkg.pth",
+        "_editable_skbc_pkg.start",
+    }
+
+    start = files["_editable_skbc_pkg.start"]
+    assert start == "_editable_skbc_pkg:entrypoint".encode("utf-8-sig")
+
+    pth = files["_editable_skbc_pkg.pth"].decode()
+    assert "import _editable_skbc_pkg" not in pth
+    assert str(tmp_path / "src") in pth
+
+    py = files["_editable_skbc_pkg.py"].decode()
+    assert "def entrypoint() -> None:" in py
+    assert "install_inplace(" in py
+
+
+def test_editable_inplace_files_bakes_rebuild_flag(tmp_path: Path):
+    from scikit_build_core.settings.skbuild_model import EditableSettings
+
+    files = editable_inplace_files(
+        name="pkg",
+        packages={"pkg": "src/pkg"},
+        package_paths=[str(tmp_path / "src")],
+        source_dir=tmp_path / "build",
+        settings=ScikitBuildSettings(
+            editable=EditableSettings(mode="inplace", rebuild=True, verbose=False)
+        ),
+        use_start=False,
+    )
+
+    # install_inplace args: known_packages, search_paths, path, rebuild, verbose,
+    # build_options -- so a rebuild-on-import editable bakes ..., True, False, [].
+    py = files["_editable_skbc_pkg.py"].decode()
+    assert f"{str(tmp_path / 'build')!r}, True, False, []" in py
 
 
 def test_editable_redirect_files_absolute_install_dir_no_rebuild(tmp_path: Path):

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -533,6 +533,25 @@ def test_editable_inplace_files_pep829_start(tmp_path: Path):
     assert "install_inplace(" in py
 
 
+def test_editable_inplace_files_module_entry(tmp_path: Path):
+    # A wheel.packages entry may point at a single module file (e.g. hello.py,
+    # #888). The finder matches fullname.partition(".")[0] (``hello``), so the
+    # wrapped name must be the module's import name, not the filename.
+    files = editable_inplace_files(
+        name="hello",
+        packages={"hello.py": "hello.py"},
+        package_paths=[str(tmp_path)],
+        source_dir=tmp_path,
+        settings=ScikitBuildSettings(),
+        use_start=False,
+    )
+
+    py = files["_editable_skbc_hello.py"].decode()
+    # install_inplace's first argument is the known_packages list.
+    assert "install_inplace(['hello']," in py
+    assert "hello.py" not in py.partition("install_inplace(")[2].partition("]")[0]
+
+
 def test_editable_inplace_files_bakes_rebuild_flag(tmp_path: Path):
     from scikit_build_core.settings.skbuild_model import EditableSettings
 

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -156,30 +156,28 @@ def test_hatchling_editable_wheel(editable_mode: str, tmp_path: Path) -> None:
             "utf-8"
         )
 
-    # PEP 829: redirect mode moves the import line into a .start file on 3.15+
+    # PEP 829: both modes move the import line into a .start file on 3.15+
     pep829 = sys.version_info >= (3, 15)
 
     assert "hatchling_example-0.1.0.dist-info/METADATA" in file_names
     assert "_editable_skbc_hatchling_example.pth" in file_names
     assert "Root-Is-Purelib: false" in wheel_metadata
-    if editable_mode == "redirect":
-        assert "_editable_skbc_hatchling_example.py" in file_names
-        assert f"hatchling_example/_core{ext_suffix}" in file_names
-        if pep829:
-            assert (
-                start_contents
-                == "_editable_skbc_hatchling_example:entrypoint".encode("utf-8-sig")
-            )
-            # The .pth keeps only the path entries, no import line
-            assert Path(pth_lines[0]).resolve().samefile(Path("src").resolve())
-        else:
-            assert start_contents is None
-            assert pth_lines[0] == "import _editable_skbc_hatchling_example"
-    else:
-        assert "_editable_skbc_hatchling_example.py" not in file_names
-        assert start_contents is None
-        assert f"hatchling_example/_core{ext_suffix}" not in file_names
+    # Both modes ship the shim (which installs the finder exposing rebuild());
+    # only redirect also ships the compiled extension (inplace builds it into
+    # the source tree).
+    assert "_editable_skbc_hatchling_example.py" in file_names
+    assert (f"hatchling_example/_core{ext_suffix}" in file_names) == (
+        editable_mode == "redirect"
+    )
+    if pep829:
+        assert start_contents == "_editable_skbc_hatchling_example:entrypoint".encode(
+            "utf-8-sig"
+        )
+        # The .pth keeps only the path entries, no import line
         assert Path(pth_lines[0]).resolve().samefile(Path("src").resolve())
+    else:
+        assert start_contents is None
+        assert pth_lines[0] == "import _editable_skbc_hatchling_example"
 
 
 @pytest.mark.compile

--- a/tests/test_pyproject_pep660.py
+++ b/tests/test_pyproject_pep660.py
@@ -32,21 +32,19 @@ def test_pep660_wheel(editable, tmp_path: Path):
         with zf.open("simplest-0.0.1.dist-info/METADATA") as f:
             metadata = f.read().decode("utf-8")
 
-    # PEP 829: redirect mode adds a .start file alongside the .pth on 3.15+
+    # PEP 829: both modes add a .start file alongside the .pth on 3.15+. Both
+    # ship the shim + .pth; only redirect also installs the `simplest` tree
+    # (inplace builds extensions into the source tree, so nothing is installed).
     pep829 = sys.version_info >= (3, 15)
     if editable.mode == "redirect":
         assert len(file_names) == (5 if pep829 else 4)
-    else:
-        assert len(file_names) == 2
-    assert "simplest-0.0.1.dist-info" in file_names
-    if editable.mode == "redirect":
         assert "simplest" in file_names
-        assert "_editable_skbc_simplest.py" in file_names
-        assert ("_editable_skbc_simplest.start" in file_names) == pep829
     else:
+        assert len(file_names) == (4 if pep829 else 3)
         assert "simplest" not in file_names
-        assert "_editable_skbc_simplest.py" not in file_names
-        assert "_editable_skbc_simplest.start" not in file_names
+    assert "simplest-0.0.1.dist-info" in file_names
+    assert "_editable_skbc_simplest.py" in file_names
+    assert ("_editable_skbc_simplest.start" in file_names) == pep829
     assert "_editable_skbc_simplest.pth" in file_names
 
     assert "Metadata-Version: 2.2" in metadata

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -1209,6 +1209,43 @@ def test_editable_rebuild_requires_build_dir(tmp_path: Path, trigger: str):
         SettingsReader.from_file(pyproject_toml)
 
 
+def test_editable_inplace_rebuild_allowed(tmp_path: Path):
+    # Inplace builds in the source tree, so editable.rebuild needs no build-dir.
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            editable.mode = "inplace"
+            editable.rebuild = true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    reader = SettingsReader.from_file(pyproject_toml)
+    assert reader.settings.editable.rebuild is True
+    assert reader.settings.editable.mode == "inplace"
+
+
+def test_editable_inplace_rebuild_dir_rejected(tmp_path: Path):
+    # rebuild-dir relocates the install tree, which inplace mode does not have.
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            editable.mode = "inplace"
+            editable.rebuild-dir = "tree"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml)
+
+
 def test_skbuild_override_static(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Extends the on-demand `module.__loader__.rebuild()` hook — added for **redirect** editables in #1403 — to **inplace** editable installs:

```python
import some_package

some_package.__loader__.rebuild()
```

For inplace, `rebuild()` runs `cmake --build` in the source tree (which *is* the CMake build directory for inplace builds). There is no `cmake --install` step, since inplace compiles extensions straight into the source tree.

Also lifts the previous restriction so import-time `editable.rebuild` is now allowed with `editable.mode = "inplace"`.

## How

- **Slim dedicated finder** (`resources/_editable_redirect.py`): new `ScikitBuildInplaceFinder` that does *not* change import resolution — it delegates to `importlib.machinery.PathFinder` against the same search locations the `.pth` adds — and only wraps the resolved loader in the existing `_ScikitBuildLoaderWrapper` to attach `rebuild()`. It returns `None` for imports outside the installed packages and for namespace packages (no concrete loader), so native resolution is untouched. Compiled submodules of a known package get the hook too.
- **Shared rebuild logic**: the redirect finder's `rebuild()` body is extracted into a module-level `_run_editable_rebuild(...)`; passing `install_dir=None` skips the `cmake --install` step (the inplace case), keeping the file-lock/recursion-guard logic in one place.
- **Generation** (`build/_editable.py`): new `editable_inplace(...)` appends an `install_inplace(...)` call (or a PEP 829 `entrypoint()` for `.start` files); `editable_inplace_files(...)` now emits the shim + `.pth`/`.start` mirroring `editable_redirect_files`, instead of just a bare `.pth`. Both build backends (`build/wheel.py`, `hatch/plugin.py`) pass the packages, source dir, and build options.
- **Settings** (`skbuild_read_settings.py`): `editable.mode=inplace` + `editable.rebuild=true` is now valid and needs no separate `build-dir`; `editable.rebuild-dir` stays rejected for inplace (it relocates the install tree, which inplace lacks).

## Notes / behavior change

Inplace editables now ship a `_editable_skbc_<name>.py` shim (+ `.start` on 3.15+) alongside the `.pth`, where before they shipped only the `.pth`. The `.pth` path entries are kept, so native resolution still works; the finder just adds the `rebuild()` hook.

## Tests

- Unit: finder rebuilds build-only (no `--install`), loader exposes `rebuild()` on package + submodule, ignores unknown imports, debounces import-time rebuild once per process, `install_inplace` dedup, and shim generation (legacy `.pth` / PEP 829 `.start` / baked rebuild flag).
- Settings: inplace + `rebuild` allowed; inplace + `rebuild-dir` rejected.
- Integration: `test_inplace_loader_rebuild` installs inplace and confirms `simplest.__loader__.rebuild()` actually runs `cmake --build`; `test_direct_import` asserts the loader exposes `rebuild()` in both modes. Updated `test_pep660_wheel` and `test_hatchling_editable_wheel` for the new inplace file set.

## Docs

Updated the "Triggering a rebuild manually" section and the inplace-mode note in `docs/configuration/index.md`; regenerated `docs/reference/configs.md`.

`prek` (ruff/mypy/blacken-docs/prettier/cog) clean; full non-network test suite passes.