### PR TITLE
fix(settings): treat entry-point config as dynamic for validation gates

### DIFF
--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -63,6 +63,20 @@ free-form. When several providers are registered in the same group, they are
 applied in sorted name order and the alphabetically-first name wins on
 conflicts.
 
+## Validation
+
+Because entry-point config comes from the machine environment rather than the
+project, it is treated like `SKBUILD_*` environment variables and
+`-C`/config-settings for validation purposes, not like static `pyproject.toml`
+content:
+
+- Override-only fields (such as `cmake.toolchain-file`) may be set directly,
+  without wrapping them in an [`overrides`](./overrides.md) block. This is the
+  distro cross-compile use case this feature targets.
+- The project's `minimum-version` pin does not gate machine-level config, so a
+  provider may set newer fields even when a project pins an older
+  `minimum-version`.
+
 ## Conditional configuration
 
 Because the returned table is treated like a `[tool.scikit-build]` table, it may

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -179,10 +179,10 @@ def _validate_overrides(
     Validate all fields with any override information.
 
     ``dynamic_sources`` are the sources that may legitimately set
-    ``override_only`` fields at build time (env vars and PEP 517
-    config-settings); ``toml_sources`` are the static ``pyproject.toml`` (and
-    ``extra_settings``) tables where ``override_only`` fields are forbidden
-    outside of an ``[[overrides]]`` section.
+    ``override_only`` fields at build time (env vars, PEP 517 config-settings,
+    and machine-level entry-point config); ``toml_sources`` are the static
+    ``pyproject.toml`` (and ``extra_settings``) tables where ``override_only``
+    fields are forbidden outside of an ``[[overrides]]`` section.
     """
 
     def validate_field(
@@ -338,6 +338,13 @@ class SettingsReader:
         # it, just above the hard-coded defaults. Either way the user's per-build
         # env vars and config-settings still win. Opt out entirely with
         # SKBUILD_NO_ENTRYPOINT_CONFIG.
+        # Entry-point config comes from the *machine environment* (installed
+        # distro packages), not the project, so for validation gates it is
+        # treated like env vars / config-settings (dynamic), not like static
+        # pyproject content: override-only fields are allowed and the project's
+        # minimum-version pin does not gate it. It still participates in normal
+        # precedence/merging via ``toml_srcs`` (see ``ep_srcs`` below).
+        ep_srcs: list[Source] = []
         if not strtobool(environ.get("SKBUILD_NO_ENTRYPOINT_CONFIG", "")):
             override_index = 0
             for level, ep_name, ep_table in load_config_providers(
@@ -349,6 +356,7 @@ class SettingsReader:
                 )
                 self.overrides |= ep_matched
                 ep_source = TOMLSource(settings=ep_skb)
+                ep_srcs.append(ep_source)
                 ep_display = f"entry-point config ({ep_name})"
                 if level == "override":
                     self.overridden_items.update(ep_overridden)
@@ -374,9 +382,20 @@ class SettingsReader:
             ConfSource("skbuild", settings=prefixed, verify=verify_conf),
             ConfSource(settings=remaining, verify=verify_conf),
         ]
-        # Static pyproject.toml (and extra_settings) tables; override-only fields
-        # are forbidden here outside of an [[overrides]] section.
+        # env vars + config-settings; these lead ``self.sources`` (see below),
+        # so ``print_suggestions`` relies on their count.
         self._dynamic_srcs = tuple(dynamic_srcs)
+        # Entry-point config is machine-level (not project-static), so for
+        # validation it is grouped with the dynamic sources: override-only
+        # fields are allowed and the project's minimum-version pin does not
+        # gate it. It still participates in normal precedence via ``toml_srcs``.
+        self._ep_srcs = tuple(ep_srcs)
+        # Static pyproject.toml (and extra_settings) tables; override-only fields
+        # are forbidden here outside of an [[overrides]] section, and their
+        # values are gated by the project's minimum-version pin.
+        self._static_srcs = tuple(s for s in toml_srcs if s not in ep_srcs)
+        # Full TOML precedence chain (including entry-point config), used for
+        # value resolution and unrecognized-option reporting.
         self._toml_srcs = tuple(toml_srcs)
         self._toml_src_names = tuple(toml_src_names)
         self.sources = SourceChain(
@@ -397,8 +416,11 @@ class SettingsReader:
 
         validate_variant_settings(self.settings)
 
+        # Values that come *only* from static project sources (pyproject.toml
+        # and extra_settings), used by the minimum-version move gates below.
+        # Entry-point config is excluded so it behaves like env/config-settings.
         static_settings = SourceChain(
-            *toml_srcs, prefixes=["tool", "scikit-build"]
+            *self._static_srcs, prefixes=["tool", "scikit-build"]
         ).convert_target(ScikitBuildSettings)
 
         if self.settings.minimum_version:
@@ -599,8 +621,8 @@ class SettingsReader:
         _validate_overrides(
             self.settings,
             self.overridden_items,
-            dynamic_sources=self._dynamic_srcs,
-            toml_sources=self._toml_srcs,
+            dynamic_sources=(*self._dynamic_srcs, *self._ep_srcs),
+            toml_sources=self._static_srcs,
         )
 
         if self.settings.metadata and self._dynamic_metadata:

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -204,14 +204,28 @@ def test_zero_arg_provider_supported(tmp_path, register):
     assert settings.cmake.build_type == "RelWithDebInfo"
 
 
-def test_override_only_field_rejected(tmp_path, register):
-    # cmake.toolchain-file is an override_only field: hard-coding it in a static
-    # source (including ep config) is rejected under strict_config.
+def test_override_only_field_allowed(tmp_path, register):
+    # cmake.toolchain-file is an override_only field, but entry-point config
+    # comes from the machine environment (installed distro packages), not the
+    # project's static pyproject.toml, so it may set it directly -- just like
+    # env vars / config-settings -- without wrapping it in an [[overrides]]
+    # block. This is the distro cross-compile use case the feature targets.
     toolchain = str(tmp_path / "tc.cmake")
     register("default", "distro", lambda **_: {"cmake": {"toolchain-file": toolchain}})
     reader = make_reader(tmp_path, state="wheel")
-    with pytest.raises(SystemExit):
-        reader.validate_may_exit()
+    reader.validate_may_exit()
+    assert str(reader.settings.cmake.toolchain_file) == toolchain
+
+
+def test_minimum_version_gate_not_triggered(tmp_path, register):
+    # A field gated behind a newer minimum-version (build.verbose, introduced in
+    # 0.10) set by entry-point config must not hard-fail a project pinning an
+    # older minimum-version. Machine-level config is dynamic, like env vars and
+    # config-settings, which are exempt from the project's version pin.
+    register("default", "distro", lambda **_: {"build": {"verbose": True}})
+    body = "[tool.scikit-build]\nminimum-version = '0.9'\n"
+    settings = make_reader(tmp_path, body, state="wheel").settings
+    assert settings.build.verbose is True
 
 
 def test_suggestions_name_entry_point_source(tmp_path, register):

--- a/tests/test_entrypoint_config.py
+++ b/tests/test_entrypoint_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 from packaging.version import Version
 
+import scikit_build_core.settings.skbuild_read_settings
 from scikit_build_core._compat.importlib import metadata as compat_metadata
 from scikit_build_core.settings import _load_entrypoint_config
 from scikit_build_core.settings.skbuild_read_settings import SettingsReader
@@ -217,11 +218,16 @@ def test_override_only_field_allowed(tmp_path, register):
     assert str(reader.settings.cmake.toolchain_file) == toolchain
 
 
-def test_minimum_version_gate_not_triggered(tmp_path, register):
+def test_minimum_version_gate_not_triggered(tmp_path, register, monkeypatch):
     # A field gated behind a newer minimum-version (build.verbose, introduced in
     # 0.10) set by entry-point config must not hard-fail a project pinning an
     # older minimum-version. Machine-level config is dynamic, like env vars and
     # config-settings, which are exempt from the project's version pin.
+    # Pin the running version so the project's minimum-version = '0.9' is not
+    # itself rejected as "too old" in dev/shallow builds (version 0.1.dev*).
+    monkeypatch.setattr(
+        scikit_build_core.settings.skbuild_read_settings, "__version__", "0.10.0"
+    )
     register("default", "distro", lambda **_: {"build": {"verbose": True}})
     body = "[tool.scikit-build]\nminimum-version = '0.9'\n"
     settings = make_reader(tmp_path, body, state="wheel").settings


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Entry-point configuration providers (feature #1406) contribute configuration from the *machine environment* (installed distro packages), not from the project's static `pyproject.toml`. The settings reader nonetheless classified the entry-point sources alongside `pyproject.toml` content (`self._toml_srcs`), which is used both to build `static_settings` and as `_validate_overrides`' `toml_sources`. That caused two wrong behaviors:

1. **Override-only fields rejected.** An entry-point provider that directly sets an override-only field (e.g. `cmake.toolchain-file` — the distro cross-compile use case this feature explicitly targets) exited 7 with `cmake.toolchain-file is not allowed to be hard-coded in the pyproject.toml file`. The message was misleading and the classification wrong; the only workaround was to wrap the value in an `[[overrides]]` block, which should not be required.
2. **minimum-version gate misfired.** An entry-point provider setting any minimum-version-gated field (`build.verbose`, `sdist.inclusion-mode`, `sdist.resolve-symlinks`, ...) hard-failed *every* build of any project pinning an older `minimum-version` (SystemExit 7), even though the env-var / `-C` config-settings equivalents are exempted via the `static=` dynamic check. A project's pin must not gate machine-level config.

## Fix

Entry-point sources are now tracked separately (`self._ep_srcs`) and, for validation purposes, grouped with the dynamic sources (env vars and PEP 517 config-settings):

- `_validate_overrides` receives entry-point sources as `dynamic_sources`, so override-only fields set by a provider are permitted (like env/`-C`), while `toml_sources` is now only the truly-static `pyproject.toml` + `extra_settings`.
- `static_settings` (used by the `minimum-version` move gates) is built from the static sources only, so entry-point-provided values are treated as dynamic and are not gated by the project's `minimum-version` pin.

Normal precedence and merging are unchanged (env > `-C` > EP override > extra_settings > pyproject > EP default > defaults): entry-point sources remain in `self._toml_srcs`/the source chain for value resolution and unrecognized-option reporting. Overrides defined *inside* entry-point tables are still validated — their records are merged into `self.overridden_items` as before, and `_validate_overrides` uses those records independently of `toml_sources`.

## Tests

- `test_override_only_field_allowed` (replaces the old `test_override_only_field_rejected`, which encoded the buggy behavior): a provider setting `cmake.toolchain-file` directly now builds without exit 7 and the value is applied.
- `test_minimum_version_gate_not_triggered`: a provider setting `build.verbose` (introduced in 0.10) with a project pinning `minimum-version = "0.9"` no longer errors, matching env-var behavior.

Both were confirmed to fail before the fix. `tests/test_entrypoint_config.py tests/test_skbuild_settings.py tests/test_settings.py tests/test_settings_overrides.py` all pass (205), mypy strict clean.

## Known related gap (not fixed here)

`src/scikit_build_core/build/__init__.py` `_has_safe_metadata()` scans only `pyproject.toml` for `if.failed` overrides, so entry-point-contributed `failed` overrides do not unexport the prepare-metadata hooks. A clean fix isn't trivial: `_has_safe_metadata()` runs at backend *import* time, the build state isn't known there, and consulting entry-point config would force eager loading of all providers, defeating the lazy-import design. Flagging for a follow-up.

Part of #1417.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd