### PR TITLE
fix(cli): argument parsing and clear errors for common mistakes

### DIFF
--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __lazy_modules__ = {
     "argparse",
     "json",
@@ -12,10 +14,10 @@ __lazy_modules__ = {
 import argparse
 import json
 from pathlib import Path
-from typing import Literal, get_args
+from typing import Any, Literal, get_args
 
 from scikit_build_core._compat import tomllib
-from scikit_build_core._logging import rich_warning
+from scikit_build_core._logging import rich_error, rich_warning
 from scikit_build_core.build import (
     get_requires_for_build_editable,
     get_requires_for_build_sdist,
@@ -28,10 +30,20 @@ from scikit_build_core.builder._load_provider import (
 )
 
 
+def _load_pyproject() -> dict[str, Any]:
+    """Read ``pyproject.toml`` from the current directory, erroring out clearly if missing."""
+    path = Path("pyproject.toml")
+    if not path.is_file():
+        rich_error(
+            "No {bold}pyproject.toml{normal} found in the current directory; run this from the root of a project."
+        )
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
 def main_project_table(args: argparse.Namespace, /) -> None:
     """Get the full project table, including dynamic metadata."""
-    with Path("pyproject.toml").open("rb") as f:
-        pyproject = tomllib.load(f)
+    pyproject = _load_pyproject()
 
     project = pyproject.get("project", {})
     legacy = pyproject.get("tool", {}).get("scikit-build", {}).get("metadata", {})
@@ -50,8 +62,7 @@ def main_requires(args: argparse.Namespace, /) -> None:
 def get_requires(mode: Literal["sdist", "wheel", "editable"]) -> None:
     """Get the build requirements."""
 
-    with Path("pyproject.toml").open("rb") as f:
-        pyproject = tomllib.load(f)
+    pyproject = _load_pyproject()
 
     requires = pyproject.get("build-system", {}).get("requires", [])
     backend = pyproject.get("build-system", {}).get("build-backend", "")

--- a/src/scikit_build_core/builder/__main__.py
+++ b/src/scikit_build_core/builder/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 __lazy_modules__ = {
+    "argparse",
     "pathlib",
     "scikit_build_core._logging",
     "scikit_build_core.builder.get_requires",
@@ -9,6 +10,7 @@ __lazy_modules__ = {
     "scikit_build_core.program_search",
 }
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -19,10 +21,6 @@ from scikit_build_core.builder.get_requires import GetRequires
 from scikit_build_core.builder.sysconfig import info_print as ip_sysconfig
 from scikit_build_core.builder.wheel_tag import WheelTag
 from scikit_build_core.program_search import info_print as ip_program_search
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    import argparse
 
 __all__ = ["main"]
 
@@ -77,7 +75,14 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
 
 
 def main() -> None:
-    main_info()
+    parser = argparse.ArgumentParser(
+        prog="python -m scikit_build_core.builder",
+        allow_abbrev=False,
+        description="Info about the system and build environment.",
+    )
+    populate_parser(parser)
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/scikit_build_core/init/__main__.py
+++ b/src/scikit_build_core/init/__main__.py
@@ -177,6 +177,18 @@ def main_init(args: argparse.Namespace, /) -> None:
             raw_name=raw_name,
         )
     module = project_name.replace("-", "_").replace(".", "_")
+    if not module.isidentifier():
+        rich_error(
+            "{module!r} (derived from {raw_name!r}) is not a valid Python identifier; pass a {bold}--name{normal} that starts with a letter or underscore.",
+            module=module,
+            raw_name=raw_name,
+        )
+
+    if directory.exists() and not directory.is_dir():
+        rich_error(
+            "{directory} already exists and is not a directory.",
+            directory=directory,
+        )
 
     if directory.is_dir() and any(directory.iterdir()) and not args.force:
         rich_error(

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -131,6 +131,23 @@ class DynamicMetadata:
 """
 
 
+@pytest.mark.parametrize("subcommand", ["requires", "project-table"])
+def test_missing_pyproject_gives_clear_error(
+    subcommand: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Running outside a project directory used to raise a raw FileNotFoundError.
+    monkeypatch.setattr(sys, "argv", ["scikit_build_core.build", subcommand])
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        main()
+    _, err = capsys.readouterr()
+    assert "pyproject.toml" in err
+
+
 @pytest.mark.parametrize(
     ("args", "expected"),
     [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -131,6 +131,25 @@ def test_generate_project_rejects_unsafe_name(name: str, tmp_path: Path) -> None
         generate_project(tmp_path / "proj", "c", name)
 
 
+def test_init_rejects_non_identifier_module(tmp_path: Path) -> None:
+    # "1demo" is a valid distribution name (packaging allows leading digits) but
+    # its derived module "1demo" is not a valid Python identifier; the CLI must
+    # reject it up front instead of scaffolding an unimportable package.
+    project = tmp_path / "proj"
+    with pytest.raises(SystemExit):
+        main(["init", str(project), "--backend", "c", "--name", "1demo"])
+    assert not (project / "pyproject.toml").exists()
+
+
+def test_init_rejects_existing_file_as_directory(tmp_path: Path) -> None:
+    # A plain file at the target path must produce a clear error, not a raw
+    # FileExistsError from deep inside template generation.
+    target = tmp_path / "existing-file"
+    target.write_text("hi")
+    with pytest.raises(SystemExit):
+        main(["init", str(target), "--backend", "c", "--name", "my-pkg"])
+
+
 def test_init_interactive_selection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_printouts.py
+++ b/tests/test_printouts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from scikit_build_core.builder.__main__ import main
 
 TYPE_CHECKING = False
@@ -7,7 +9,23 @@ if TYPE_CHECKING:
     import pytest
 
 
-def test_builder_printout(capsys: pytest.CaptureFixture[str]) -> None:
+def test_builder_printout(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["scikit_build_core.builder"])
     main()
     out, _ = capsys.readouterr()
     assert "Detected Python Library" in out
+
+
+def test_builder_module_wheel_tag(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test: ``python -m scikit_build_core.builder <subcommand>`` used to
+    # silently ignore its arguments and always print the full info dump.
+    monkeypatch.setattr(
+        sys, "argv", ["scikit_build_core.builder", "wheel-tag", "--purelib"]
+    )
+    main()
+    out, _ = capsys.readouterr()
+    assert out.strip() == "py3-none-any"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `python -m scikit_build_core.builder <args>` silently ignored all arguments and always printed the full info dump instead of dispatching to subcommands like `wheel-tag` and `sysconfig`. It now builds and parses its own argument parser (mirroring `build`/`file-api`/`init`), so `python -m scikit_build_core.builder wheel-tag` matches `scikit-build builder wheel-tag`.
- `scikit-build init --name 1demo` scaffolded an unimportable package: `packaging`'s `canonicalize_name` accepts leading-digit names, but the derived module (`1demo`) is not a valid Python identifier, and the printed next-steps even included a `python -c "import 1demo; ..."` snippet that's a `SyntaxError`. The CLI now checks `module.isidentifier()` after deriving the module name and exits with a clear error suggesting `--name`.
- `scikit-build init <path>` where `<path>` is an existing file raised a raw `FileExistsError` deep inside template generation. It now checks up front and reports a clear "already exists and is not a directory" error.
- `scikit-build build requires` / `project-table` run outside a project directory raised a raw `FileNotFoundError`. A shared `_load_pyproject()` helper now gives a clear "No pyproject.toml found in the current directory" error.

Part of #1417.

## Test plan

- [x] Added regression tests confirming each bug reproduces before the fix (verified failing on unfixed code, then passing).
- [x] `uv run pytest tests/test_init.py tests/test_build_cli.py tests/test_cli.py tests/test_printouts.py` — all pass.
- [x] `uv run pytest tests/ -m "not integration and not network"` — full suite passes.
- [x] `prek -a --quiet` — clean (aside from the known local `check-sdist` noise from gitignored `uv.lock`/`.claude`, unrelated to this change).

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd