### PR TITLE
docs: fix sdist.inclusion-mode name and dynamic-metadata field requirement

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -72,8 +72,10 @@ unless `minimum-version` is set below `1.0`.
 
 We provide some built-in plugins in `scikit_build_core.metadata`. These work in
 either mode with the same `provider` string (e.g.
-`scikit_build_core.metadata.regex`), though the modern
-`[[tool.dynamic-metadata]]` mode always requires a `field =` key.
+`scikit_build_core.metadata.regex`). In the modern `[[tool.dynamic-metadata]]`
+mode, a `field =` key is normally required, but it can be omitted for
+fixed-target plugins that declare a default: `setuptools_scm` defaults to
+`field = "version"` and `fancy_pypi_readme` defaults to `field = "readme"`.
 
 Third party plugins (like those inside the `dynamic-metadata` package) and
 custom plugins are fully supported in the new mode.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -134,7 +134,7 @@ The following behaviors are affected by `minimum-version`:
   replaced with `build.targets` and `build.verbose`. The CMake minimum version
   will be detected if not given.
 - `minimum-version` 0.12+ (or unset) uses `"default"` instead of `"classic"` as
-  the default for `sdist.include-mode`.
+  the default for `sdist.inclusion-mode`.
 - `minimum-version` 1.0+ (or unset) deprecates the `tool.scikit-build.metadata`
   table in favor of the standard top-level `[[tool.dynamic-metadata]]`; see
   [](./dynamic.md).
@@ -208,7 +208,7 @@ control this, without reading `.gitignore`, use:
 
 ```toml
 [tool.scikit-build]
-sdist.include-mode = "manual"
+sdist.inclusion-mode = "manual"
 ```
 
 There's also a `"classic"` mode, which fully traverses all directories to check


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two verified documentation bugs:

- `docs/configuration/index.md` used the wrong setting name
  `sdist.include-mode` in two spots (the `minimum-version` compatibility
  note and the manual-inclusion example). The real key, per the schema and
  `settings/skbuild_model.py`, is `sdist.inclusion-mode`. Copying the
  example as written triggers a strict-config validation error.
- `docs/configuration/dynamic.md` claimed the modern
  `[[tool.dynamic-metadata]]` mode "always requires" a `field =` key. That's
  not accurate for the bundled `setuptools_scm` and `fancy_pypi_readme`
  providers, which default `field` to `"version"` and `"readme"`
  respectively (see `metadata/setuptools_scm.py`, `metadata/fancy_pypi_readme.py`,
  and `tests/test_dynamic_metadata_unit.py::test_scm_provider_defaults_field_and_requires`).
  Updated the text to note the exception.

Grepped `docs/` and `README.md` for other occurrences of both issues; none
found (the generated `README.md`/`docs/reference/configs.md` sections
already use the correct `inclusion-mode` name).

Part of #1417.

## Test plan

- [x] Doc-only change, no tests needed
- [x] `prek -a --quiet` passes (only pre-existing `check-sdist` noise from
      gitignored `.claude/settings.local.json`)

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd