### PR TITLE
fix(hatch): ignore hatchling's reserved enable-by-default hook option

### DIFF
--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -79,6 +79,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         config_dict.pop("dependencies", None)
         config_dict.pop("require-runtime-dependencies", None)
         config_dict.pop("require-runtime-features", None)
+        config_dict.pop("enable-by-default", None)
 
         if state is None:
             state = typing.cast(

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -44,6 +44,27 @@ def test_hatchling_force_include_rejected() -> None:
         _validate_settings(pyproject)
 
 
+class _FakeHook:
+    def __init__(self, config: dict[str, object]) -> None:
+        self.config = config
+
+
+def test_hatchling_enable_by_default_ignored(tmp_path: Path, monkeypatch) -> None:
+    # enable-by-default is one of hatchling's own reserved build-hook options
+    # (read directly off the hook config by hatchling, see
+    # hatchling.builders.config.BuilderConfig.hook_config); scikit-build-core
+    # must strip it before handing the rest of the config to SettingsReader,
+    # or every enabled build fails validation (regression test, gh-1417).
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    fake_hook = _FakeHook({"enable-by-default": False})
+    reader = ScikitBuildHook._read_config(fake_hook, state="wheel")  # type: ignore[arg-type]
+    reader.validate_may_exit()
+
+
 def set_hatchling_editable_mode(mode: str) -> None:
     pyproject = Path("pyproject.toml")
     pyproject.write_text(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

Hatchling's `BuildHookInterface` treats `enable-by-default` as a reserved,
hook-level config option — it reads it directly off the hook's config dict
(`config.get("enable-by-default", True)`, see
`hatchling.builders.config.BuilderConfig.hook_config`) and never strips it.

`ScikitBuildHook._read_config` already pops the other three reserved
hatchling hook keys (`dependencies`, `require-runtime-dependencies`,
`require-runtime-features`) before handing the rest of the hook config to
`SettingsReader` as `extra_settings`, but it missed `enable-by-default`. When
that key is left in the config, it reaches `SettingsReader.validate_may_exit`
as an unrecognized option and every build — including the lightweight
`dependencies()` hook call — exits with `SystemExit(7)`:

```
ERROR: Unrecognized options in extra settings:
  enable-by-default
```

This breaks the documented pattern for on-demand builds:

```toml
[tool.hatch.build.targets.wheel.hooks.scikit-build]
enable-by-default = false
```

together with `HATCH_BUILD_HOOK_ENABLE_SCIKIT_BUILD=1`.

## Fix

Pop `enable-by-default` alongside the other reserved keys in
`ScikitBuildHook._read_config` (`src/scikit_build_core/hatch/plugin.py`). I
checked hatchling's `builders/config.py` for other hook-level reserved keys
read via `config.get(...)` on an individual hook's config dict, and
`enable-by-default`, `require-runtime-dependencies`, and
`require-runtime-features` are the only ones — all now handled.

## Testing

Added a regression test (`tests/test_hatchling.py::test_hatchling_enable_by_default_ignored`)
that calls `ScikitBuildHook._read_config` directly with
`enable-by-default` in the hook config and asserts `validate_may_exit()`
doesn't raise. Confirmed it fails with `SystemExit: 7` before the fix and
passes after.

`uv run pytest tests/ -k hatch -x -q -n auto` — 13 passed.
`prek -a --quiet` — clean (aside from the usual local `check-sdist` noise
from gitignored `uv.lock`/`.claude`).

Part of #1417.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd