### PR TITLE
feat(metadata): entry-point discovery for [[tool.dynamic-metadata]]

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -22,10 +22,14 @@ Support for the standard
 
 The standard, cross-backend way to configure plugins is the top-level
 `[[tool.dynamic-metadata]]` **ordered array of tables**. Each entry names a
-`provider` (a module, or `"<module>:<Class>"`); every other key is passed to
-that plugin as its settings. Entries run **in order**, so a later entry sees
-every field an earlier one produced (no dependency graph, no cycles), and a
-plugin can read an already-resolved field with `project[...]`.
+`provider`: either the **name** an installed plugin registers in the
+`dynamic_metadata.provider` entry-point group (scikit-build-core's built-ins
+register their module path, e.g. `scikit_build_core.metadata.regex`), or an
+inline `{ path, module }` table for a plugin living inside your own project.
+Every other key is passed to that plugin as its settings. Entries run **in
+order**, so a later entry sees every field an earlier one produced (no
+dependency graph, no cycles), and a plugin can read an already-resolved field
+with `project[...]`.
 
 ```toml
 [project]
@@ -39,12 +43,12 @@ input = "src/mypackage/__init__.py"
 ```
 
 The field-agnostic plugins (`regex`, `template`) can target any field, chosen
-with a `field` setting. A `provider-path` key may point at a local directory so
-a plugin can live inside your own project. Following [PEP 808][], a list or
-table field can be given a static value in `[project]` _and_ listed in
-`dynamic`, in which case a provider only **adds** to it; the single-value fields
-(`version`, `description`, `requires-python`, `license`, `readme`) cannot be
-both static and dynamic.
+with a `field` setting. An inline `provider = { path, module }` table (see
+[Custom plugins](#custom-plugins)) lets a plugin live inside your own project.
+Following [PEP 808][], a list or table field can be given a static value in
+`[project]` _and_ listed in `dynamic`, in which case a provider only **adds** to
+it; the single-value fields (`version`, `description`, `requires-python`,
+`license`, `readme`) cannot be both static and dynamic.
 
 [PEP 808]: https://peps.python.org/pep-0808/
 
@@ -67,8 +71,9 @@ unless `minimum-version` is set below `1.0`.
 ## Built-in plugins
 
 We provide some built-in plugins in `scikit_build_core.metadata`. These work in
-either mode, though they always require a `field =` key in the modern
-`[[tool.dynamic-metadata]]` mode.
+either mode with the same `provider` string (e.g.
+`scikit_build_core.metadata.regex`), though the modern
+`[[tool.dynamic-metadata]]` mode always requires a `field =` key.
 
 Third party plugins (like those inside the `dynamic-metadata` package) and
 custom plugins are fully supported in the new mode.
@@ -331,13 +336,18 @@ def dynamic_metadata(
 And several optional ones (`build_state`, `dynamic_wheel`, and
 `get_requires_for_dynamic_metadata`). You can optionally use a class, as well.
 
-To use a local plugin, you need to set both `provider` and `provider-path`:
+A plugin distributed as a package is referenced by the name it registers in the
+`dynamic_metadata.provider` entry-point group. A plugin that lives inside your
+own project instead uses an inline `{ path, module }` table — no packaging or
+entry point required:
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "my_plugin"
-provider-path = "helpers/plugins"
+provider = {path = "helpers/plugins", module = "my_plugin"}
 ```
+
+`module` may also be `"my_plugin:MyClass"` to load a class (instantiated with no
+arguments, so its hooks share state through `self`).
 
 ## `build-system.requires`: Scikit-build-core's `build.requires`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,14 @@ scikit-build-core = "scikit_build_core.__main__:main"
 "setuptools.finalize_distribution_options".scikit_build_entry = "scikit_build_core.setuptools.build_cmake:finalize_distribution_options"
 "validate_pyproject.tool_schema".scikit-build = "scikit_build_core.settings.skbuild_schema:get_skbuild_schema"
 hatch.scikit-build = "scikit_build_core.hatch.hooks"
+# New-style (dynamic-metadata 0.3) wrappers for the bundled plugins. The name
+# matches the module path used by the legacy tool.scikit-build.metadata table,
+# so one provider string works in both forms; it also keeps our names clear of
+# dynamic-metadata's own dynamic_metadata.* names in the shared group.
+"dynamic_metadata.provider"."scikit_build_core.metadata.regex" = "scikit_build_core.metadata.regex:Provider"
+"dynamic_metadata.provider"."scikit_build_core.metadata.template" = "scikit_build_core.metadata.template:Provider"
+"dynamic_metadata.provider"."scikit_build_core.metadata.setuptools_scm" = "scikit_build_core.metadata.setuptools_scm:Provider"
+"dynamic_metadata.provider"."scikit_build_core.metadata.fancy_pypi_readme" = "scikit_build_core.metadata.fancy_pypi_readme:Provider"
 
 
 [dependency-groups]

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -20,6 +20,7 @@ from typing import (
     Literal,
     Protocol,
     Union,
+    cast,
     get_args,
     runtime_checkable,
 )
@@ -47,6 +48,7 @@ __all__ = [
     "BUILD_STATES",
     "BuildState",
     "load_dynamic_metadata",
+    "load_entry_provider",
     "load_provider",
     "process_dynamic_metadata",
     "process_legacy_dynamic_metadata",
@@ -63,10 +65,6 @@ BuildState = Literal[
     "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
 ]
 BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
-
-# Per-entry keys consumed by the loader itself; everything else is plugin
-# settings, passed through verbatim to the provider.
-_RESERVED_KEYS = frozenset(["provider", "provider-path"])
 
 
 @runtime_checkable
@@ -169,20 +167,57 @@ def load_provider(
     return getattr(module, class_name)() if class_name else module
 
 
+def load_entry_provider(provider: str | Mapping[str, Any]) -> DMProtocols:
+    """Resolve a ``[[tool.dynamic-metadata]]`` provider (dynamic-metadata 0.3).
+
+    A string is a name registered in the ``dynamic_metadata.provider``
+    entry-point group; a class-valued entry point is instantiated, a
+    module-valued one used as-is. An inline table ``{path, module}`` names a
+    local in-project plugin: ``module`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) is
+    imported from the ``path`` directory via the same finder as ``load_provider``.
+
+    Unlike the deprecated ``tool.scikit-build.metadata`` table, a bare import
+    string is not accepted here -- an installed plugin is reached through its
+    entry point, a local one through the inline table.
+    """
+    if not isinstance(provider, str):
+        module = provider.get("module")
+        path = provider.get("path")
+        if not isinstance(module, str) or not isinstance(path, str):
+            msg = "A table provider must set string 'path' and 'module' keys"
+            raise TypeError(msg)
+        return load_provider(module, path)
+
+    from .._compat.importlib.metadata import entry_points
+
+    eps = entry_points(group="dynamic_metadata.provider")
+    matches = [ep for ep in eps if ep.name == provider]
+    if not matches:
+        import difflib
+
+        names = sorted(ep.name for ep in eps)
+        close = difflib.get_close_matches(provider, names, n=1)
+        hint = f"; did you mean {close[0]!r}?" if close else ""
+        msg = f"Unknown dynamic-metadata provider {provider!r}{hint}"
+        raise ModuleNotFoundError(msg)
+    obj: Any = matches[0].load()
+    return cast("DMProtocols", obj() if isinstance(obj, type) else obj)
+
+
 def load_dynamic_metadata(
     entries: Sequence[Mapping[str, Any]],
 ) -> Generator[tuple[DMProtocols, dict[str, Any]], None, None]:
     """Load each ``[[tool.dynamic-metadata]]`` entry's provider in order.
 
-    ``provider`` and ``provider-path`` are consumed here; the remaining keys are
-    returned as that provider's plugin settings.
+    ``provider`` is consumed here; the remaining keys are returned as that
+    provider's plugin settings.
     """
     for entry in entries:
         if "provider" not in entry:
             msg = "Each [[tool.dynamic-metadata]] entry must set a 'provider'"
             raise KeyError(msg)
-        settings = {k: v for k, v in entry.items() if k not in _RESERVED_KEYS}
-        provider = load_provider(entry["provider"], entry.get("provider-path"))
+        settings = {k: v for k, v in entry.items() if k != "provider"}
+        provider = load_entry_provider(entry["provider"])
         yield provider, settings
 
 
@@ -231,40 +266,6 @@ def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
     return merged_groups
 
 
-def _call_dynamic_metadata(
-    provider: DMProtocols,
-    settings: Mapping[str, Any],
-    snapshot: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Call a provider's ``dynamic_metadata`` hook, returning a project fragment.
-
-    Supports both the 0.3 hook ``dynamic_metadata(settings, project) -> dict``
-    and the legacy ``dynamic_metadata(field, settings[, project]) -> value``
-    used by scikit-build-core's bundled plugins. A legacy hook is detected by
-    its first parameter being named ``field``; the target field comes from the
-    entry's ``field`` setting and its scalar return is wrapped into a fragment.
-    """
-    # Legacy hooks have a different shape, so they are called untyped.
-    hook: Any = provider.dynamic_metadata
-    params = list(inspect.signature(hook).parameters)
-    if params and params[0] == "field":
-        field = settings.get("field")
-        if not isinstance(field, str):
-            msg = "This plugin requires a 'field' setting naming the target field"
-            raise RuntimeError(msg)
-        sub = {k: v for k, v in settings.items() if k != "field"}
-        if len(params) >= 3:
-            value = hook(field, sub, snapshot)
-        elif sub:
-            value = hook(field, sub)
-        else:
-            value = hook(field)
-        return {field: value}
-
-    fragment: dict[str, Any] = hook(settings, snapshot)
-    return fragment
-
-
 def process_dynamic_metadata(
     project: Mapping[str, Any],
     entries: Sequence[Mapping[str, Any]],
@@ -297,7 +298,7 @@ def process_dynamic_metadata(
     for provider, settings in load_dynamic_metadata(entries):
         if isinstance(provider, DynamicMetadataBuildStateProtocol):
             provider.build_state(build_state)
-        fragment = _call_dynamic_metadata(provider, settings, snapshot)
+        fragment: dict[str, Any] = provider.dynamic_metadata(settings, snapshot)
 
         for field in fragment:
             if field not in _ALL_FIELDS:

--- a/src/scikit_build_core/metadata/__init__.py
+++ b/src/scikit_build_core/metadata/__init__.py
@@ -5,7 +5,8 @@ import typing
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
+    from typing import Any
 
 
 __all__: list[str] = [
@@ -13,6 +14,7 @@ __all__: list[str] = [
     "_EXTENDABLE_FIELDS",
     "_SCALAR_FIELDS",
     "_process_dynamic_metadata",
+    "_require_field",
 ]
 
 
@@ -79,6 +81,26 @@ T = typing.TypeVar(
     "T",
     bound="str | list[str] | list[dict[str, str]] | dict[str, str] | dict[str, list[str]] | dict[str, dict[str, str]]",
 )
+
+
+def _require_field(
+    settings: Mapping[str, Any], *, default: str | None = None
+) -> tuple[str, dict[str, Any]]:
+    """Split the target ``field`` out of new-style (0.3) plugin settings.
+
+    The ``[[tool.dynamic-metadata]]`` table has no field key of its own, so a
+    single-value plugin names its target through a ``field`` setting. Returns the
+    field name and the remaining settings (``field`` removed) to forward to the
+    bundled legacy hook. ``default`` supplies the field for a fixed-target plugin
+    (e.g. ``setuptools_scm`` only sets ``version``).
+    """
+    field: Any = settings.get("field", default)
+    if not isinstance(field, str):
+        # Usually a *missing* setting (None), not a wrong type, so not TypeError.
+        msg = "This plugin requires a 'field' setting naming the target field"
+        raise RuntimeError(msg)  # noqa: TRY004
+    rest = {k: v for k, v in settings.items() if k != "field"}
+    return field, rest
 
 
 def _process_dynamic_metadata(field: str, action: Callable[[str], str], result: T) -> T:

--- a/src/scikit_build_core/metadata/fancy_pypi_readme.py
+++ b/src/scikit_build_core/metadata/fancy_pypi_readme.py
@@ -10,12 +10,14 @@ from pathlib import Path
 from typing import Any
 
 from .._compat import tomllib
+from . import _require_field
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 __all__ = [
+    "Provider",
     "dynamic_metadata",
     "get_requires_for_dynamic_metadata",
 ]
@@ -73,3 +75,24 @@ def get_requires_for_dynamic_metadata(
     _settings: dict[str, object] | None = None,
 ) -> list[str]:
     return ["hatch-fancy-pypi-readme>=23.2"]
+
+
+class Provider:
+    """New-style (dynamic-metadata 0.3) wrapper around :func:`dynamic_metadata`.
+
+    Registered as the ``scikit_build_core.metadata.fancy_pypi_readme`` entry
+    point; only the ``readme`` field is produced, so ``field`` defaults to
+    ``"readme"``.
+    """
+
+    @staticmethod
+    def dynamic_metadata(
+        settings: Mapping[str, Any],
+        project: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        field, rest = _require_field(settings, default="readme")
+        return {field: dynamic_metadata(field, rest, project)}
+
+    @staticmethod
+    def get_requires_for_dynamic_metadata(settings: Mapping[str, Any]) -> list[str]:
+        return get_requires_for_dynamic_metadata(dict(settings))

--- a/src/scikit_build_core/metadata/regex.py
+++ b/src/scikit_build_core/metadata/regex.py
@@ -7,13 +7,13 @@ import re
 from pathlib import Path
 from typing import Any
 
-from . import _process_dynamic_metadata
+from . import _process_dynamic_metadata, _require_field
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-__all__ = ["dynamic_metadata"]
+__all__ = ["Provider", "dynamic_metadata"]
 
 
 def __dir__() -> list[str]:
@@ -68,3 +68,19 @@ def dynamic_metadata(
     return _process_dynamic_metadata(
         field, functools.partial(_process, match, remove), result
     )
+
+
+class Provider:
+    """New-style (dynamic-metadata 0.3) wrapper around :func:`dynamic_metadata`.
+
+    Registered as the ``scikit_build_core.metadata.regex`` entry point; the
+    target field comes from a ``field`` setting instead of the legacy table key.
+    """
+
+    @staticmethod
+    def dynamic_metadata(
+        settings: Mapping[str, Any],
+        _project: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        field, rest = _require_field(settings)
+        return {field: dynamic_metadata(field, rest)}

--- a/src/scikit_build_core/metadata/setuptools_scm.py
+++ b/src/scikit_build_core/metadata/setuptools_scm.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-__all__ = ["dynamic_metadata", "get_requires_for_dynamic_metadata"]
+from . import _require_field
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+__all__ = ["Provider", "dynamic_metadata", "get_requires_for_dynamic_metadata"]
 
 
 def __dir__() -> list[str]:
@@ -52,3 +59,23 @@ def get_requires_for_dynamic_metadata(
     _settings: dict[str, object] | None = None,
 ) -> list[str]:
     return ["setuptools-scm"]
+
+
+class Provider:
+    """New-style (dynamic-metadata 0.3) wrapper around :func:`dynamic_metadata`.
+
+    Registered as the ``scikit_build_core.metadata.setuptools_scm`` entry point;
+    only the ``version`` field is produced, so ``field`` defaults to ``"version"``.
+    """
+
+    @staticmethod
+    def dynamic_metadata(
+        settings: Mapping[str, Any],
+        _project: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        field, rest = _require_field(settings, default="version")
+        return {field: dynamic_metadata(field, rest)}
+
+    @staticmethod
+    def get_requires_for_dynamic_metadata(settings: Mapping[str, Any]) -> list[str]:
+        return get_requires_for_dynamic_metadata(dict(settings))

--- a/src/scikit_build_core/metadata/template.py
+++ b/src/scikit_build_core/metadata/template.py
@@ -4,13 +4,13 @@ __lazy_modules__ = {"typing"}
 
 from typing import Any
 
-from . import _process_dynamic_metadata
+from . import _process_dynamic_metadata, _require_field
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-__all__ = ["dynamic_metadata"]
+__all__ = ["Provider", "dynamic_metadata"]
 
 
 def __dir__() -> list[str]:
@@ -40,3 +40,19 @@ def dynamic_metadata(
         lambda r: r.format(project=project),
         result,
     )
+
+
+class Provider:
+    """New-style (dynamic-metadata 0.3) wrapper around :func:`dynamic_metadata`.
+
+    Registered as the ``scikit_build_core.metadata.template`` entry point; the
+    target field comes from a ``field`` setting instead of the legacy table key.
+    """
+
+    @staticmethod
+    def dynamic_metadata(
+        settings: Mapping[str, Any],
+        project: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        field, rest = _require_field(settings)
+        return {field: dynamic_metadata(field, rest, project)}

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -118,8 +118,7 @@ name = "test"
 dynamic = ["version"]
 
 [[tool.dynamic-metadata]]
-provider = "state_plugin:DynamicMetadata"
-provider-path = "plugins"
+provider = {module = "state_plugin:DynamicMetadata", path = "plugins"}
 """
 
 STATE_PLUGIN = """

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -411,8 +411,7 @@ def test_array_dynamic_metadata(
             input = "version.txt"
 
             [[tool.dynamic-metadata]]
-            provider = "req_plugin"
-            provider-path = "local_plugins"
+            provider = {path = "local_plugins", module = "req_plugin"}
             """
         ),
         encoding="utf-8",
@@ -521,8 +520,8 @@ def test_legacy_does_not_mutate_input(
     assert project == {"name": "p", "dynamic": ["version"]}
 
 
-def test_array_legacy_plugin_requires_field() -> None:
-    """A bundled (legacy-signature) plugin in the array form needs a 'field'."""
+def test_array_plugin_requires_field() -> None:
+    """A bundled generic plugin in the array form needs a 'field' setting."""
     from scikit_build_core.builder._load_provider import process_dynamic_metadata
 
     with pytest.raises(RuntimeError, match="field"):

--- a/tests/test_dynamic_metadata_unit.py
+++ b/tests/test_dynamic_metadata_unit.py
@@ -3,13 +3,18 @@ from typing import Any
 
 import pytest
 
+from scikit_build_core._compat.importlib.metadata import entry_points
 from scikit_build_core.builder._load_provider import (
     load_provider,
     process_dynamic_metadata,
     process_legacy_dynamic_metadata,
 )
 from scikit_build_core.metadata import _process_dynamic_metadata
+from scikit_build_core.metadata.fancy_pypi_readme import Provider as FancyProvider
+from scikit_build_core.metadata.regex import Provider as RegexProvider
 from scikit_build_core.metadata.regex import dynamic_metadata as regex_dynamic_metadata
+from scikit_build_core.metadata.setuptools_scm import Provider as ScmProvider
+from scikit_build_core.metadata.template import Provider as TemplateProvider
 from scikit_build_core.metadata.template import (
     dynamic_metadata as template_dynamic_metadata,
 )
@@ -174,8 +179,8 @@ def test_load_provider_path_not_shadowed(
 
 
 def test_array_regex_via_field_setting() -> None:
-    # The bundled (legacy-signature) regex plugin works in the 0.3 array form;
-    # the adapter sources the target field from the entry's ``field`` setting.
+    # The bundled regex plugin is reached by its entry-point name in the 0.3
+    # array form; the new-style wrapper sources the target from ``field``.
     project = process_dynamic_metadata(
         {"name": "test", "version": "0.1.0", "dynamic": ["requires-python"]},
         [
@@ -254,7 +259,7 @@ def test_array_new_style_multi_field(tmp_path: Path) -> None:
     )
     project = process_dynamic_metadata(
         {"name": "t", "dynamic": ["version", "description"]},
-        [{"provider": "multi_prov", "provider-path": path}],
+        [{"provider": {"path": path, "module": "multi_prov"}}],
     )
     assert project["version"] == "1.2.3"
     assert project["description"] == "hi"
@@ -270,7 +275,7 @@ def test_array_pep808_add_only_list(tmp_path: Path) -> None:
     )
     project = process_dynamic_metadata(
         {"name": "t", "dependencies": ["torch"], "dynamic": ["dependencies"]},
-        [{"provider": "deps_prov", "provider-path": path}],
+        [{"provider": {"path": path, "module": "deps_prov"}}],
     )
     # Existing static entries kept first, provider additions appended.
     assert project["dependencies"] == ["torch", "numpy"]
@@ -285,7 +290,7 @@ def test_array_scalar_static_and_dynamic_raises(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="both statically and dynamically"):
         process_dynamic_metadata(
             {"name": "t", "version": "1.0", "dynamic": ["version"]},
-            [{"provider": "ver_prov", "provider-path": path}],
+            [{"provider": {"path": path, "module": "ver_prov"}}],
         )
 
 
@@ -298,7 +303,7 @@ def test_array_field_not_in_dynamic_raises(tmp_path: Path) -> None:
     with pytest.raises(KeyError, match="must be listed in project"):
         process_dynamic_metadata(
             {"name": "t", "dynamic": []},
-            [{"provider": "ver_prov2", "provider-path": path}],
+            [{"provider": {"path": path, "module": "ver_prov2"}}],
         )
 
 
@@ -314,7 +319,7 @@ def test_array_build_state_hook(tmp_path: Path) -> None:
     )
     project = process_dynamic_metadata(
         {"name": "t", "dynamic": ["version"]},
-        [{"provider": "state_prov:Provider", "provider-path": path}],
+        [{"provider": {"path": path, "module": "state_prov:Provider"}}],
         build_state="sdist",
     )
     assert project["version"] == "sdist"
@@ -335,3 +340,56 @@ def test_array_missing_provider_raises() -> None:
             {"name": "t", "dynamic": ["version"]},
             [{"field": "version"}],
         )
+
+
+def test_regex_provider_new_style() -> None:
+    # The new-style wrapper takes (settings, project) and reads the target from
+    # the ``field`` setting, returning a {field: value} fragment.
+    fragment = RegexProvider.dynamic_metadata(
+        {
+            "field": "requires-python",
+            "input": "pyproject.toml",
+            "regex": r"name = \"(?P<name>.+)\"",
+            "result": ">={name}",
+        },
+        {},
+    )
+    assert fragment == {"requires-python": ">=scikit_build_core"}
+
+
+def test_template_provider_new_style() -> None:
+    fragment = TemplateProvider.dynamic_metadata(
+        {"field": "requires-python", "result": ">={project[version]}"},
+        {"version": "0.1.0"},
+    )
+    assert fragment == {"requires-python": ">=0.1.0"}
+
+
+def test_provider_requires_field() -> None:
+    with pytest.raises(RuntimeError, match="requires a 'field' setting"):
+        RegexProvider.dynamic_metadata({"input": "pyproject.toml"}, {})
+
+
+def test_scm_provider_defaults_field_and_requires() -> None:
+    # setuptools_scm only ever sets version, so ``field`` defaults to "version".
+    assert ScmProvider.get_requires_for_dynamic_metadata({}) == ["setuptools-scm"]
+
+
+def test_fancy_provider_defaults_field_and_requires() -> None:
+    assert FancyProvider.get_requires_for_dynamic_metadata({}) == [
+        "hatch-fancy-pypi-readme>=23.2"
+    ]
+
+
+def test_bundled_providers_registered_as_entry_points() -> None:
+    eps = {
+        ep.name: ep.value
+        for ep in entry_points(group="dynamic_metadata.provider")
+        if ep.name.startswith("scikit_build_core.")
+    }
+    assert eps == {
+        "scikit_build_core.metadata.regex": "scikit_build_core.metadata.regex:Provider",
+        "scikit_build_core.metadata.template": "scikit_build_core.metadata.template:Provider",
+        "scikit_build_core.metadata.setuptools_scm": "scikit_build_core.metadata.setuptools_scm:Provider",
+        "scikit_build_core.metadata.fancy_pypi_readme": "scikit_build_core.metadata.fancy_pypi_readme:Provider",
+    }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adopts [dynamic-metadata 0.4.0](https://github.com/scikit-build/dynamic-metadata/releases/tag/v0.4.0)'s entry-point provider discovery for our 0.3 `[[tool.dynamic-metadata]]` array, and gives the bundled plugins modern-shaped wrappers so the array no longer has to sniff hook shapes to tell old plugins from new ones.

## Motivation

Our loader is a fork of dynamic-metadata's, and the array path used `inspect.signature` to detect legacy-shaped bundled plugins (`dynamic_metadata(field, settings[, project])`) vs the 0.3 shape (`dynamic_metadata(settings, project) -> dict`). Upstream 0.4.0 replaced the import-path + `provider-path` scheme with entry-point discovery under the `dynamic_metadata.provider` group, and dropped its own `setuptools_scm`/`fancy_pypi_readme` wrappers — so those live on our side now. Registering our bundled plugins as new-shape entry points lets us delete the sniffing.

## What changed

**1. New-shape `Provider` wrappers + entry points**
- New `Provider` classes wrap the existing legacy functions for `regex`, `template`, `setuptools_scm`, and `fancy_pypi_readme`. The legacy-shape functions are untouched, so the deprecated `tool.scikit-build.metadata` table keeps resolving them by module path.
- Registered in the shared `dynamic_metadata.provider` group under the **same name as the module path** (`scikit_build_core.metadata.regex`, …). This means one `provider` string works in both the array and the legacy table (simpler docs), and it keeps our names clear of dynamic-metadata's own `dynamic_metadata.*` names in the shared group. Because we're always the installed backend, these resolve with no extra `build-system.requires`.

**2. Entry-point + inline-table resolution for the array**
- `load_entry_provider`: a string is an entry-point name (unknown → `ModuleNotFoundError` with a "did you mean" suggestion); an inline `{path, module}` table imports a local in-project plugin via the existing path finder.
- Bare-import strings and the top-level `provider-path` key are dropped from the array **with no deprecation** — the 0.3 array had no users yet. The legacy `tool.scikit-build.metadata` table (module-path, old-shape) is entirely unchanged.

**3. Removed the sniffing**
- Deleted `_call_dynamic_metadata` and its signature inspection; the array now calls `provider.dynamic_metadata(settings, snapshot)` directly. Old-shape lives only in the legacy table.

Docs (`docs/configuration/dynamic.md`) and tests updated; because the array and legacy table now share the same `provider` string, the docs no longer distinguish two names.

## Notes for review

- The array fixture and a discovery test depend on the freshly-registered entry points, so a clean install is required (CI installs fresh; verified locally with a reinstall).
- No JSON-schema change: our schema only covers `tool.scikit-build`; the top-level `[[tool.dynamic-metadata]]` array is validated by dynamic-metadata's own `validate_pyproject` plugin, which already ships the `oneOf(string, {path, module})` shape.
- `prek` (ruff + mypy) clean; 65 metadata tests pass.

https://claude.ai/code/session_01EVUBUXJ3EoruaVSq75mYu3
