### PR TITLE
fix(setuptools): accept wheel-free-setuptools extra in plugin warning

### DIFF
--- a/src/scikit_build_core/_check_extra.py
+++ b/src/scikit_build_core/_check_extra.py
@@ -37,15 +37,16 @@ def _has_extra(reqlist: Iterable[str], extra: str) -> bool:
 
 
 def warn_missing_extra(
-    extra: str, *, pyproject_path: Path | str = "pyproject.toml"
+    extra: str, *alt_extras: str, pyproject_path: Path | str = "pyproject.toml"
 ) -> None:
     """
-    Warn if ``scikit-build-core[{extra}]`` is missing from
-    ``build-system.requires``.
+    Warn if none of ``scikit-build-core[{extra}]`` (or the ``alt_extras``
+    alternatives) are in ``build-system.requires``.
 
     The setuptools and hatchling plugins may eventually move to separate
     packages; depending on the extra keeps the plugin's requirements installed
-    if that happens.
+    if that happens. Any of the given extras satisfies the check (e.g. the
+    setuptools plugin accepts both ``setuptools`` and ``wheel-free-setuptools``).
     """
     path = Path(pyproject_path)
     if not path.is_file():
@@ -53,9 +54,13 @@ def warn_missing_extra(
     with path.open("rb") as f:
         pyproject = tomllib.load(f)
     reqlist = pyproject.get("build-system", {}).get("requires", [])
-    if not _has_extra(reqlist, extra):
+    extras = (extra, *alt_extras)
+    if not any(_has_extra(reqlist, e) for e in extras):
+        names = " or ".join(
+            f"{{bold}}scikit-build-core[{canonicalize_name(e)}]{{normal}}"
+            for e in extras
+        )
         rich_warning(
-            f"{{bold}}scikit-build-core[{extra}]{{normal}} is not in "
-            "build-system.requires. Add it to keep working if the plugin moves "
-            "to a separate package in the future."
+            f"{names} is not in build-system.requires. Add it to keep working "
+            "if the plugin moves to a separate package in the future."
         )

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -536,7 +536,7 @@ class BuildCMake(setuptools.Command):
         assert self.build_temp is not None
         assert self.plat_name is not None
 
-        warn_missing_extra("setuptools")
+        warn_missing_extra("setuptools", "wheel-free-setuptools")
 
         self.editable_mode = self._get_editable_mode()
         # run() is always a wheel or editable build; pass the matching state so

--- a/tests/test_check_extra.py
+++ b/tests/test_check_extra.py
@@ -18,6 +18,11 @@ if TYPE_CHECKING:
     [
         (["scikit-build-core[setuptools]"], "setuptools", True),
         (["scikit_build_core[Setuptools]>=1"], "setuptools", True),
+        (
+            ["scikit-build-core[Wheel_Free_Setuptools]"],
+            "wheel-free-setuptools",
+            True,
+        ),
         (['scikit-build-core[setuptools]; python_version>="3"'], "setuptools", True),
         (["scikit-build-core[hatchling]"], "hatchling", True),
         (["scikit-build-core", "setuptools"], "setuptools", False),
@@ -55,6 +60,24 @@ def test_warn_missing_extra_quiet(tmp_path: Path, capsys: CaptureFixture[str]) -
     path = _write_pyproject(tmp_path, '["scikit-build-core[setuptools]"]')
     warn_missing_extra("setuptools", pyproject_path=path)
     assert capsys.readouterr().err == ""
+
+
+def test_warn_missing_extra_alt_present(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    path = _write_pyproject(tmp_path, '["scikit-build-core[wheel-free-setuptools]"]')
+    warn_missing_extra("setuptools", "wheel-free-setuptools", pyproject_path=path)
+    assert capsys.readouterr().err == ""
+
+
+def test_warn_missing_extra_lists_alternatives(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    path = _write_pyproject(tmp_path, '["scikit-build-core", "setuptools"]')
+    warn_missing_extra("setuptools", "wheel-free-setuptools", pyproject_path=path)
+    err = capsys.readouterr().err
+    assert "scikit-build-core[setuptools]" in err
+    assert "scikit-build-core[wheel-free-setuptools]" in err
 
 
 def test_warn_missing_extra_no_pyproject(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The setuptools plugin warned that `scikit-build-core[setuptools]` was missing from `build-system.requires` even when the equivalent `wheel-free-setuptools` extra was declared.

## Changes

- **`_check_extra.py`** — `warn_missing_extra` now accepts alternative extras (`*alt_extras`). The check passes if *any* of them is present, and the warning lists all acceptable extras (normalized via `canonicalize_name`), e.g. `scikit-build-core[setuptools] or scikit-build-core[wheel-free-setuptools]`.
- **`setuptools/build_cmake.py`** — the plugin now calls `warn_missing_extra("setuptools", "wheel-free-setuptools")`.
- **`tests/test_check_extra.py`** — added coverage for the alternative extra satisfying the check, the warning listing both extras, and extra-name normalization.

The hatchling caller is unchanged.