### PR TITLE
fix(editable): make namespace package editable installs importable

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -37,6 +37,7 @@ __all__ = [
     "get_packages",
     "libdir_to_installed",
     "mapping_to_modules",
+    "package_search_dirs",
 ]
 
 
@@ -231,11 +232,13 @@ def editable_inplace_files(
     """
     if use_start is None:
         use_start = sys.version_info >= (3, 15)
-    # The importable top-level name is the entry's leaf with any module suffix
-    # stripped -- a package dir keeps its name (``mypkg``), a single-module entry
-    # drops the extension (``hello.py`` -> ``hello``, #888) so it matches the
-    # finder's ``fullname.partition(".")[0]`` check.
-    known_packages = sorted({Path(v).name.partition(".")[0] for v in packages.values()})
+    # The importable top-level name is the first component of the package key
+    # with any module suffix stripped -- a nested namespace package
+    # (``myns/mypkg``) is imported as ``myns`` (not the leaf ``mypkg``), a plain
+    # package keeps its name (``mypkg``), and a single-module entry drops the
+    # extension (``hello.py`` -> ``hello``, #888). This matches the finder's
+    # ``fullname.partition(".")[0]`` check.
+    known_packages = sorted({Path(k).parts[0].partition(".")[0] for k in packages})
     editable_txt = editable_inplace(
         known_packages=known_packages,
         search_paths=list(package_paths),
@@ -294,6 +297,27 @@ def get_packages(
                 return {rel: str(path)}
 
     return {}
+
+
+def package_search_dirs(packages: Mapping[str, str]) -> list[str]:
+    """
+    Compute the ``sys.path`` search directories for a set of packages.
+
+    Each package key records where the package lands relative to the platlib
+    root, so its source directory must be stripped by as many levels as the key
+    is deep to yield the directory to put on ``sys.path``: a nested namespace
+    package ``{"myns/mypkg": "src/myns/mypkg"}`` yields ``src`` (so
+    ``import myns.mypkg`` works), while a plain ``{"mypkg": "src/mypkg"}`` yields
+    ``src`` too. Stripping only one level (``.parent``) breaks nested packages by
+    exposing the leaf as a top-level import.
+    """
+    result: list[str] = []
+    for key, value in packages.items():
+        search = Path.cwd().joinpath(value)
+        for _ in Path(key).parts:
+            search = search.parent
+        result.append(str(search.resolve()))
+    return result
 
 
 def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
@@ -386,6 +410,17 @@ def collect_search_locations(
             parent = module.rpartition(".")[0]
         if parent:
             directories.setdefault(parent, set()).add(directory)
+            # Register every namespace ancestor (PEP 420) of the package holding
+            # this file, so the redirect finder can synthesize them. ``directory``
+            # is the package's own directory, so each ancestor sits one level up
+            # (``myns/mypkg`` -> ``myns``). Without this a nested namespace
+            # package's top ancestor is never registered and ``import myns`` fails.
+            ancestor = parent
+            ancestor_dir = directory
+            while "." in ancestor:
+                ancestor = ancestor.rpartition(".")[0]
+                ancestor_dir = str(Path(ancestor_dir).parent)
+                directories.setdefault(ancestor, set()).add(ancestor_dir)
 
     return (
         {pkg: sorted(dirs) for pkg, dirs in directories.items()},

--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -410,17 +410,23 @@ def collect_search_locations(
             parent = module.rpartition(".")[0]
         if parent:
             directories.setdefault(parent, set()).add(directory)
-            # Register every namespace ancestor (PEP 420) of the package holding
-            # this file, so the redirect finder can synthesize them. ``directory``
-            # is the package's own directory, so each ancestor sits one level up
-            # (``myns/mypkg`` -> ``myns``). Without this a nested namespace
-            # package's top ancestor is never registered and ``import myns`` fails.
-            ancestor = parent
-            ancestor_dir = directory
-            while "." in ancestor:
-                ancestor = ancestor.rpartition(".")[0]
-                ancestor_dir = str(Path(ancestor_dir).parent)
-                directories.setdefault(ancestor, set()).add(ancestor_dir)
+            # Register every namespace ancestor (PEP 420) of a *package* -- a
+            # directory with an importable ``__init__`` -- so the redirect finder
+            # can synthesize them. ``directory`` is then the package's own
+            # directory, so each ancestor sits one level up (``myns/mypkg`` ->
+            # ``myns``); without this a nested namespace package's top ancestor is
+            # never registered and ``import myns`` fails. Only packages drive this:
+            # a loose file's containing chain is not a namespace hierarchy, so a
+            # ``wheel.install-dir`` prefix over a bare installed module (e.g.
+            # ``other_pkg/simplest/_module.so``) must not synthesize ``other_pkg``,
+            # which would shadow a real top-level package (#1427).
+            if is_init:
+                ancestor = parent
+                ancestor_dir = directory
+                while "." in ancestor:
+                    ancestor = ancestor.rpartition(".")[0]
+                    ancestor_dir = str(Path(ancestor_dir).parent)
+                    directories.setdefault(ancestor, set()).add(ancestor_dir)
 
     return (
         {pkg: sorted(dirs) for pkg, dirs in directories.items()},

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -47,7 +47,12 @@ from .._variants import get_wheel_variant
 from ..cmake import CMake
 from ..errors import FailedLiveProcessError
 from ..settings.skbuild_read_settings import SettingsReader
-from ._editable import editable_inplace_files, editable_redirect_files, get_packages
+from ._editable import (
+    editable_inplace_files,
+    editable_redirect_files,
+    get_packages,
+    package_search_dirs,
+)
 from ._init import setup_logging
 from ._pathutil import (
     iter_force_include,
@@ -546,9 +551,7 @@ def _build_wheel_impl_impl(
                 exclude_exempt=force_included,
             )
 
-            str_pkgs = (
-                str(Path.cwd().joinpath(p).parent.resolve()) for p in packages.values()
-            )
+            str_pkgs = package_search_dirs(packages)
             if editable and settings.editable.mode == "redirect":
                 reload_dir = build_dir.resolve() if settings.build_dir else None
 

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -36,6 +36,7 @@ from ..build._editable import (
     editable_inplace_files,
     editable_redirect_files,
     get_packages,
+    package_search_dirs,
 )
 from ..build._init import setup_logging
 from ..build._pathutil import packages_to_file_mapping, scantree
@@ -259,10 +260,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                 packages=settings.wheel.packages,
                 name=self.build_config.builder.metadata.name,
             )
-            package_paths = [
-                str(Path.cwd().joinpath(package).parent.resolve())
-                for package in packages.values()
-            ]
+            package_paths = package_search_dirs(packages)
             if package_paths:
                 self.build_config.target_config["dev-mode-dirs"] = package_paths
 

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -16,6 +16,7 @@ from scikit_build_core.build._editable import (
     get_packages,
     libdir_to_installed,
     mapping_to_modules,
+    package_search_dirs,
 )
 from scikit_build_core.build._pathutil import (
     is_module,
@@ -313,6 +314,67 @@ def test_navigate_editable_remapped_namespace(
     assert virtualenv.execute(read_data) == "payload"
 
 
+def test_package_search_dirs_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # A nested namespace package's sys.path entry is the src root (stripped by
+    # the key depth), not one level shallower -- otherwise the leaf leaks as a
+    # top-level import (#1417).
+    monkeypatch.chdir(tmp_path)
+    src = str((tmp_path / "src").resolve())
+    assert package_search_dirs({"myns/mypkg": str(Path("src") / "myns" / "mypkg")}) == [
+        src
+    ]
+    # A plain package strips exactly one level, unchanged from before.
+    assert package_search_dirs({"mypkg": str(Path("src") / "mypkg")}) == [src]
+
+
+def test_navigate_editable_namespace_package(
+    tmp_path: Path, virtualenv: VEnv, monkeypatch: pytest.MonkeyPatch
+):
+    # Regression test for #1417: an auto-discovered nested namespace package
+    # (myns/mypkg) must be importable as `import myns.mypkg`, and must not leak
+    # the leaf as a top-level `import mypkg`.
+    site_packages = virtualenv.purelib
+
+    source_dir = tmp_path / "source"
+    leaf = source_dir / "src" / "myns" / "mypkg"
+    leaf.mkdir(parents=True)
+    monkeypatch.chdir(source_dir)
+    leaf.joinpath("__init__.py").write_text("value = 'ns'\n")
+
+    packages = {"myns/mypkg": str(Path("src") / "myns" / "mypkg")}
+    mapping = packages_to_file_mapping(
+        packages=packages,
+        platlib_dir=site_packages,
+        include=[],
+        src_exclude=[],
+        target_exclude=[],
+        build_dir="",
+        mode="classic",
+    )
+    search_dirs = package_search_dirs(packages)
+    # The sys.path entry is the src root, not src/myns.
+    assert search_dirs == [str((source_dir / "src").resolve())]
+
+    files = editable_redirect_files(
+        libdir=site_packages,
+        mapping=mapping,
+        name="myns_mypkg",
+        packages=search_dirs,
+        reload_dir=None,
+        settings=ScikitBuildSettings(),
+        use_start=False,
+    )
+    for fname, content in files.items():
+        site_packages.joinpath(fname).write_bytes(content)
+
+    assert virtualenv.execute("import myns.mypkg; print(myns.mypkg.value)") == "ns"
+    # The leaf must not be importable as a top-level module.
+    out = virtualenv.execute(
+        "import importlib.util; print(importlib.util.find_spec('mypkg') is not None)"
+    )
+    assert out == "False"
+
+
 def test_packages_to_file_mapping_module(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -550,6 +612,25 @@ def test_editable_inplace_files_module_entry(tmp_path: Path):
     # install_inplace's first argument is the known_packages list.
     assert "install_inplace(['hello']," in py
     assert "hello.py" not in py.partition("install_inplace(")[2].partition("]")[0]
+
+
+def test_editable_inplace_files_namespace_top_level(tmp_path: Path):
+    # A nested namespace package must wrap its top-level namespace name (myns),
+    # not the leaf (mypkg), or `import myns.mypkg` fails while `import mypkg`
+    # wrongly succeeds (#1417).
+    files = editable_inplace_files(
+        name="myns_mypkg",
+        packages={"myns/mypkg": str(Path("src") / "myns" / "mypkg")},
+        package_paths=[str(tmp_path / "src")],
+        source_dir=tmp_path / "build",
+        settings=ScikitBuildSettings(),
+        use_start=False,
+    )
+
+    py = files["_editable_skbc_myns_mypkg.py"].decode()
+    # The finder matches fullname.partition(".")[0], so the wrapped name is the
+    # top-level namespace, and the leaf never appears as a known package.
+    assert "install_inplace(['myns']," in py
 
 
 def test_editable_inplace_files_bakes_rebuild_flag(tmp_path: Path):
@@ -951,6 +1032,29 @@ def test_collect_search_locations_data_only_install_dir(tmp_path: Path):
     assert str(Path("pkg")) in directories["pkg"]
     # The data file itself is not an importable module.
     assert "pkg.data" not in libdir_to_installed(libdir)
+
+
+def test_collect_search_locations_namespace_ancestor(tmp_path: Path):
+    # A nested namespace package (myns/mypkg) must register its namespace
+    # ancestor (myns) as a search location so the redirect finder can synthesize
+    # the namespace package, making `import myns.mypkg` work (#1417).
+    libdir = tmp_path / "site"
+    libdir.mkdir()
+    src = tmp_path / "src"
+    mapping = {
+        str(src / "myns" / "mypkg" / "__init__.py"): str(
+            libdir / "myns" / "mypkg" / "__init__.py"
+        )
+    }
+
+    directories, packages = collect_search_locations(mapping, libdir)
+
+    # The leaf is a regular package; the namespace ancestor is not.
+    assert packages == ["myns.mypkg"]
+    assert "myns" not in packages
+    # The namespace ancestor is registered, pointing at the parent directory.
+    assert "myns" in directories
+    assert str(src / "myns") in directories["myns"]
 
 
 def test_collect_search_locations_pxd_packages(tmp_path: Path):

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -1057,6 +1057,32 @@ def test_collect_search_locations_namespace_ancestor(tmp_path: Path):
     assert str(src / "myns") in directories["myns"]
 
 
+def test_collect_search_locations_install_dir_prefix_not_namespace(tmp_path: Path):
+    # A wheel.install-dir prefix (other_pkg/) applies only to CMake-installed
+    # files; the Python package (simplest) stays unprefixed. The prefix is not a
+    # namespace package, so it must not be synthesized as a namespace ancestor --
+    # doing so makes the redirect finder claim `other_pkg`, shadowing a real
+    # top-level package and breaking its import/rebuild (#1427).
+    libdir = tmp_path / "site"
+    libdir.mkdir()
+    src = tmp_path / "src"
+    (src / "simplest").mkdir(parents=True)
+    (src / "simplest" / "__init__.py").touch()
+    # CMake output installed under the install-dir prefix, with no __init__.
+    mod_dir = libdir / "other_pkg" / "simplest"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "_module.py").touch()
+    mapping = {
+        str(src / "simplest" / "__init__.py"): str(libdir / "simplest" / "__init__.py"),
+    }
+
+    directories, packages = collect_search_locations(mapping, libdir)
+
+    assert packages == ["simplest"]
+    # The install-dir prefix is not registered as a synthesizable namespace.
+    assert "other_pkg" not in directories
+
+
 def test_collect_search_locations_pxd_packages(tmp_path: Path):
     # .pxd/.pyx __init__ files define packages even though they are not
     # importable; they must be marked as packages and given their own directory

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -319,7 +319,11 @@ def test_package_search_dirs_namespace(tmp_path: Path, monkeypatch: pytest.Monke
     # the key depth), not one level shallower -- otherwise the leaf leaks as a
     # top-level import (#1417).
     monkeypatch.chdir(tmp_path)
-    src = str((tmp_path / "src").resolve())
+    # Build the expected value from Path.cwd() like the code under test does:
+    # deriving it from tmp_path is not alias-proof (on cygwin, TEMP holds a
+    # Windows 8.3 short name like RUNNER~1 while getcwd returns the long form,
+    # and resolve() does not reliably canonicalize between them).
+    src = str(Path.cwd().joinpath("src").resolve())
     assert package_search_dirs({"myns/mypkg": str(Path("src") / "myns" / "mypkg")}) == [
         src
     ]
@@ -352,8 +356,10 @@ def test_navigate_editable_namespace_package(
         mode="classic",
     )
     search_dirs = package_search_dirs(packages)
-    # The sys.path entry is the src root, not src/myns.
-    assert search_dirs == [str((source_dir / "src").resolve())]
+    # The sys.path entry is the src root, not src/myns. Expected value built
+    # from Path.cwd() like the code under test, to stay immune to Windows 8.3
+    # short-name aliasing in tmp_path on cygwin.
+    assert search_dirs == [str(Path.cwd().joinpath("src").resolve())]
 
     files = editable_redirect_files(
         libdir=site_packages,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

Editable installs of nested namespace packages (PEP 420) are broken. With
`tests/packages/namespace_purelib_package` (project `myns.mypkg` at
`src/myns/mypkg`, auto-discovered as `{"myns/mypkg": "src/myns/mypkg"}`):

- The generated `.pth` put `<proj>/src/myns` on `sys.path` (one level too
  shallow) and the redirect `install()` mapped only `myns.mypkg`.
- Result: `import myns.mypkg` raised `ModuleNotFoundError: No module named 'myns'`,
  while `import mypkg` wrongly succeeded as a top-level name.

Non-editable wheels were fine. This affects both redirect and inplace modes and
both the backend and the hatch plugin. Explicit dotted `wheel.packages` tables
hit the same paths; #1385's auto-discovery made it the silent default.

### Repro

```console
$ pip install -e .   # in tests/packages/namespace_purelib_package
$ python -c 'import myns.mypkg'   # ModuleNotFoundError: No module named 'myns'
$ python -c 'import mypkg'        # incorrectly succeeds
```

## Fix

Three root causes, all addressed:

1. **`build/wheel.py` / `hatch/plugin.py`** stripped exactly one path level
   (`Path.cwd().joinpath(p).parent`) regardless of package-key depth. New
   `package_search_dirs()` strips as many levels as the key has parts
   (`src/myns/mypkg` with key `myns/mypkg` -> `src`).
2. **`build/_editable.py` `collect_search_locations`** never registered the
   namespace ancestor (`myns`), so the redirect finder could not synthesize the
   `myns` namespace package. It now registers every PEP 420 namespace ancestor.
3. **`build/_editable.py` inplace `known_packages`** used the leaf name
   (`mypkg`); it now uses the package key's top-level component (`myns`).

## Tests

Added regression tests in `tests/test_editable_unit.py` (confirmed failing before
the fix): namespace-ancestor registration, inplace top-level naming, the search-dir
computation, and an end-to-end redirect install asserting `import myns.mypkg` works
and `import mypkg` fails. Verified both redirect and inplace modes end-to-end
against the real fixture.

Part of #1417.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd