### PR TITLE
refactor: use local TYPE_CHECKING = False instead of importing from typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,6 +346,7 @@ docstring-code-format = true
 "typing.Sequence".msg = "Use collections.abc.Sequence instead."
 "typing.Set".msg = "Use collections.abc.Set instead."
 "typing.Self".msg = "Use scikit_build_core._compat.typing.Self instead."
+"typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING = False instead."
 "typing_extensions.Self".msg = "Use scikit_build_core._compat.typing.Self instead."
 "typing.assert_never".msg = "Add scikit_build_core._compat.typing.assert_never instead."
 "tomli".msg = "Use scikit_build_core._compat.tomllib instead."

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import argparse
-from typing import TYPE_CHECKING
 
 from ._logging import rich_print
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
 

--- a/src/scikit_build_core/_check_extra.py
+++ b/src/scikit_build_core/_check_extra.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
@@ -9,6 +8,7 @@ from packaging.utils import canonicalize_name
 from ._compat import tomllib
 from ._logging import rich_warning
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -4,7 +4,9 @@ import importlib.metadata
 import sys
 import typing
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     if sys.version_info < (3, 10):
         from importlib.metadata import EntryPoint
 

--- a/src/scikit_build_core/_compat/setuptools/errors.py
+++ b/src/scikit_build_core/_compat/setuptools/errors.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import typing
+TYPE_CHECKING = False
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from setuptools.errors import SetupError
 else:
     try:

--- a/src/scikit_build_core/_compat/typing.py
+++ b/src/scikit_build_core/_compat/typing.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import sys
 import typing
 
+TYPE_CHECKING = False
+
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated, get_args, get_origin
 else:
     from typing import Annotated, get_args, get_origin
 
 if sys.version_info < (3, 11):
-    if typing.TYPE_CHECKING:
+    if TYPE_CHECKING:
         from typing_extensions import Self, assert_never
     else:
         Self = object
@@ -21,7 +23,7 @@ else:
     from typing import Self, assert_never
 
 if sys.version_info < (3, 13):
-    if typing.TYPE_CHECKING:
+    if TYPE_CHECKING:
         from typing_extensions import TypeVar
     else:
         # The final noqa is a false positive, see https://github.com/astral-sh/ruff/issues/22178

--- a/src/scikit_build_core/_logging.py
+++ b/src/scikit_build_core/_logging.py
@@ -9,8 +9,11 @@ import os
 import platform
 import sys
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import Any, Literal, NoReturn
 
+from . import __version__
+
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -19,8 +22,6 @@ if TYPE_CHECKING:
     StrMapping = Mapping[str, "Style"]
 else:
     StrMapping = Mapping
-
-from . import __version__
 
 __all__ = [
     "LEVEL_VALUE",

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import dataclasses
 import os
 import subprocess
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 from ._logging import logger
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/src/scikit_build_core/_variants.py
+++ b/src/scikit_build_core/_variants.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import dataclasses
 import importlib
 import re
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from ._vendor.pyproject_metadata import StandardMetadata
     from .settings.skbuild_model import ScikitBuildSettings

--- a/src/scikit_build_core/ast/ast.py
+++ b/src/scikit_build_core/ast/ast.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import dataclasses
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from .._logging import rich_print
 from .tokenizer import Token, TokenType, tokenize
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator
 

--- a/src/scikit_build_core/ast/tokenizer.py
+++ b/src/scikit_build_core/ast/tokenizer.py
@@ -5,10 +5,10 @@ import enum
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from .._logging import rich_print
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator
 

--- a/src/scikit_build_core/build/__init__.py
+++ b/src/scikit_build_core/build/__init__.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import contextlib
 import sys
-from typing import TYPE_CHECKING
 
 from .._compat import tomllib
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-import typing
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -16,7 +15,9 @@ from ._pathutil import (
     scantree,
 )
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from ..settings.skbuild_model import ScikitBuildSettings

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import contextlib
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import pathspec
 
 from .._logging import logger
 from ..format import pyproject_format
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -4,12 +4,13 @@ import importlib.machinery
 import os
 import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import pathspec
 
 from ._file_processor import EXCLUDE_LINES, each_unignored_file
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 

--- a/src/scikit_build_core/build/_scripts.py
+++ b/src/scikit_build_core/build/_scripts.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import re
-from typing import TYPE_CHECKING
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -12,7 +12,6 @@ import zipfile
 from email.message import Message
 from email.policy import EmailPolicy
 from pathlib import Path
-from typing import TYPE_CHECKING
 from zipfile import ZipInfo
 
 import pathspec
@@ -25,6 +24,7 @@ from .._reproducible import (
 )
 from .._variants import VARIANT_DIST_INFO_FILENAME
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from collections.abc import Set as AbstractSet

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import sysconfig
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from .._logging import logger, rich_print
 from ..builder.builder import (
@@ -29,6 +29,7 @@ from ..format import pyproject_format
 from ..settings.skbuild_model import normalize_build_types
 from ._pathutil import resolve_wheel_tree
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/scikit_build_core/build/generate.py
+++ b/src/scikit_build_core/build/generate.py
@@ -4,8 +4,8 @@ __all__ = ["generate_file_contents"]
 
 import dataclasses
 import string
-from typing import TYPE_CHECKING
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from .._vendor.pyproject_metadata import StandardMetadata
     from ..settings.skbuild_model import GenerateSettings

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from packaging.version import Version
 
@@ -18,6 +18,7 @@ from ..builder._load_provider import (
     process_legacy_dynamic_metadata,
 )
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from packaging.requirements import Requirement
 from packaging.tags import Tag
@@ -48,6 +48,7 @@ from .common_wheel_helpers import (
 from .generate import generate_file_contents
 from .metadata import get_standard_metadata
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 

--- a/src/scikit_build_core/builder/__main__.py
+++ b/src/scikit_build_core/builder/__main__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from .. import __version__
 from .._logging import rich_print
@@ -12,6 +11,7 @@ from .get_requires import GetRequires
 from .sysconfig import info_print as ip_sysconfig
 from .wheel_tag import WheelTag
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import argparse
 

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -10,7 +10,6 @@ from collections.abc import Iterator, Mapping
 from pathlib import Path
 from types import MappingProxyType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Literal,
     Protocol,
@@ -18,15 +17,6 @@ from typing import (
     get_args,
     runtime_checkable,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
-    from importlib.machinery import ModuleSpec
-    from types import ModuleType
-
-    StrMapping = Mapping[str, Any]
-else:
-    StrMapping = Mapping
 
 from ..metadata import (
     _ALL_FIELDS,
@@ -36,6 +26,16 @@ from ..metadata import (
     _LIST_STR_FIELDS,
     _SCALAR_FIELDS,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+    from importlib.machinery import ModuleSpec
+    from types import ModuleType
+
+    StrMapping = Mapping[str, Any]
+else:
+    StrMapping = Mapping
 
 __all__ = [
     "BUILD_STATES",

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -9,7 +9,7 @@ import shlex
 import sys
 import sysconfig
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .. import __version__
 from .._compat.importlib import metadata, resources
@@ -26,6 +26,7 @@ from .sysconfig import (
     get_soabi,
 )
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Mapping, Sequence
 

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -5,13 +5,13 @@ import shlex
 import subprocess
 import sys
 import sysconfig
-from typing import TYPE_CHECKING
 
 from .._logging import logger
 from ..errors import NinjaNotFoundError
 from ..program_search import best_program, get_make_programs, get_ninja_programs
 from .sysconfig import get_cmake_platform
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Mapping, MutableMapping
 

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -7,7 +7,7 @@ import os
 import shlex
 import sysconfig
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from packaging.tags import sys_tags
 
@@ -26,6 +26,7 @@ from ..settings.skbuild_read_settings import SettingsReader
 from ._load_provider import load_dynamic_metadata, load_provider
 from .generator import parse_generator
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
 

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import os
 import platform
 import re
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 
 from .._logging import logger
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -5,12 +5,13 @@ import os
 import sys
 import sysconfig
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import packaging.tags
 
 from .._logging import logger, rich_print
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Mapping

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -5,13 +5,13 @@ import itertools
 import os
 import sys
 import sysconfig
-from typing import TYPE_CHECKING
 
 import packaging.tags
 
 from .._logging import logger
 from .macos import get_macosx_deployment_target
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Iterable, Mapping, Sequence

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -10,7 +10,7 @@ import sys
 import sysconfig
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from packaging.version import Version
 
@@ -24,6 +24,7 @@ from .file_api.query import stateless_query
 from .file_api.reply import load_reply_dir
 from .program_search import Program, best_program, get_cmake_program, get_cmake_programs
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Mapping, Sequence
 

--- a/src/scikit_build_core/errors.py
+++ b/src/scikit_build_core/errors.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import subprocess
 

--- a/src/scikit_build_core/file_api/query.py
+++ b/src/scikit_build_core/file_api/query.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import argparse
 

--- a/src/scikit_build_core/format.py
+++ b/src/scikit_build_core/format.py
@@ -6,10 +6,11 @@ import dataclasses
 import sys
 import typing
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
 
 from .settings.skbuild_model import normalize_build_types
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Literal
 

--- a/src/scikit_build_core/init/__main__.py
+++ b/src/scikit_build_core/init/__main__.py
@@ -5,13 +5,13 @@ import dataclasses
 import string
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from packaging.utils import InvalidName, canonicalize_name
 
 from .._logging import rich_error, rich_print
 from ..resources import resources
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
 

--- a/src/scikit_build_core/metadata/__init__.py
+++ b/src/scikit_build_core/metadata/__init__.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import typing
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from collections.abc import Callable
 
 

--- a/src/scikit_build_core/metadata/fancy_pypi_readme.py
+++ b/src/scikit_build_core/metadata/fancy_pypi_readme.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .._compat import tomllib
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import functools
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from . import _process_dynamic_metadata
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/scikit_build_core/metadata/template.py
+++ b/src/scikit_build_core/metadata/template.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from typing import Any
 
 from . import _process_dynamic_metadata
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = ["dynamic_metadata"]
 

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -9,13 +9,14 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from typing import Literal, NamedTuple
 
 from packaging.version import InvalidVersion, Version
 
 from ._logging import logger, rich_print
 from ._shutil import Run
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 

--- a/src/scikit_build_core/settings/auto_requires.py
+++ b/src/scikit_build_core/settings/auto_requires.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -13,7 +13,9 @@ from packaging.version import Version
 from .. import __version__
 from .._compat.typing import Annotated, get_args, get_origin
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from collections.abc import Generator
 
 

--- a/src/scikit_build_core/settings/skbuild_docs_readme.py
+++ b/src/scikit_build_core/settings/skbuild_docs_readme.py
@@ -7,7 +7,9 @@ import typing
 from .documentation import mk_docs
 from .skbuild_model import ScikitBuildSettings
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from .documentation import DCDoc
 
 __all__ = ["mk_skbuild_docs"]

--- a/src/scikit_build_core/settings/skbuild_docs_sphinx.py
+++ b/src/scikit_build_core/settings/skbuild_docs_sphinx.py
@@ -13,7 +13,9 @@ from .._compat.typing import Annotated, get_args, get_origin
 from .documentation import mk_docs
 from .skbuild_model import ScikitBuildSettings
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from .documentation import DCDoc
 
 __all__ = ["mk_skbuild_docs"]

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -6,7 +6,7 @@ import platform
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import packaging.tags
 from packaging.specifiers import SpecifierSet
@@ -26,6 +26,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -6,7 +6,7 @@ import difflib
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -29,6 +29,7 @@ from .skbuild_model import (
 from .skbuild_overrides import process_overrides
 from .sources import ConfSource, EnvSource, Source, SourceChain, TOMLSource
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
 

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -87,7 +87,6 @@ from __future__ import annotations
 
 import dataclasses
 import os
-import typing
 from typing import Any, Literal, Protocol, TypeVar
 
 from .._compat.builtins import ExceptionGroup
@@ -100,7 +99,9 @@ from ..utils.typing import (
     process_union,
 )
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from fnmatch import fnmatchcase
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import setuptools
 from packaging.version import Version
@@ -23,6 +23,7 @@ from ..cmake import CMake, CMaker
 from ..settings.skbuild_model import normalize_build_types
 from ..settings.skbuild_read_settings import SettingsReader
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable
 

--- a/src/scikit_build_core/setuptools/wrapper.py
+++ b/src/scikit_build_core/setuptools/wrapper.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import setuptools
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
 
 from .._compat.setuptools.errors import SetupError
 from .._compat.typing import TypeVar
 from .build_cmake import WRAPPER_COMPAT
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 __all__ = ["setup"]
 

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -4,13 +4,13 @@ import json
 import shutil
 import sys
 import sysconfig
-from typing import TYPE_CHECKING
 
 import pytest
 
 from scikit_build_core._logging import rich_warning
 from scikit_build_core.build.__main__ import main
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_check_extra.py
+++ b/tests/test_check_extra.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING
 
 import pytest
 
 from scikit_build_core._check_extra import _has_extra, warn_missing_extra
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from scikit_build_core.__main__ import main
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -5,7 +5,6 @@ import shutil
 import sysconfig
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -16,6 +15,7 @@ from scikit_build_core.cmake import CMake, CMaker
 from scikit_build_core.errors import CMakeNotFoundError
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator
 

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -8,7 +8,7 @@ import textwrap
 import types
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from packaging.requirements import Requirement
@@ -26,6 +26,7 @@ from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
 from pathutils import contained
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Literal
 

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.machinery
 import sys
 import textwrap
-import typing
 from pathlib import Path
 from typing import NamedTuple
 
@@ -25,7 +24,9 @@ from scikit_build_core.build._pathutil import (
 )
 from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from conftest import VEnv
 
 # The bare extension-module suffix for this interpreter (.so on Unix, .pyd on

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -4,12 +4,13 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import pytest
 
 from scikit_build_core.build._file_processor import each_unignored_file
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator
 

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import tarfile
 import textwrap
 import zipfile
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,6 +13,7 @@ from scikit_build_core.build import (
     prepare_metadata_for_build_wheel,
 )
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from scikit_build_core.format import RootPathResolver, pyproject_format
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sysconfig
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,6 +12,7 @@ from scikit_build_core.build import (
 )
 from scikit_build_core.builder.get_requires import GetRequires
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pytest_subprocess import FakeProcess
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from packaging.utils import InvalidName
 
@@ -9,6 +7,7 @@ from scikit_build_core.__main__ import main
 from scikit_build_core._compat import tomllib
 from scikit_build_core.init.__main__ import BACKENDS, generate_project
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import platform
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pytest import CaptureFixture, MonkeyPatch
 
 import scikit_build_core._logging
 from scikit_build_core import __version__
 from scikit_build_core._logging import Style, colors, rich_print
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pytest import CaptureFixture, MonkeyPatch
 
 
 def test_colors_no_stdout(monkeypatch: MonkeyPatch):

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from scikit_build_core.builder.__main__ import main
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import pytest
 

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -12,7 +12,9 @@ import scikit_build_core.settings.skbuild_overrides
 from scikit_build_core.settings.skbuild_overrides import regex_match
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from pytest_subprocess import FakeProcess
 
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import shutil
 import stat
 import sys
-from typing import TYPE_CHECKING
 
 import pytest
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/utils/pathutils.py
+++ b/tests/utils/pathutils.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import contextlib
-import typing
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
     from pathlib import Path
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
- Ban `typing.TYPE_CHECKING` via ruff's `flake8-tidy-imports` banned-api and replace every occurrence with a local `TYPE_CHECKING = False` module-level constant (the trick already used in `resources/_editable_redirect.py`). mypy special-cases the name `TYPE_CHECKING` in `if` guards regardless of where it's bound, so this avoids importing `typing` at runtime purely for the guard.
- ~~`src/scikit_build_core/_compat/**` is left untouched (already exempt from the banned-api rule via per-file-ignores) since those shims need the real `typing.TYPE_CHECKING`.~~
- A handful of files had real imports following the `if TYPE_CHECKING:` guard; ruff's `E402` only recognizes the guard as import-prologue when `TYPE_CHECKING` comes from `from typing import TYPE_CHECKING`, so those guards were moved after all real imports to keep `E402` happy.

## Test plan
- [x] `prek -a --quiet` (ruff check/format, mypy, cog, sp-repo-review, etc.) passes
- [x] `nox -t gen` produces no diff
- [x] `nox -s tests` (non-isolated/virtualenv subset): 782 passed, 4 skipped