### PR TITLE
fix(settings): robust signature dispatch and duplicate-name handling for entry-point providers

### DIFF
--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -20,8 +20,10 @@ def config(*, state, env):
     }
 ```
 
-The callable may also take no arguments; `state` (the build state, e.g.
-`"wheel"`) and `env` (the environment mapping) are passed when accepted.
+Each argument is passed only when the callable accepts it: `state` (the build
+state, e.g. `"wheel"`) and `env` (the environment mapping) are matched by
+parameter name, and a `**kwargs` provider receives both. A provider may accept
+any subset -- both, either one, or none. The callable is invoked exactly once.
 
 It is registered under one of two groups; the **group** selects the precedence
 level, and the entry-point name is arbitrary:

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -155,8 +155,8 @@ def load_provider(
         module = importlib.import_module(module_name)
     else:
         if not Path(provider_path).is_dir():
-            msg = "provider-path must be an existing directory"
-            raise AssertionError(msg)
+            msg = f"provider-path {provider_path!r} must be an existing directory"
+            raise FileNotFoundError(msg)
         finder = _ProviderPathFinder([provider_path], module_name)
         sys.meta_path.insert(0, finder)
         try:
@@ -200,6 +200,17 @@ def load_entry_provider(provider: str | Mapping[str, Any]) -> DMProtocols:
         hint = f"; did you mean {close[0]!r}?" if close else ""
         msg = f"Unknown dynamic-metadata provider {provider!r}{hint}"
         raise ModuleNotFoundError(msg)
+    if len(matches) > 1:
+        from .._logging import rich_warning
+
+        dists = ", ".join(
+            getattr(getattr(ep, "dist", None), "name", None) or "unknown distribution"
+            for ep in matches
+        )
+        rich_warning(
+            f"Multiple 'dynamic_metadata.provider' entry points named "
+            f"{provider!r} found (from {dists}); using the first"
+        )
     obj: Any = matches[0].load()
     return cast("DMProtocols", obj() if isinstance(obj, type) else obj)
 

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -23,10 +23,13 @@ from __future__ import annotations
 __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    "inspect",
 }
 
+import inspect
+
 from .._compat.importlib import metadata
-from .._logging import logger, rich_error
+from .._logging import logger, rich_error, rich_warning
 
 __all__ = ["GROUP_DEFAULT", "GROUP_OVERRIDE", "load_config_providers"]
 
@@ -37,25 +40,62 @@ def __dir__() -> list[str]:
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
+    from importlib.metadata import EntryPoint
 
 
 GROUP_DEFAULT = "scikit-build-core.config.default"
 GROUP_OVERRIDE = "scikit-build-core.config.override"
 
 
+def _dist_name(ep: object) -> str:
+    """Best-effort distribution name for an entry point (for diagnostics)."""
+    dist = getattr(ep, "dist", None)
+    return getattr(dist, "name", None) or "unknown distribution"
+
+
+def _call_provider(
+    func: Callable[..., object], *, state: str, env: Mapping[str, str]
+) -> object:
+    """Call a provider with exactly the ``state``/``env`` arguments it accepts.
+
+    The documented contract is per-argument: ``state`` and ``env`` are each
+    passed only when the callable accepts them (a ``**kwargs`` provider accepts
+    both). The callable is invoked exactly once, so an argument-binding retry
+    can never re-run a provider's side effects or swallow a body ``TypeError``.
+    """
+    params = inspect.signature(func).parameters
+    accepts_var_kw = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+    kwargs: dict[str, object] = {}
+    if accepts_var_kw or "state" in params:
+        kwargs["state"] = state
+    if accepts_var_kw or "env" in params:
+        kwargs["env"] = env
+    return func(**kwargs)
+
+
 def _load_group(
     level: str, group: str, *, state: str, env: Mapping[str, str]
 ) -> list[tuple[str, str, dict[str, object]]]:
     providers: list[tuple[str, str, dict[str, object]]] = []
-    for ep in sorted(metadata.entry_points(group=group), key=lambda e: e.name):
+    by_name: dict[str, list[EntryPoint]] = {}
+    for ep in metadata.entry_points(group=group):
+        by_name.setdefault(ep.name, []).append(ep)
+    for name in sorted(by_name):
+        eps = by_name[name]
+        if len(eps) > 1:
+            dists = ", ".join(_dist_name(e) for e in eps)
+            rich_warning(
+                f"Multiple {group!r} providers named {name!r} found "
+                f"(from {dists}); using the first"
+            )
+        ep = eps[0]
         func = ep.load()
         if not callable(func):
             rich_error(f"{group} provider {ep.name!r} must be callable")
-        try:
-            table = func(state=state, env=env)
-        except TypeError:
-            table = func()
+        table = _call_provider(func, state=state, env=env)
         if not isinstance(table, dict):
             rich_error(
                 f"{group} provider {ep.name!r} must return a tool.scikit-build "

--- a/tests/test_dynamic_metadata_unit.py
+++ b/tests/test_dynamic_metadata_unit.py
@@ -178,6 +178,50 @@ def test_load_provider_path_not_shadowed(
         load_provider("shadow_prov", str(empty))
 
 
+def test_load_provider_path_missing_dir_raises(tmp_path: Path) -> None:
+    # A non-existent provider-path is a user config error and must raise a real
+    # exception (not an AssertionError, which vanishes under python -O).
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError, match="existing directory"):
+        load_provider("whatever", str(missing))
+
+
+class _FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeEP:
+    def __init__(self, name: str, obj: object, dist: str) -> None:
+        self.name = name
+        self._obj = obj
+        self.dist = _FakeDist(dist)
+
+    def load(self) -> object:
+        return self._obj
+
+
+def test_duplicate_provider_names_warn(monkeypatch, capsys) -> None:
+    from scikit_build_core._compat.importlib import metadata as compat_metadata
+    from scikit_build_core._logging import rich_warning
+    from scikit_build_core.builder._load_provider import load_entry_provider
+
+    rich_warning.cache_clear()
+
+    class Prov:
+        def dynamic_metadata(self, *_args):
+            return {}
+
+    eps = [_FakeEP("dup", Prov, "dist-a"), _FakeEP("dup", Prov, "dist-b")]
+    monkeypatch.setattr(compat_metadata, "entry_points", lambda **_: eps)
+
+    load_entry_provider("dup")
+    err = capsys.readouterr().err
+    assert "dup" in err
+    assert "dist-a" in err
+    assert "dist-b" in err
+
+
 def test_array_regex_via_field_setting() -> None:
     # The bundled regex plugin is reached by its entry-point name in the 0.3
     # array form; the new-style wrapper sources the target from ``field``.

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -18,12 +18,18 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+class FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
 class FakeEntryPoint:
     """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
 
-    def __init__(self, name: str, func: object) -> None:
+    def __init__(self, name: str, func: object, dist: str | None = None) -> None:
         self.name = name
         self._func = func
+        self.dist = FakeDist(dist) if dist is not None else None
 
     def load(self) -> object:
         return self._func
@@ -212,6 +218,78 @@ def test_override_only_field_rejected(tmp_path, register):
     reader = make_reader(tmp_path, state="wheel")
     with pytest.raises(SystemExit):
         reader.validate_may_exit()
+
+
+def test_provider_body_typeerror_not_retried(tmp_path, register):
+    # A TypeError raised inside the provider body must propagate as-is and the
+    # provider must run exactly once (no silent bare-argument retry).
+    calls = []
+
+    def provider(**kwargs):
+        calls.append(kwargs)
+        msg = "boom in body"
+        raise TypeError(msg)
+
+    register("default", "distro", provider)
+    with pytest.raises(TypeError, match="boom in body"):
+        _ = make_reader(tmp_path, state="wheel").settings
+    assert len(calls) == 1
+
+
+def test_provider_accepts_only_state(tmp_path, register):
+    def provider(*, state):
+        assert state == "wheel"
+        return {"cmake": {"build-type": "RelWithDebInfo"}}
+
+    register("default", "distro", provider)
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_provider_accepts_only_env(tmp_path, register):
+    def provider(*, env):
+        assert isinstance(env, dict) or hasattr(env, "get")
+        return {"cmake": {"build-type": "RelWithDebInfo"}}
+
+    register("default", "distro", provider)
+    settings = make_reader(tmp_path, state="wheel").settings
+    assert settings.cmake.build_type == "RelWithDebInfo"
+
+
+def test_provider_var_kwargs_receives_both(tmp_path, register):
+    seen: dict[str, object] = {}
+
+    def provider(**kwargs):
+        seen.update(kwargs)
+        return {}
+
+    register("default", "distro", provider)
+    _ = make_reader(tmp_path, state="wheel").settings
+    assert set(seen) == {"state", "env"}
+    assert seen["state"] == "wheel"
+
+
+def test_duplicate_entry_point_names_warn(monkeypatch, capsys):
+    from scikit_build_core._logging import rich_warning
+
+    rich_warning.cache_clear()
+
+    eps = [
+        FakeEntryPoint("dup", lambda **_: {"cmake": {"build-type": "Debug"}}, "dist-a"),
+        FakeEntryPoint(
+            "dup", lambda **_: {"cmake": {"build-type": "Release"}}, "dist-b"
+        ),
+    ]
+
+    def fake_entry_points(*, group):
+        return eps if group == _load_entrypoint_config.GROUP_DEFAULT else []
+
+    monkeypatch.setattr(compat_metadata, "entry_points", fake_entry_points)
+    _load_entrypoint_config.load_config_providers(state="wheel", env={})
+    err = capsys.readouterr().err
+    assert "dup" in err
+    assert "dist-a" in err
+    assert "dist-b" in err
 
 
 def test_suggestions_name_entry_point_source(tmp_path, register):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes several verified bugs in entry-point provider loading.

## Bug A: unsound `except TypeError` signature fallback

`settings/_load_entrypoint_config.py` called each config provider as
`func(state=state, env=env)` and, on `TypeError`, retried as `func()`. This was
unsound:

- A provider whose **body** raised `TypeError` was executed twice (side effects
  duplicated), and if the bare retry happened to succeed the original error was
  silently swallowed.
- A provider accepting only one of the kwargs (`def config(*, state)`) crashed
  with a misleading "missing 1 required keyword-only argument".

Fix: dispatch now uses `inspect.signature` to pass exactly the `state`/`env`
arguments the callable accepts (both for a `**kwargs` provider) and invokes it
**exactly once**. Docs updated so the documented per-argument contract matches.

## Bug B: duplicate entry-point names resolved silently

Both the shared `dynamic_metadata.provider` group (`builder/_load_provider.py`)
and a single config-provider group (`_load_entrypoint_config.py`, which claimed
sorted-name determinism) silently tie-broke duplicate names by discovery order.
They now emit a warning naming the distributions involved before using the
first match.

## Bug C: wrong exception type for missing provider-path

A missing `provider-path` directory raised `AssertionError` (which vanishes
under `python -O`); it now raises `FileNotFoundError`.

## Tests

Regression tests added for each bug (body-raised `TypeError` propagates and runs
once; providers accepting only `state`, only `env`, neither, or `**kwargs`;
duplicate-name warnings; missing provider-path). `test_entrypoint_config.py` and
`test_dynamic_metadata_unit.py` pass (52 tests); broader settings/dynamic
metadata suites stay green.

Part of #1417.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd