### PR TITLE
fix(builder): free-threaded Windows import library and two-token -D parsing

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -84,9 +84,26 @@ def get_archs(env: Mapping[str, str], cmake_args: Sequence[str] = ()) -> list[st
     """
 
     if sys.platform.startswith("darwin"):
+        # Handles both the joined -DVAR=value and two-token -D VAR=value
+        # forms; a plain substring test would false-positive on any arg
+        # merely containing "CMAKE_SYSTEM_PROCESSOR" (e.g. -DFOO=CMAKE_SYSTEM_PROCESSOR).
+        expecting_value = False
         for cmake_arg in cmake_args:
-            if "CMAKE_SYSTEM_PROCESSOR" in cmake_arg:
-                return [cmake_arg.split("=")[1]]
+            if expecting_value:
+                match = re.fullmatch(
+                    r"CMAKE_SYSTEM_PROCESSOR(?::[^=]*)?=(.*)", cmake_arg.strip()
+                )
+                if match:
+                    return [match.group(1)]
+                expecting_value = False
+            elif cmake_arg == "-D":
+                expecting_value = True
+            else:
+                match = re.fullmatch(
+                    r"-D\s*CMAKE_SYSTEM_PROCESSOR(?::[^=]*)?=(.*)", cmake_arg
+                )
+                if match:
+                    return [match.group(1)]
         return re.findall(r"-arch (\S+)", env.get("ARCHFLAGS", ""))
     if sys.platform.startswith("win") and get_platform(env) == "win-arm64":
         return ["win_arm64"]

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -56,17 +56,32 @@ def get_cmake_osx_deployment_target(
     """
     Find an explicit ``CMAKE_OSX_DEPLOYMENT_TARGET`` known before the build
     directory exists: a ``cmake.define`` entry or a ``-DCMAKE_OSX_DEPLOYMENT_TARGET=``
-    in ``cmake.args``. The args value wins over the define, mirroring CMake's own
+    in ``cmake.args``. Handles both the joined ``-DVAR=value`` and the
+    two-token ``-D VAR=value`` forms (mirroring ``parse_generator``'s ``-G``
+    handling). The args value wins over the define, mirroring CMake's own
     command-line-over-cache precedence. Settings in ``CMakeLists.txt`` or a
     toolchain file cannot be seen here and are not honored.
     """
     target: str | None = None
     if cmake_defines is not None:
         target = cmake_defines.get("CMAKE_OSX_DEPLOYMENT_TARGET", None)
+    expecting_value = False
     for arg in cmake_args:
-        match = re.fullmatch(r"-D\s*CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg)
-        if match:
-            target = match.group(1)
+        if expecting_value:
+            match = re.fullmatch(
+                r"CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg.strip()
+            )
+            if match:
+                target = match.group(1)
+            expecting_value = False
+        elif arg == "-D":
+            expecting_value = True
+        else:
+            match = re.fullmatch(
+                r"-D\s*CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg
+            )
+            if match:
+                target = match.group(1)
     return target
 
 

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -120,7 +120,9 @@ def get_python_library(
         if result:
             logger.info("Reading DIST_EXTRA_CONFIG:build_ext.library_dirs={}", result)
             minor = "" if (abi3 or abi3t) else sys.version_info[1]
-            suffix = "t" if abi3t else ""
+            # Stable-ABI abi3 has no free-threaded variant of its own; only
+            # abi3t (already handled) and non-SABI builds pick up the "t" flag.
+            suffix = "t" if abi3t or (not abi3 and _is_free_threaded()) else ""
             return Path(result) / f"python3{minor}{suffix}.lib"
 
     # Windows CPython has no LIBDIR/LDLIBRARY/LIBRARY config vars, so construct

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -121,6 +121,22 @@ def test_macos_version(monkeypatch, pycom, envvar, answer):
             "10.13",
             id="arg_typed",
         ),
+        # Two-token `-D VAR=value` form, as produced by a shell-split
+        # CMAKE_ARGS="-D CMAKE_OSX_DEPLOYMENT_TARGET=10.13" (#1417).
+        pytest.param(
+            None,
+            {},
+            ("-D", "CMAKE_OSX_DEPLOYMENT_TARGET=10.13"),
+            "10.13",
+            id="arg_only_two_token",
+        ),
+        pytest.param(
+            None,
+            {},
+            ("-D", "CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13"),
+            "10.13",
+            id="arg_typed_two_token",
+        ),
         # cmake.define / cmake.args win over the env var fallback.
         pytest.param(
             "12.0",
@@ -265,6 +281,39 @@ library_dirs=C:\\Python\\libs
     assert lib3 == Path("C:\\Python\\libs\\python3t.lib")
 
 
+def test_get_python_library_xcompile_free_threaded(tmp_path, monkeypatch):
+    # Regression test (#1417): a non-SABI cross-compile (e.g. cibuildwheel
+    # win_arm64 cp313t) must consult Py_GIL_DISABLED and request the
+    # free-threaded import library, not the GIL one. This DIST_EXTRA_CONFIG
+    # path isn't gated on the host platform, so it's testable everywhere.
+    real = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda name: "1" if name == "Py_GIL_DISABLED" else real(name),
+    )
+
+    config_path = tmp_path / "tmp.cfg"
+    config_path.write_text(
+        """\
+[build_ext]
+library_dirs=C:\\Python\\libs
+    """
+    )
+    env = {"DIST_EXTRA_CONFIG": str(config_path)}
+
+    libdir = Path("C:\\Python\\libs")
+    lib = get_python_library(env)
+    assert lib == libdir / f"python3{sys.version_info[1]}t.lib"
+
+    # Stable-ABI abi3 (non-t) is unaffected by free-threading.
+    abi3_lib = get_python_library(env, abi3=True)
+    assert abi3_lib == libdir / "python3.lib"
+
+    abi3t_lib = get_python_library(env, abi3t=True)
+    assert abi3t_lib == libdir / "python3t.lib"
+
+
 @pytest.mark.parametrize("archs", [["x86_64"], ["arm64", "universal2"]])
 def test_builder_macos_arch(monkeypatch, archs):
     archflags = " ".join(f"-arch {arch}" for arch in archs)
@@ -280,6 +329,24 @@ def test_builder_macos_arch_cmake_system_processor(monkeypatch):
     assert get_archs(env, cmake_args) == ["arm64"]
     # Without the cmake arg, ARCHFLAGS wins.
     assert get_archs(env) == ["x86_64"]
+
+
+def test_builder_macos_arch_cmake_system_processor_two_token(monkeypatch):
+    # Two-token `-D VAR=value` form, mirroring the CMAKE_OSX_DEPLOYMENT_TARGET
+    # two-token fix (#1417).
+    monkeypatch.setattr(sys, "platform", "darwin")
+    env: dict[str, str] = {}
+    cmake_args = ["-D", "CMAKE_SYSTEM_PROCESSOR=arm64"]
+    assert get_archs(env, cmake_args) == ["arm64"]
+
+
+def test_builder_macos_arch_cmake_system_processor_false_positive(monkeypatch):
+    # A substring match on an unrelated arg must not be mistaken for a real
+    # -DCMAKE_SYSTEM_PROCESSOR=... definition (#1417).
+    monkeypatch.setattr(sys, "platform", "darwin")
+    env = {"ARCHFLAGS": "-arch x86_64"}
+    cmake_args = ["-DFOO=CMAKE_SYSTEM_PROCESSOR"]
+    assert get_archs(env, cmake_args) == ["x86_64"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two independent bugs in `builder/`:

**Bug A — Windows free-threaded non-SABI cross-compile links the GIL import library.**
`get_python_library()` (`builder/sysconfig.py`) has a cross-compile path that reads
`DIST_EXTRA_CONFIG`'s `library_dirs` (used by e.g. cibuildwheel win_arm64) and
constructs the import-library filename directly. The non-stable-ABI branch never
consulted `Py_GIL_DISABLED`, so a `cp313t` cross-compile got `python313.lib`
instead of `python313t.lib`, which is then fed to CMake as `Python3_LIBRARY`
(`builder.py:404`) — linking the extension against the GIL runtime and breaking
it under the free-threaded interpreter. Fixed by reusing the existing
`_is_free_threaded()` helper (already used elsewhere in the same file) for the
non-abi3 case; abi3 (non-abi3t) stays free-threading-agnostic since the classic
stable ABI has no `t` variant, and abi3t was already handled correctly.

**Bug B — two-token `-D VAR=value` in CMAKE_ARGS is missed.**
- `get_cmake_osx_deployment_target()` (`builder/macos.py`) only matched `-D` and
  the variable name within a single argv token, so the ordinary shell form
  `-D CMAKE_OSX_DEPLOYMENT_TARGET=10.15` (two tokens, accepted by CMake) was
  silently ignored — the wheel platform tag would fall back to
  `MACOSX_DEPLOYMENT_TARGET`/host while CMake built for the requested target.
  This is the same class of bug as #1352 (fixed for `-G` in `builder/generator.py`);
  the fix mirrors that two-token state-machine handling.
- `get_archs()` (`builder/builder.py`) had a related, sloppier bug: it tested
  `"CMAKE_SYSTEM_PROCESSOR" in cmake_arg` and blindly took `split("=")[1]`,
  which false-positives on any arg merely *containing* the substring (e.g.
  `-DFOO=CMAKE_SYSTEM_PROCESSOR`). Tightened to match an actual
  `-DCMAKE_SYSTEM_PROCESSOR[:type]=value` (plus the two-token `-D` form, for
  consistency with the fix above).

Part of #1417.

## Test plan

- [x] Added regression tests that fail without the fix and pass with it:
  - `test_get_python_library_xcompile_free_threaded` (Bug A)
  - `test_macos_version_cmake_osx_deployment_target[arg_only_two_token]` /
    `[arg_typed_two_token]` (Bug B, macos.py)
  - `test_builder_macos_arch_cmake_system_processor_false_positive` (Bug B, builder.py)
- [x] `uv run pytest tests/test_builder.py -v` — 95 passed, 1 skipped (MSVC-only)
- [x] `uv run pytest tests/ -k "not virtualenv and not isolated and not network and not integration"` — 781 passed
- [x] `prek -a --quiet` — all hooks pass except `check-sdist`, which only flags gitignored `uv.lock`/`.claude` noise unrelated to this change

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd