### PR TITLE
fix(sdist): don't crash on dangling symlinks with resolve-symlinks="all"

### DIFF
--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -35,7 +35,7 @@ from packaging.utils import canonicalize_name
 
 from .. import __version__
 from .._compat import tomllib
-from .._logging import rich_print
+from .._logging import rich_print, rich_warning
 from .._reproducible import get_reproducible_epoch, normalize_file_permissions
 from ..settings.skbuild_read_settings import SettingsReader
 from ._file_processor import each_unignored_file
@@ -44,6 +44,10 @@ from ._pathutil import iter_force_include
 from .generate import generate_file_contents
 from .metadata import get_standard_metadata
 from .wheel import _build_wheel_impl
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = ["build_sdist"]
 
@@ -83,6 +87,37 @@ def add_bytes_to_tar(
     with io.BytesIO(data) as bio:
         tarinfo.size = bio.getbuffer().nbytes
         tar.addfile(tarinfo, bio)
+
+
+def add_path_to_tar(
+    tar: tarfile.TarFile,
+    filepath: Path,
+    arcname: Path,
+    *,
+    tar_filter: Callable[[tarfile.TarInfo], tarfile.TarInfo],
+) -> None:
+    """
+    Add ``filepath`` to ``tar`` at ``arcname``, applying ``tar_filter`` for
+    reproducibility normalization.
+
+    ``tar.dereference`` (``sdist.resolve-symlinks = "all"``) makes ``tar.add``
+    stat through symlinks; a dangling symlink then raises ``FileNotFoundError``
+    instead of being archived (#1417). Fall back to storing the symlink itself
+    in that case, matching the pre-1.0 behavior, and warn.
+    """
+    if tar.dereference and filepath.is_symlink() and not filepath.exists():
+        rich_warning(
+            f"{filepath} is a dangling symlink; storing it as a symlink instead "
+            'of resolving it. Set sdist.resolve-symlinks = "none" to silence '
+            "this warning."
+        )
+        tar.dereference = False
+        try:
+            tar.add(filepath, arcname=arcname, filter=tar_filter)
+        finally:
+            tar.dereference = True
+    else:
+        tar.add(filepath, arcname=arcname, filter=tar_filter)
 
 
 def build_sdist(
@@ -152,10 +187,11 @@ def build_sdist(
             )
         )
         for filepath in paths:
-            tar.add(
+            add_path_to_tar(
+                tar,
                 filepath,
                 arcname=srcdirname / filepath,
-                filter=normalize_tar_info if reproducible else lambda x: x,
+                tar_filter=normalize_tar_info if reproducible else lambda x: x,
             )
 
         # A force-included file is forced in; a force-included directory's
@@ -174,10 +210,11 @@ def build_sdist(
         # .tar.gz bytes) does not depend on filesystem ordering for directories.
         forced.sort(key=lambda pair: pair[1])
         for src_file, target in forced:
-            tar.add(
+            add_path_to_tar(
+                tar,
                 src_file,
                 arcname=target,
-                filter=normalize_tar_info if reproducible else lambda x: x,
+                tar_filter=normalize_tar_info if reproducible else lambda x: x,
             )
 
         add_bytes_to_tar(

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from scikit_build_core._logging import rich_warning
 from scikit_build_core.build import build_sdist
 
 
@@ -48,3 +49,29 @@ def test_pep517_sdist_symlink(
             assert link_member.issym(), (
                 "The symlink should have been stored as a symlink"
             )
+
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")
+def test_pep517_sdist_dangling_symlink(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    A dangling symlink cannot be dereferenced; with the ``resolve-symlinks =
+    "all"`` default the build must fall back to storing it as a symlink member
+    instead of crashing (#1417).
+    """
+    Path("dangling_link.txt").symlink_to("does-not-exist.txt")
+
+    rich_warning.cache_clear()
+    out = build_sdist(str(tmp_path), config_settings=None)
+
+    with tarfile.open(tmp_path / out, "r:gz") as tar:
+        link_member = tar.getmember("cmake_example-0.0.1/dangling_link.txt")
+        assert link_member.issym(), (
+            "A dangling symlink should be stored as a symlink, not dereferenced"
+        )
+
+    err = capsys.readouterr().err
+    assert "dangling_link.txt" in err
+    assert "sdist.resolve-symlinks" in err


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`sdist.resolve-symlinks = "all"` (the new 1.0 default) sets `dereference=True` on the `tarfile.TarFile` used to build the sdist. `tar.add()` then calls `os.stat()` on every path, including symlinks. A **dangling (broken) symlink** anywhere in the source tree — e.g. a link into a gitignored build directory, or a stray test fixture — makes `os.stat()` raise `FileNotFoundError`, which propagates unhandled out of the PEP 517 `build_sdist` hook and crashes the build. This is a regression from 0.12.2, where such a symlink was simply stored as a symlink tar member.

The same crash could occur for a dangling symlink found while walking a `sdist.force-include` directory.

## Fix

Added `add_path_to_tar()` in `src/scikit_build_core/build/sdist.py`, used for both the main file walk and the force-include walk. Before adding a path, it checks whether the tar is set to dereference symlinks and whether the path is a symlink whose target doesn't exist. If so, it:

- emits a warning naming the dangling link and pointing at `sdist.resolve-symlinks`,
- temporarily flips `tar.dereference` off for that one `tar.add()` call so the symlink is stored as-is (preserving 0.12.2 behavior),
- restores `tar.dereference` afterward.

The existing reproducibility filter (`normalize_tar_info`) still applies to the fallback symlink member, so sdist reproducibility is unaffected.

Part of #1417.

## Test plan

- [x] Added a regression test (`test_pep517_sdist_dangling_symlink` in `tests/test_pep517_sdist_symlink.py`) that creates a dangling symlink and asserts `build_sdist` succeeds, the tar stores it as a symlink member, and a warning naming the link and `sdist.resolve-symlinks` is printed. Confirmed it reproduces the crash (`FileNotFoundError`) before the fix.
- [x] `uv run pytest tests/test_pep517_sdist_symlink.py -x -q` and `-k sdist` (56 tests) pass.
- [x] Full non-network/non-isolated test suite (872 tests) passes.
- [x] `prek -a --quiet` passes (the only failure is the known local `check-sdist` noise from gitignored `.claude/settings.local.json`/`uv.lock`, unrelated to this change).

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd