### PR TITLE
fix(wheel): clamp SOURCE_DATE_EPOCH to the ZIP timestamp range

### DIFF
--- a/src/scikit_build_core/_reproducible.py
+++ b/src/scikit_build_core/_reproducible.py
@@ -2,14 +2,40 @@ from __future__ import annotations
 
 import os
 
-__all__ = ["MIN_TIMESTAMP", "get_reproducible_epoch", "normalize_file_permissions"]
+__all__ = [
+    "MAX_TIMESTAMP",
+    "MIN_TIMESTAMP",
+    "get_reproducible_epoch",
+    "normalize_file_permissions",
+    "parse_source_date_epoch",
+]
 
 # The ZIP file format does not support timestamps before 1980-01-01 00:00:00 UTC.
 MIN_TIMESTAMP = 315532800
+# Nor after 2107-12-31 23:59:59 UTC (the DOS date field's year is a 7-bit offset
+# from 1980, so the last representable year is 1980 + 127 = 2107).
+MAX_TIMESTAMP = 4354819199
 
 
 def __dir__() -> list[str]:
     return __all__
+
+
+def parse_source_date_epoch(raw: str) -> int:
+    """
+    Parse a `SOURCE_DATE_EPOCH` environment variable value.
+
+    Per the reproducible-builds.org spec, a malformed value should cause the
+    build to fail with a clear error rather than being silently ignored.
+    """
+    try:
+        return int(raw)
+    except ValueError:
+        from ._logging import rich_error
+
+        rich_error(
+            f"Invalid SOURCE_DATE_EPOCH value {raw!r}: must be an integer number of seconds since the Unix epoch"
+        )
 
 
 def get_reproducible_epoch() -> int:
@@ -19,7 +45,8 @@ def get_reproducible_epoch() -> int:
     If the `SOURCE_DATE_EPOCH` environment variable is set, use that value. Otherwise,
     always return `1667997441`.
     """
-    return int(os.environ.get("SOURCE_DATE_EPOCH", "1667997441"))
+    raw = os.environ.get("SOURCE_DATE_EPOCH")
+    return 1667997441 if raw is None else parse_source_date_epoch(raw)
 
 
 def normalize_file_permissions(st_mode: int) -> int:

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -32,9 +32,11 @@ import pathspec
 
 from .. import __version__
 from .._reproducible import (
+    MAX_TIMESTAMP,
     MIN_TIMESTAMP,
     get_reproducible_epoch,
     normalize_file_permissions,
+    parse_source_date_epoch,
 )
 from .._variants import VARIANT_DIST_INFO_FILENAME
 
@@ -132,9 +134,15 @@ class WheelWriter:
             # Honor SOURCE_DATE_EPOCH, else a fixed epoch (ignore per-file mtime).
             timestamp = get_reproducible_epoch()
         else:
-            timestamp = int(os.environ.get("SOURCE_DATE_EPOCH", mtime or time.time()))
-        # The ZIP file format does not support timestamps before 1980.
-        timestamp = max(timestamp, MIN_TIMESTAMP)
+            raw = os.environ.get("SOURCE_DATE_EPOCH")
+            timestamp = (
+                parse_source_date_epoch(raw)
+                if raw is not None
+                else int(mtime or time.time())
+            )
+        # The ZIP file format only supports timestamps from 1980-01-01 to
+        # 2107-12-31 23:59:59 (inclusive); clamp rather than let zipfile crash.
+        timestamp = min(max(timestamp, MIN_TIMESTAMP), MAX_TIMESTAMP)
         return time.gmtime(timestamp)[0:6]
 
     def dist_info_contents(self) -> dict[str, bytes]:

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -8,7 +8,7 @@ import pytest
 from packaging.tags import Tag
 
 import scikit_build_core.build._wheelfile
-from scikit_build_core._reproducible import get_reproducible_epoch
+from scikit_build_core._reproducible import MAX_TIMESTAMP, get_reproducible_epoch
 from scikit_build_core._vendor.pyproject_metadata import StandardMetadata
 from scikit_build_core.build._wheelfile import WheelWriter
 
@@ -42,6 +42,42 @@ def test_wheel_timestamp_non_reproducible_uses_mtime(tmp_path, monkeypatch):
     wheel = _make_writer(tmp_path, reproducible=False)
     mtime = 1234567890
     assert wheel.timestamp(mtime) == time.gmtime(mtime)[0:6]
+
+
+@pytest.mark.parametrize("reproducible", [True, False])
+def test_wheel_timestamp_clamps_epoch_beyond_zip_range(
+    tmp_path, monkeypatch, reproducible
+):
+    # A SOURCE_DATE_EPOCH beyond 2107-12-31 23:59:59 UTC (e.g. a milliseconds-epoch
+    # mistake) cannot be represented in the ZIP date format and must be clamped
+    # rather than crash deep inside zipfile with a struct.error.
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(MAX_TIMESTAMP + 1))
+    wheel = _make_writer(tmp_path, reproducible=reproducible)
+    assert wheel.timestamp() == time.gmtime(MAX_TIMESTAMP)[0:6]
+
+    # The resulting date must actually be writable to a real ZIP archive (the DOS
+    # date format only stores even seconds, so the last field may round down).
+    with wheel:
+        wheel.writestr("data.txt", b"hello")
+    with zipfile.ZipFile(wheel.wheelpath) as zf:
+        assert zf.getinfo("data.txt").date_time[:5] == time.gmtime(MAX_TIMESTAMP)[0:5]
+
+
+def test_reproducible_epoch_non_integer_errors(monkeypatch, capsys):
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1.7e9")
+    with pytest.raises(SystemExit):
+        get_reproducible_epoch()
+    assert "SOURCE_DATE_EPOCH" in capsys.readouterr().err
+
+
+def test_wheel_timestamp_non_reproducible_non_integer_epoch_errors(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "")
+    wheel = _make_writer(tmp_path, reproducible=False)
+    with pytest.raises(SystemExit):
+        wheel.timestamp()
+    assert "SOURCE_DATE_EPOCH" in capsys.readouterr().err
 
 
 def test_wheel_write_normalizes_permissions(tmp_path, monkeypatch):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`SOURCE_DATE_EPOCH` values at or beyond `4354819200` (2108-01-01 00:00:00 UTC) — notably a milliseconds-epoch mistake like `1667997441000` set by some CI systems — crash wheel writing deep inside `zipfile` with an opaque `struct.error: 'H' format requires 0 <= number <= 65535`. This happens because the ZIP/DOS date format encodes the year as a 7-bit offset from 1980, so the last representable date is 2107-12-31 23:59:59 UTC. `WheelWriter.timestamp()` in `src/scikit_build_core/build/_wheelfile.py` only clamped the *lower* bound (`max(timestamp, MIN_TIMESTAMP)`), not the upper one. This applies in both reproducible and non-reproducible modes.

Separately, a non-integer `SOURCE_DATE_EPOCH` (e.g. `""` or `"1.7e9"`) raised a bare `ValueError` from `int()` in `get_reproducible_epoch()` (`src/scikit_build_core/_reproducible.py`), with no indication of which environment variable was at fault.

## Fix

- Added `MAX_TIMESTAMP` (4354819199, i.e. 2107-12-31 23:59:59 UTC) alongside the existing `MIN_TIMESTAMP`, and clamp `timestamp()` to `[MIN_TIMESTAMP, MAX_TIMESTAMP]` in both reproducible and non-reproducible code paths.
- Extracted a `parse_source_date_epoch()` helper that raises a clear `rich_error` (naming the offending value) instead of a bare `ValueError` when `SOURCE_DATE_EPOCH` isn't a valid integer, per the [reproducible-builds.org SOURCE_DATE_EPOCH spec](https://reproducible-builds.org/specs/source-date-epoch/), which recommends the build process exit with a non-zero error code on a malformed value. Both `get_reproducible_epoch()` and the non-reproducible fallback in `WheelWriter.timestamp()` now share this helper.
- Behavior for valid `SOURCE_DATE_EPOCH` values is unchanged.

Part of #1417.

## Test plan

- [x] Added regression tests in `tests/test_wheelfile_utils.py`:
  - `test_wheel_timestamp_clamps_epoch_beyond_zip_range` (parametrized over reproducible/non-reproducible) — confirms an out-of-range epoch is clamped and the wheel writes successfully.
  - `test_reproducible_epoch_non_integer_errors` and `test_wheel_timestamp_non_reproducible_non_integer_epoch_errors` — confirm a non-integer `SOURCE_DATE_EPOCH` raises a clear, `SystemExit`-based error naming `SOURCE_DATE_EPOCH` rather than a bare `ValueError`.
  - Confirmed these tests fail without the fix (import error / crash / bare `ValueError`) and pass with it.
- [x] `uv run pytest tests/test_wheelfile_utils.py tests/ -k "reproducib or wheelfile or sdist" -q -n auto` — 70 passed.
- [x] Manually reproduced the original crash with `SOURCE_DATE_EPOCH=1667997441000` on `main`, confirmed it now builds a wheel successfully with the fix.
- [x] `prek -a --quiet` — clean (only the known local `check-sdist` noise from gitignored `uv.lock`/`.claude`).

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd