### PR TITLE
fix(builder): keep compiler wrappers when stripping sysconfig CC/CXX flags

### DIFF
--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -107,10 +107,17 @@ def get_default(cmake: CMake) -> str | None:
 
 def _strip_flags(compiler: str) -> str:
     """
-    Drop flag-like tokens (starting with "-") from a sysconfig compiler
-    string, keeping any leading compiler-wrapper tokens (e.g. "ccache gcc").
+    Keep only the leading non-flag tokens of a sysconfig compiler string
+    (e.g. a compiler wrapper such as "ccache gcc"), stopping at the first
+    flag-like token (starting with "-"). Tokens after that point are dropped
+    even if they don't start with "-" themselves, since they may be a flag's
+    value argument (e.g. "arm64" in "-arch arm64") rather than a wrapper.
     """
-    tokens = [tok for tok in shlex.split(compiler) if not tok.startswith("-")]
+    tokens = []
+    for tok in shlex.split(compiler):
+        if tok.startswith("-"):
+            break
+        tokens.append(tok)
     return " ".join(tokens)
 
 

--- a/src/scikit_build_core/builder/generator.py
+++ b/src/scikit_build_core/builder/generator.py
@@ -105,6 +105,15 @@ def get_default(cmake: CMake) -> str | None:
     return generator
 
 
+def _strip_flags(compiler: str) -> str:
+    """
+    Drop flag-like tokens (starting with "-") from a sysconfig compiler
+    string, keeping any leading compiler-wrapper tokens (e.g. "ccache gcc").
+    """
+    tokens = [tok for tok in shlex.split(compiler) if not tok.startswith("-")]
+    return " ".join(tokens)
+
+
 def set_environment_for_gen(
     generator: str | None,
     cmake: CMake,
@@ -143,21 +152,24 @@ def set_environment_for_gen(
         return {}
 
     # Set Python's recommended CC and CXX if not already set by the user. Only
-    # the executable is kept; sysconfig may append flags (e.g. "c++ -pthread"),
-    # which would otherwise leak into tools like autotools sub-builds. CMake adds
-    # any flags it needs itself. See #1330. A key the user manages via the
-    # ``env`` table is left alone (even when it resolves to nothing), letting
-    # CMake pick the compiler from ``PATH`` for projects whose compiler probes
-    # break on the sysconfig compiler. See #1367.
+    # leading non-flag tokens (the compiler, plus any wrapper such as "ccache
+    # gcc") are kept; sysconfig may append flags (e.g. "c++ -pthread"), which
+    # would otherwise leak into tools like autotools sub-builds. CMake adds
+    # any flags it needs itself. See #1330. Trailing flags are dropped but a
+    # leading wrapper is preserved, since CMake understands multi-word CC/CXX
+    # values (the second word becomes CMAKE_<LANG>_COMPILER_ARG1). See #1417.
+    # A key the user manages via the ``env`` table is left alone (even when it
+    # resolves to nothing), letting CMake pick the compiler from ``PATH`` for
+    # projects whose compiler probes break on the sysconfig compiler. See #1367.
     if "CC" not in env and "CC" not in env_managed_keys:
         cc = sysconfig.get_config_var("CC")
         if cc:
-            env["CC"] = shlex.split(cc)[0]
+            env["CC"] = _strip_flags(cc)
 
     if "CXX" not in env and "CXX" not in env_managed_keys:
         cxx = sysconfig.get_config_var("CXX")
         if cxx:
-            env["CXX"] = shlex.split(cxx)[0]
+            env["CXX"] = _strip_flags(cxx)
 
     if "Ninja" in (generator or "Ninja"):
         ninja = best_program(get_ninja_programs(), version=ninja_settings.version)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -957,6 +957,11 @@ def test_set_environment_for_gen_strips_cc_cxx_flags(
         ("c++ -pthread", "c++"),
         ("ccache gcc", "ccache gcc"),
         ("sccache cc -O2", "sccache cc"),
+        # macOS/PyPy sysconfig CC includes a flag with a non-flag-like value
+        # argument (e.g. "-arch arm64"); the value must not be mistaken for a
+        # wrapper token and kept. Regression test for the pypy-3.10 macOS CI
+        # failure on #1418.
+        ("gcc -pthread -arch arm64", "gcc"),
     ],
 )
 def test_set_environment_for_gen_keeps_compiler_wrappers(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -950,6 +950,42 @@ def test_set_environment_for_gen_strips_cc_cxx_flags(
     assert env["CXX"] == "c++"
 
 
+@pytest.mark.parametrize(
+    ("cc", "expected"),
+    [
+        ("gcc", "gcc"),
+        ("c++ -pthread", "c++"),
+        ("ccache gcc", "ccache gcc"),
+        ("sccache cc -O2", "sccache cc"),
+    ],
+)
+def test_set_environment_for_gen_keeps_compiler_wrappers(
+    monkeypatch: pytest.MonkeyPatch, cc: str, expected: str
+) -> None:
+    # sysconfig's CC/CXX may be prefixed with a compiler wrapper (e.g.
+    # "ccache gcc"), common with pyenv/Gentoo/self-built Pythons. Only
+    # flag-like tokens (leading "-") should be stripped, not the wrapper.
+    # Regression test for #1417 (broken by the flag-stripping in #1330/#1331).
+    from scikit_build_core.builder import generator as gen_mod
+    from scikit_build_core.program_search import Program
+    from scikit_build_core.settings.skbuild_model import NinjaSettings
+
+    fake_ninja = Program(Path("/usr/bin/ninja"), Version("1.11.0"))
+    monkeypatch.setattr(gen_mod, "get_ninja_programs", lambda: [fake_ninja])
+    config_vars = {"CC": cc, "CXX": cc}
+    monkeypatch.setattr(sysconfig, "get_config_var", config_vars.get)
+
+    env: dict[str, str] = {}
+    gen_mod.set_environment_for_gen(
+        "Ninja",
+        CMake(Version("3.30"), Path("cmake")),
+        env,
+        NinjaSettings(),
+    )
+    assert env["CC"] == expected
+    assert env["CXX"] == expected
+
+
 def test_set_environment_for_gen_sysconfig_compiler(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`set_environment_for_gen` sets `CC`/`CXX` from `sysconfig.get_config_var()` when the user hasn't configured one, keeping only `shlex.split(cc)[0]`. This regressed in #1331: on interpreters built with a compiler wrapper (`CC="ccache gcc"`, `"sccache cc"`, `"distcc gcc"` — common with pyenv, Gentoo, or self-built Pythons), it exports `CC=ccache`, which is not a working compiler on its own, so CMake's compiler identification fails at configure time.

#1331's intent (#1330) was only to strip trailing *flags* that sysconfig sometimes appends (e.g. `"c++ -pthread"`), which would otherwise leak into tools like autotools sub-builds. Truncating to the first token went further than necessary and also dropped legitimate leading wrapper tokens.

## Fix

Only drop tokens starting with `-`; keep all leading non-flag tokens (wrapper + compiler) and rejoin them with a space. CMake explicitly supports multi-word `CC`/`CXX` env values (the second word becomes `CMAKE_<LANG>_COMPILER_ARG1`), so `CC="ccache gcc"` continues to work correctly, while `"c++ -pthread"` still collapses to `"c++"`, preserving #1330's fix.

Single-token behavior (`"gcc"` → `"gcc"`) is unchanged.

Part of #1417.

## Testing

- Added a regression test (`test_set_environment_for_gen_keeps_compiler_wrappers` in `tests/test_builder.py`), parametrized over `"gcc"`, `"c++ -pthread"`, `"ccache gcc"`, `"sccache cc -O2"`. Confirmed it fails on `main` (for the two wrapper cases) before the fix.
- `uv run pytest tests/test_builder.py` — all pass.
- `prek -a --quiet` — clean (aside from a pre-existing local-only `check-sdist` diff from gitignored `uv.lock`/`.claude`, unrelated to this change).

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd