### PR TITLE
fix(setuptools): build-type list rejection, package_dir editable root, FT limited-api gate

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -324,7 +324,15 @@ class Builder:
             if sys.implementation.name != "cpython":
                 logger.info("PyPy doesn't support the Limited API, ignoring")
             elif gil_disabled:
-                sabi = _SabiMode.ABI3T
+                # The free-threaded stable ABI (PEP 803 / abi3t) only exists on
+                # CPython 3.15+; older free-threaded builds have no abi3t, so a
+                # forced abi3t module would be unimportable. Downgrade instead.
+                if sys.version_info >= (3, 15):
+                    sabi = _SabiMode.ABI3T
+                else:
+                    logger.info(
+                        "Free-threaded Python doesn't support the Limited API currently, ignoring"
+                    )
             else:
                 sabi = _SabiMode.ABI3
         elif limited_api is None and py_api.startswith("cp3"):

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -93,6 +93,9 @@ def _validate_settings(
     if settings.wheel.py_api:
         msg = "wheel.py_api is not supported in setuptools mode, use bdist_wheel options instead"
         raise SetupError(msg)
+    if len(normalize_build_types(settings.cmake.build_type)) > 1:
+        msg = "cmake.build-type lists (multi-config) are not supported in setuptools mode, use a single build type"
+        raise SetupError(msg)
     if editable_mode:
         if settings.editable.mode != "inplace":
             msg = "setuptools editable installs require editable.mode = 'inplace'"
@@ -442,9 +445,16 @@ class BuildCMake(setuptools.Command):
         if not self.editable_mode:
             return Path(self.build_lib).resolve() / install_subdir
 
-        package_dir = getattr(self.distribution, "package_dir", {}) or {}
-        source_root = package_dir.get("", ".")
-        return Path(source_root).resolve() / install_subdir
+        # The wrapper translates cmake_install_dir relative to the package base
+        # dir (which honors per-package package_dir), so the editable source
+        # root must use the same base or the extension lands beside the wrong
+        # tree (creating a junk directory).
+        if self._wrapper_compat_enabled():
+            source_root = _package_base_dir(self.distribution)
+        else:
+            package_dir = getattr(self.distribution, "package_dir", {}) or {}
+            source_root = Path(package_dir.get("", "."))
+        return source_root.resolve() / install_subdir
 
     def _set_generated_data_files(
         self, data_files: list[tuple[str, list[str]]] | None = None

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15...4.3)
+project(
+  "${SKBUILD_PROJECT_NAME}"
+  LANGUAGES C
+  VERSION "${SKBUILD_PROJECT_VERSION}")
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+python_add_library(_core MODULE src/main.c WITH_SOABI)
+
+target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
+
+install(TARGETS _core LIBRARY DESTINATION .)

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/pyproject.toml
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "scikit_build_core[setuptools]",
+]
+build-backend = "scikit_build_core.setuptools.build_meta"
+
+[tool.scikit-build]
+editable.mode = "inplace"

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/setup.py
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/setup.py
@@ -1,0 +1,15 @@
+from scikit_build_core.setuptools.wrapper import setup
+
+# Per-package package_dir mapping (as opposed to the root "" -> "src" form):
+# the editable source root must resolve to src/wrapper_pkgdir, not "." (which
+# would create a junk ./wrapper_pkgdir directory).
+setup(
+    name="wrapper-pkgdir",
+    version="0.0.1",
+    cmake_source_dir=".",
+    cmake_install_dir="src/wrapper_pkgdir",
+    package_dir={"wrapper_pkgdir": "src/wrapper_pkgdir"},
+    packages=["wrapper_pkgdir"],
+    zip_safe=False,
+    python_requires=">=3.8",
+)

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/src/main.c
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/src/main.c
@@ -1,0 +1,28 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+static PyObject *add(PyObject *self, PyObject *args) {
+  int i, j;
+  if (!PyArg_ParseTuple(args, "ii", &i, &j)) {
+    return NULL;
+  }
+  return PyLong_FromLong((long)i + (long)j);
+}
+
+static PyObject *subtract(PyObject *self, PyObject *args) {
+  int i, j;
+  if (!PyArg_ParseTuple(args, "ii", &i, &j)) {
+    return NULL;
+  }
+  return PyLong_FromLong((long)i - (long)j);
+}
+
+static PyMethodDef core_methods[] = {
+    {"add", add, METH_VARARGS, "Add two numbers"},
+    {"subtract", subtract, METH_VARARGS, "Subtract two numbers"},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef core_module = {PyModuleDef_HEAD_INIT, "_core", NULL,
+                                         -1, core_methods};
+
+PyMODINIT_FUNC PyInit__core(void) { return PyModule_Create(&core_module); }

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/src/wrapper_pkgdir/__init__.py
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/src/wrapper_pkgdir/__init__.py
@@ -1,0 +1,3 @@
+from ._core import add  # type: ignore[import-not-found]
+
+__all__ = ["add"]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -71,6 +71,9 @@ class VersionInfo:
     def __ge__(self, other: tuple[int, ...]) -> bool:
         return (self.major, self.minor, self.micro) >= other[:3]
 
+    def __lt__(self, other: tuple[int, ...]) -> bool:
+        return (self.major, self.minor, self.micro) < other[:3]
+
 
 # The envvar_higher case shouldn't happen, but the compiler should cause the
 # correct failure
@@ -466,6 +469,8 @@ def test_builder_limited_api_override_free_threaded(tmp_path, monkeypatch):
         lambda x: "t" if x == "Py_GIL_DISABLED" else get_config_var(x),
     )
     patch_cpython_runtime(monkeypatch)
+    # abi3t (PEP 803) requires CPython 3.15+.
+    monkeypatch.setattr(sys, "version_info", VersionInfo(3, 15))
 
     cache = configure_builder_with_limited_api(tmp_path, monkeypatch, limited_api=True)
 
@@ -473,6 +478,24 @@ def test_builder_limited_api_override_free_threaded(tmp_path, monkeypatch):
     assert "Development.SABIModule" in cache
     assert f"set(SKBUILD_SOABI [===[{expected_soabi}]===] CACHE STRING" in cache
     assert "set(Py_TARGET_ABI3T [===[1]===] CACHE STRING" in cache
+
+
+def test_builder_limited_api_override_free_threaded_no_abi3t(tmp_path, monkeypatch):
+    # Free-threaded CPython < 3.15 has no abi3t; forcing limited_api=True must
+    # downgrade (no SABI) instead of emitting an unimportable abi3t module.
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: "t" if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    patch_cpython_runtime(monkeypatch)
+    monkeypatch.setattr(sys, "version_info", VersionInfo(3, 14))
+
+    cache = configure_builder_with_limited_api(tmp_path, monkeypatch, limited_api=True)
+
+    assert "Development.SABIModule" not in cache
+    assert "Py_TARGET_ABI3T" not in cache
 
 
 def test_builder_limited_api_auto_free_threaded(tmp_path, monkeypatch):

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -51,9 +51,16 @@ SETUPTOOLS_INSTALL_DIR_CASES = [
         editable_dir=Path("src/wrapper_example"),
         wheel_missing="src/wrapper_example/__init__.py",
     ),
+    SetuptoolsInstallDirCase(
+        package="wrapper_setuptools_install_dir_pkgdir",
+        module="wrapper_pkgdir",
+        wheel_prefix="wrapper_pkgdir",
+        editable_dir=Path("src/wrapper_pkgdir"),
+        wheel_missing="src/wrapper_pkgdir/__init__.py",
+    ),
 ]
 
-SETUPTOOLS_INSTALL_DIR_CASE_IDS = ["plugin", "wrapper"]
+SETUPTOOLS_INSTALL_DIR_CASE_IDS = ["plugin", "wrapper", "wrapper_pkgdir"]
 
 
 def _assert_extension_import(venv: VEnv, module: str) -> None:
@@ -397,6 +404,9 @@ def test_wrapper_classic_layout_wheel(tmp_path: Path):
     reason="Cygwin fails here with ld errors",
     strict=False,
 )
+# Per-package package_dir makes setuptools fall back to the meta-path finder,
+# which emits an InformationOnly note (turned into an error by filterwarnings).
+@pytest.mark.filterwarnings("ignore:Editable installation")
 @pytest.mark.parametrize(
     ("package", "case"),
     [(case.package, case) for case in SETUPTOOLS_INSTALL_DIR_CASES],
@@ -530,6 +540,46 @@ def test_validate_settings_raises_setup_error():
     settings.wheel.py_api = "cp39"
     with pytest.raises(SetupError, match=r"wheel\.py_api is not supported"):
         build_cmake._validate_settings(settings)
+
+
+def test_validate_settings_rejects_build_type_list():
+    # The setuptools plugin builds a single config; a multi-config build-type
+    # list would be silently truncated to the first entry, so reject it.
+    settings = build_cmake._load_settings()
+    settings.cmake.build_type = ["Release", "Debug"]
+    with pytest.raises(SetupError, match=r"cmake\.build-type lists"):
+        build_cmake._validate_settings(settings)
+
+
+def test_validate_settings_allows_single_build_type_list():
+    settings = build_cmake._load_settings()
+    settings.cmake.build_type = ["Release"]
+    build_cmake._validate_settings(settings)
+
+
+def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
+    # Per-package package_dir (as opposed to {"": "src"}): the wrapper
+    # translates cmake_install_dir relative to src, so the editable source root
+    # must also be src, not "." (which would create a junk ./wrapper_example).
+    monkeypatch.chdir(tmp_path)
+    dist = setuptools.Distribution(
+        {
+            "name": "wrapper-example",
+            "version": "0.0.1",
+            "packages": ["wrapper_example"],
+            "package_dir": {"wrapper_example": "src/wrapper_example"},
+        }
+    )
+    setattr(dist, build_cmake.WRAPPER_COMPAT, True)
+    dist.cmake_install_dir = "src/wrapper_example"  # type: ignore[attr-defined]
+
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.build_lib = str(tmp_path / "build")
+    cmd.editable_mode = True
+
+    install_dir = cmd._get_install_dir()
+    assert install_dir == (tmp_path / "src" / "wrapper_example").resolve()
 
 
 def test_wrapper_setup_raises_setup_error():

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -562,6 +562,11 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     # translates cmake_install_dir relative to src, so the editable source root
     # must also be src, not "." (which would create a junk ./wrapper_example).
     monkeypatch.chdir(tmp_path)
+    # Materialize the source tree so Path.resolve() is deterministic: before
+    # Python 3.10, resolving a nonexistent path is unreliable (Windows leaves it
+    # relative, cygwin keeps 8.3 short names). A real editable install always has
+    # the source present.
+    (tmp_path / "src" / "wrapper_example").mkdir(parents=True)
     dist = setuptools.Distribution(
         {
             "name": "wrapper-example",

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -562,10 +562,9 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     # translates cmake_install_dir relative to src, so the editable source root
     # must also be src, not "." (which would create a junk ./wrapper_example).
     monkeypatch.chdir(tmp_path)
-    # Materialize the source tree so Path.resolve() is deterministic: before
-    # Python 3.10, resolving a nonexistent path is unreliable (Windows leaves it
-    # relative, cygwin keeps 8.3 short names). A real editable install always has
-    # the source present.
+    # Materialize the source tree: resolving a nonexistent path is unreliable
+    # before Python 3.10 (Windows leaves it relative), and samefile below needs
+    # to stat it. A real editable install always has the source present.
     (tmp_path / "src" / "wrapper_example").mkdir(parents=True)
     dist = setuptools.Distribution(
         {
@@ -584,7 +583,10 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     cmd.editable_mode = True
 
     install_dir = cmd._get_install_dir()
-    assert install_dir == (tmp_path / "src" / "wrapper_example").resolve()
+    # samefile compares stat identity, immune to Windows 8.3 short-name
+    # aliasing (RUNNER~1 vs runneradmin) that resolve() misses on cygwin.
+    assert install_dir.is_absolute()
+    assert install_dir.samefile(tmp_path / "src" / "wrapper_example")
 
 
 def test_wrapper_setup_raises_setup_error():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes three verified bugs in the setuptools plugin (and a shared builder gate). Part of #1417.

## Bug A: multi-config `cmake.build-type` lists silently truncated
The setuptools plugin used `normalize_build_types(settings.cmake.build_type)[0]`, dropping every build type after the first (the backend and hatch plugins build the extras). Following the plugin's established pattern of raising `SetupError` in `_validate_settings` for unsupported settings, it now rejects multi-config lists with a clear message telling users the setuptools plugin supports a single build type.

## Bug B: editable install root ignored per-package `package_dir` under wrapper compat
`_get_install_dir` computed the editable source root as `package_dir.get("", ".")`, while the wrapper translates `cmake_install_dir` via `_package_base_dir` (which honors per-package `package_dir` entries). With `package_dir={"mypkg": "src/mypkg"}` + `cmake_install_dir="src/mypkg"` + inplace editable, the subdir translated to `mypkg` but the root stayed `.`, so CMake installed into a freshly-created `./mypkg/` junk directory instead of `./src/mypkg/` next to the exposed sources. It now uses `_package_base_dir(self.distribution)` as the source root when wrapper compat is enabled. Added a new `wrapper_setuptools_install_dir_pkgdir` test package covering the per-package mapping (the existing one only covered `package_dir={"": "src"}`), plus a fast unit test.

## Bug C: external `limited_api=True` on free-threaded Python force-selected ABI3T with no version gate
`limited_api=True` + `Py_GIL_DISABLED` unconditionally set `_SabiMode.ABI3T`. Unlike the `py-api` path, there was no interpreter-version check, so `py_limited_api` via the setuptools plugin on 3.13t/3.14t (no PEP 803/abi3t support) produced `SKBUILD_SOABI=abi3t` modules the interpreter cannot import and probed for a nonexistent `python3t` library. It now mirrors the py-api gate: only free-threaded CPython 3.15+ selects ABI3T; older free-threaded builds downgrade with a warning (restoring 0.12.2 behavior).

## Tests
- Regression tests added for each bug and confirmed to fail before the fix.
- `tests/test_builder.py`, `tests/test_setuptools_pep517.py`, `tests/test_setuptools_abi3.py`, `tests/test_pyproject_abi3.py` pass; ruff + mypy clean.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd