### PR TITLE
fix(editable): safe install/build paths for manual rebuild()

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -55,7 +55,7 @@ def editable_redirect(
     verbose: bool,
     build_options: Sequence[str],
     install_options: Sequence[str],
-    install_dir: str,
+    install_dir: str | None,
     as_entrypoint: bool = False,
 ) -> str:
     """
@@ -128,17 +128,22 @@ def editable_redirect_files(
         mapping, libdir, absolute=external_install
     )
     rebuild = settings.editable.rebuild_enabled
+    install_dir: str | None
     if install_prefix is not None:
         # The persistent install tree lives outside the wheel, so the shim is
         # given an absolute prefix (os.path.join drops DIR for an absolute path)
         # and references the installed files by absolute path.
         install_dir = install_prefix
     else:
-        install_dir = settings.wheel.install_dir
-        if rebuild:
-            # The shim joins install_dir onto the platlib root; a platlib/purelib
-            # selector reduces to its remainder, any other tree is rejected.
-            install_dir = editable_rebuild_install_dir(install_dir)
+        # The shim joins install_dir onto the platlib root for a manual
+        # module.__loader__.rebuild(), available whenever a build-dir is set even
+        # with rebuild off (#1403). A platlib/purelib selector reduces to its
+        # remainder. When rebuild is enabled any other tree is a hard error;
+        # otherwise it is baked as None (see editable_rebuild_install_dir) so
+        # rebuild() refuses rather than install to a bogus (or root) path.
+        install_dir = editable_rebuild_install_dir(
+            settings.wheel.install_dir, strict=rebuild
+        )
     editable_txt = editable_redirect(
         modules=modules,
         installed=installed,

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Mapping, Sequence
 
 __all__ = [
+    "NON_PLATLIB_REBUILD_MSG",
     "editable_rebuild_install_dir",
     "is_module",
     "is_trackable",
@@ -194,7 +195,15 @@ def resolve_wheel_tree(
     return wheel_dirs[targetlib], dest
 
 
-def editable_rebuild_install_dir(install_dir: str) -> str:
+NON_PLATLIB_REBUILD_MSG = (
+    "Editable installs cannot rebuild a non-platlib wheel.install-dir. Use an "
+    "override to change if needed."
+)
+
+
+def editable_rebuild_install_dir(
+    install_dir: str, *, strict: bool = True
+) -> str | None:
     """
     Reduce ``wheel.install-dir`` to a platlib-relative path for the editable shim.
 
@@ -202,7 +211,13 @@ def editable_rebuild_install_dir(install_dir: str) -> str:
     understands a relative path. A platlib/purelib tree selector
     (``${SKBUILD_PLATLIB_DIR}/pkg`` or ``/platlib/pkg``) is equivalent to a plain
     ``pkg`` and is reduced to its remainder. A selector for any other tree
-    escapes the platlib and cannot be rebuilt on import, so it raises.
+    escapes the platlib and cannot be rebuilt.
+
+    With ``strict`` (rebuild enabled on import), such a tree is a hard error.
+    Otherwise -- a non-rebuild editable that still exposes a manual
+    ``module.__loader__.rebuild()`` (#1403) -- ``None`` is returned as a sentinel
+    so the shim can refuse a rebuild rather than install to a bogus (or
+    filesystem-root) path.
     """
     if install_dir.startswith("${"):
         var_match = _WHEEL_TREE_VAR.fullmatch(install_dir)
@@ -217,8 +232,9 @@ def editable_rebuild_install_dir(install_dir: str) -> str:
         return install_dir
     if tree in {"platlib", "purelib"}:
         return rest
-    msg = "Editable installs cannot rebuild a non-platlib wheel.install-dir. Use an override to change if needed."
-    raise AssertionError(msg)
+    if strict:
+        raise AssertionError(NON_PLATLIB_REBUILD_MSG)
+    return None
 
 
 def resolve_from_sdist_force_include(

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -50,6 +50,7 @@ from ..settings.skbuild_read_settings import SettingsReader
 from ._editable import editable_inplace_files, editable_redirect_files, get_packages
 from ._init import setup_logging
 from ._pathutil import (
+    NON_PLATLIB_REBUILD_MSG,
     iter_force_include,
     packages_to_file_mapping,
     resolve_from_sdist_force_include,
@@ -380,14 +381,19 @@ def _build_wheel_impl_impl(
             reproducible=settings.wheel.reproducible,
         )
 
-        # A rebuildable editable cannot use an absolute wheel.install-dir (an
-        # AssertionError is raised earlier), so install_dir sits under the target
-        # lib; re-point it into the persistent install tree, and bake the same
-        # SKBUILD_<targetlib>_DIR so an absolute ${SKBUILD_*_DIR}/... destination
-        # also lands there.
+        # A rebuildable editable re-points install_dir into the persistent
+        # install tree and bakes the same SKBUILD_<targetlib>_DIR so an absolute
+        # ${SKBUILD_*_DIR}/... destination lands there too. The install tree only
+        # covers the target lib, so wheel.install-dir must resolve under it; a
+        # non-platlib (or absolute) tree cannot be rebuilt and raises the clear
+        # guard here rather than a raw relative_to() ValueError.
         editable_rebuild_cache: dict[str, str | Path] | None = None
         if editable_rebuild:
-            install_dir = targetlib_dir / install_dir.relative_to(wheel_dirs[targetlib])
+            try:
+                install_relative = install_dir.relative_to(wheel_dirs[targetlib])
+            except ValueError:
+                raise AssertionError(NON_PLATLIB_REBUILD_MSG) from None
+            install_dir = targetlib_dir / install_relative
             editable_rebuild_cache = {f"SKBUILD_{targetlib.upper()}_DIR": targetlib_dir}
 
         # Include the metadata license.file entry if provided
@@ -569,11 +575,16 @@ def _build_wheel_impl_impl(
                     msg = "Editable inplace mode requires at least one package"
                     raise AssertionError(msg)
 
+                # Only an inplace CMake build has a persistent build dir to
+                # rebuild in (get_build_dir returns the source dir). Without
+                # CMake, build_dir is a temp dir that is deleted after the build,
+                # so bake None and let rebuild() raise the friendly error instead
+                # of recreating an empty temp dir and failing in CMake.
                 for filename, editable_contents in editable_inplace_files(
                     name=normalized_name,
                     packages=packages,
                     package_paths=list(str_pkgs),
-                    source_dir=build_dir.resolve(),
+                    source_dir=build_dir.resolve() if cmake is not None else None,
                     build_options=build_options,
                     settings=settings,
                 ).items():

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -70,12 +70,16 @@ class FileLockIfUnix:
             time.sleep(poll_interval)
 
     def release(self) -> None:
+        # A no-op if the lock was never acquired: acquire() can raise before
+        # setting lock_file_fd (e.g. PermissionError on a read-only build dir),
+        # and the finally-clause release() must not mask that real error.
+        if self.lock_file_fd is None:
+            return
         try:
             import fcntl
         except ImportError:
             return
 
-        assert isinstance(self.lock_file_fd, int)
         fcntl.flock(self.lock_file_fd, fcntl.LOCK_UN)
         os.close(self.lock_file_fd)
 
@@ -414,7 +418,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         build_options: list[str],
         install_options: list[str],
         dir: str,  # noqa: A002
-        install_dir: str,
+        install_dir: str | None,
     ) -> None:
         self.known_source_files = known_source_files
         self.known_wheel_files = known_wheel_files
@@ -425,7 +429,13 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         self.build_options = build_options
         self.install_options = install_options
         self.dir = dir
-        self.install_dir = os.path.join(DIR, install_dir)
+        # install_dir is None when wheel.install-dir cannot be reproduced by a
+        # rebuild (a non-platlib tree); joining it onto DIR would yield a bogus
+        # (or, for a leading '/', filesystem-root) path, so keep the sentinel and
+        # let rebuild() refuse instead.
+        self.install_dir = (
+            os.path.join(DIR, install_dir) if install_dir is not None else None
+        )
 
         # Construct the __path__ of all package-like objects. known_directories
         # maps each package to the directories that make up its __path__,
@@ -536,6 +546,17 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         return spec
 
     def rebuild(self) -> None:
+        if self.install_dir is None:
+            # wheel.install-dir points outside the platlib, so a rebuild's
+            # 'cmake --install --prefix <site-packages>/<install-dir>' cannot
+            # reproduce the wheel's layout. Refuse rather than install anywhere.
+            msg = (
+                "Cannot rebuild: this editable install's wheel.install-dir is "
+                "outside the platlib and cannot be reproduced by a rebuild. "
+                "Reinstall with a platlib wheel.install-dir (or an override) to "
+                "enable on-demand rebuilds."
+            )
+            raise RuntimeError(msg)
         _run_editable_rebuild(
             path=self.path,
             verbose=self.verbose,
@@ -625,7 +646,7 @@ def install(
     verbose: bool = False,
     build_options: list[str] | None = None,
     install_options: list[str] | None = None,
-    install_dir: str = "",
+    install_dir: str | None = "",
 ) -> None:
     """
     Install a meta path finder that redirects imports to the source files, and

--- a/tests/test_editable_build_paths.py
+++ b/tests/test_editable_build_paths.py
@@ -87,13 +87,14 @@ def test_editable_inplace_no_build_dir_bakes_none_path(chdir_tmp: Path) -> None:
     # install_inplace args: known_packages, search_paths, path, rebuild,
     # verbose, build_options. The path (3rd) must be the None sentinel, not a
     # since-deleted temp build dir. Parse the call so the check does not depend
-    # on the source paths' text (e.g. a /tmp build root on Linux).
+    # on the source paths' text (e.g. a /tmp build root on Linux). Walk the
+    # whole module: on 3.15+ (PEP 829) the call is wrapped in an entrypoint()
+    # function for the .start file rather than emitted top-level.
     (call,) = [
-        node.value
-        for node in ast.parse(shim).body
-        if isinstance(node, ast.Expr)
-        and isinstance(node.value, ast.Call)
-        and getattr(node.value.func, "id", None) == "install_inplace"
+        node
+        for node in ast.walk(ast.parse(shim))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "install_inplace"
     ]
     path_arg = call.args[2]
     assert isinstance(path_arg, ast.Constant)

--- a/tests/test_editable_build_paths.py
+++ b/tests/test_editable_build_paths.py
@@ -1,0 +1,91 @@
+"""Pure-Python (no-CMake) editable builds that exercise the rebuild-path guards.
+
+These reach the wheel backend's editable code paths without needing CMake, so
+they stay fast and hermetic while covering #1417 bugs B and C.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+from scikit_build_core.build import build_editable
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PYPROJECT = """\
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pkg"
+version = "0.1.0"
+
+[tool.scikit-build]
+wheel.cmake = false
+sdist.cmake = false
+experimental = true
+{extra}
+"""
+
+
+def make_pure_pkg(root: Path, extra: str = "") -> None:
+    pkg = root / "pkg"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("__version__ = '0.1.0'\n")
+    (root / "pyproject.toml").write_text(PYPROJECT.format(extra=extra))
+
+
+def read_shim(dist: Path) -> str:
+    (wheel,) = dist.glob("pkg-0.1.0-*.whl")
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.read("_editable_skbc_pkg.py").decode()
+
+
+@pytest.fixture
+def chdir_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    monkeypatch.chdir(root)
+    return root
+
+
+def test_editable_rebuild_nonplatlib_install_dir_friendly_error(
+    chdir_tmp: Path,
+) -> None:
+    # #1417 Bug B: a rebuildable editable with a non-platlib wheel.install-dir
+    # must raise the clear "non-platlib" guard, not a raw
+    # ValueError('... does not start with ...') from relative_to().
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            "editable.rebuild = true\n"
+            'build-dir = "build"\n'
+            'wheel.install-dir = "${SKBUILD_DATA_DIR}/pkg"\n'
+        ),
+    )
+    dist = chdir_tmp / "dist"
+    with pytest.raises(AssertionError, match=r"non-platlib wheel\.install-dir"):
+        build_editable(str(dist), {})
+
+
+def test_editable_inplace_no_build_dir_bakes_none_path(chdir_tmp: Path) -> None:
+    # #1417 Bug C: an inplace editable with no CMake and no persistent build-dir
+    # must bake path=None (a real rebuild would recreate a deleted temp dir and
+    # fail with a confusing CMake error). None makes rebuild() give the intended
+    # friendly RuntimeError instead.
+    make_pure_pkg(chdir_tmp, extra='editable.mode = "inplace"')
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    shim = read_shim(dist)
+    call = shim.rpartition("install_inplace(")[2]
+    # install_inplace args: known_packages, search_paths, path, rebuild,
+    # verbose, build_options. The path (3rd, right after the search_paths list)
+    # must be the None sentinel, not a since-deleted temp build dir.
+    assert "], None, " in call
+    assert "tmp" not in call.partition("], None, ")[0]

--- a/tests/test_editable_build_paths.py
+++ b/tests/test_editable_build_paths.py
@@ -6,6 +6,7 @@ they stay fast and hermetic while covering #1417 bugs B and C.
 
 from __future__ import annotations
 
+import ast
 import zipfile
 
 import pytest
@@ -83,9 +84,17 @@ def test_editable_inplace_no_build_dir_bakes_none_path(chdir_tmp: Path) -> None:
     build_editable(str(dist), {})
 
     shim = read_shim(dist)
-    call = shim.rpartition("install_inplace(")[2]
     # install_inplace args: known_packages, search_paths, path, rebuild,
-    # verbose, build_options. The path (3rd, right after the search_paths list)
-    # must be the None sentinel, not a since-deleted temp build dir.
-    assert "], None, " in call
-    assert "tmp" not in call.partition("], None, ")[0]
+    # verbose, build_options. The path (3rd) must be the None sentinel, not a
+    # since-deleted temp build dir. Parse the call so the check does not depend
+    # on the source paths' text (e.g. a /tmp build root on Linux).
+    (call,) = [
+        node.value
+        for node in ast.parse(shim).body
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and getattr(node.value.func, "id", None) == "install_inplace"
+    ]
+    path_arg = call.args[2]
+    assert isinstance(path_arg, ast.Constant)
+    assert path_arg.value is None

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -344,6 +344,33 @@ def test_loader_rebuild_without_build_dir_errors(tmp_path: Path):
         spec.loader.rebuild()  # type: ignore[attr-defined]
 
 
+def test_rebuild_refuses_nonrebuildable_install_dir(tmp_path: Path):
+    """#1417 Bug A: an install_dir the shim can't reproduce is baked as None.
+
+    A non-rebuild editable with a build-dir still exposes a manual
+    module.__loader__.rebuild(). If wheel.install-dir points outside the platlib
+    (e.g. '/data'), os.path.join(DIR, install_dir) would install to a bogus (or
+    filesystem-root) path, so None is baked and rebuild() must refuse instead.
+    """
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={},
+        known_directories={},
+        known_packages=[],
+        path=str(tmp_path),
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path),
+        install_dir=None,
+    )
+    # The sentinel is not joined onto DIR, so no bogus path is produced.
+    assert finder.install_dir is None
+    with pytest.raises(RuntimeError, match="cannot be reproduced"):
+        finder.rebuild()
+
+
 def test_mapping_to_modules_prefers_py():
     """Test that mapping_to_modules prefers __init__.py over __init__.pxd."""
     from scikit_build_core.build._editable import mapping_to_modules

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -749,6 +749,65 @@ def test_editable_redirect_files_rebuild_dir_implies_rebuild(tmp_path: Path):
         )
 
 
+@pytest.mark.parametrize("install_dir", ["/data", "${SKBUILD_DATA_DIR}/pkg"])
+def test_editable_redirect_files_nonplatlib_install_dir_no_rebuild_baked_safe(
+    tmp_path: Path, install_dir: str
+):
+    # #1417 Bug A: a non-rebuild editable with a build-dir still exposes a manual
+    # module.__loader__.rebuild() (#1403). The raw non-platlib install-dir must
+    # NOT be baked into the shim, since the shim does os.path.join(DIR,
+    # install_dir): '/data' would install into the filesystem root and
+    # '${SKBUILD_DATA_DIR}/pkg' into a literal '${SKBUILD_DATA_DIR}' dir. A None
+    # sentinel is baked instead so rebuild() refuses cleanly.
+    from scikit_build_core.settings.skbuild_model import WheelSettings
+
+    settings = ScikitBuildSettings(wheel=WheelSettings(install_dir=install_dir))
+    assert not settings.editable.rebuild
+
+    files = editable_redirect_files(
+        libdir=tmp_path,
+        mapping={},
+        name="pkg",
+        packages=[],
+        reload_dir=tmp_path,
+        settings=settings,
+        use_start=False,
+    )
+    shim = files["_editable_skbc_pkg.py"].decode()
+    # The install() call's last positional arg is install_dir; it must be None.
+    call = shim.rpartition("install(")[2]
+    assert call.rstrip().endswith("None)")
+    assert "${SKBUILD" not in shim
+
+
+def test_editable_redirect_files_platlib_install_dir_no_rebuild_reduced(
+    tmp_path: Path,
+):
+    # #1417 Bug A: a platlib/purelib selector is reproducible by the shim's
+    # platlib-relative join, so even without rebuild it is reduced to its
+    # remainder (not baked raw) so a manual rebuild() installs correctly.
+    from scikit_build_core.settings.skbuild_model import WheelSettings
+
+    settings = ScikitBuildSettings(
+        wheel=WheelSettings(install_dir="${SKBUILD_PLATLIB_DIR}/pkg")
+    )
+    assert not settings.editable.rebuild
+
+    files = editable_redirect_files(
+        libdir=tmp_path,
+        mapping={},
+        name="pkg",
+        packages=[],
+        reload_dir=tmp_path,
+        settings=settings,
+        use_start=False,
+    )
+    shim = files["_editable_skbc_pkg.py"].decode()
+    call = shim.rpartition("install(")[2]
+    assert call.rstrip().endswith("'pkg')")
+    assert "SKBUILD_PLATLIB_DIR" not in shim
+
+
 def test_prepare_editable_rebuild_dir_refuses_populated(tmp_path: Path):
     from scikit_build_core.build.common_wheel_helpers import (
         prepare_editable_rebuild_dir,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`module.__loader__.rebuild()` is now functional on any editable install with a `build-dir` set (#1403 / #1411), even when `editable.rebuild` is off. That exposed several unsafe or confusing rebuild paths. This PR fixes four verified bugs.

### Bug A — manual `rebuild()` used the raw, unreduced `wheel.install-dir`
For a non-rebuild redirect editable, the raw `wheel.install-dir` was baked into the shim, which does `os.path.join(DIR, install_dir)`:
- `${SKBUILD_DATA_DIR}/pkg` created a literal `${SKBUILD_DATA_DIR}` directory under site-packages.
- The leading-slash form `/data` (allowed for non-rebuild editables by #1334) collapsed to `/data`, so a rebuild ran `cmake --install --prefix /data` — into the filesystem root.

Fix: always reduce a platlib/purelib selector to its remainder, and bake a `None` sentinel for any tree the shim can't reproduce so `rebuild()` refuses with a clear message instead of installing to a bogus (or root) path.

### Bug B — rebuild + non-platlib `wheel.install-dir` crashed with a raw `ValueError`
The friendly `editable_rebuild_install_dir` guard had become dead code on the backend path (the rebuildable-editable branch short-circuits before it), so `install_dir.relative_to(wheel_dirs[targetlib])` raised `ValueError: '.../data/pkg' does not start with '.../purelib'` instead of the intended `Editable installs cannot rebuild a non-platlib wheel.install-dir` message.

Fix: perform the friendly validation before the `relative_to()` call, and remove the stale "an AssertionError is raised earlier" comment. The hatch-plugin path (which still reaches the original guard) is unchanged.

### Bug C — inplace editable without CMake baked a deleted temp dir as the rebuild path
With `wheel.cmake = false`, `editable.mode = "inplace"` and no `build-dir`, the shim's `install_inplace(...)` received a temp `build` path that is deleted after the build. `rebuild()` (#1411) then recreated the empty temp dir and failed with a confusing CMake error.

Fix: bake `None` when there is no persistent build dir, so `rebuild()` raises the intended friendly `RuntimeError`.

### Bug D — shim lock release masked acquire errors
`FileLockIfUnix.release()` asserted `lock_file_fd` was an `int`. If `acquire()` raised before the fd was set (e.g. `PermissionError` on a read-only build dir), the `finally: release()` hit that assertion and masked the real error.

Fix: make `release()` a no-op when the fd was never set (stdlib-only, conservative — the shim runs on end-user Pythons >= 3.8).

### Tests
- Regression tests added first and confirmed failing before the fixes:
  - `tests/test_editable_unit.py` — non-platlib install-dir bakes the `None` sentinel; platlib selector is reduced even without rebuild.
  - `tests/test_editable_redirect.py` — a `None` install-dir makes `rebuild()` refuse.
  - `tests/test_editable_build_paths.py` (new) — pure-Python (no-CMake) builds for Bug B (friendly error) and Bug C (`None` path baked).
- `tests/test_editable.py`, `tests/test_editable_unit.py`, `tests/test_editable_redirect.py`, `tests/test_hatchling.py` all pass; mypy (strict) and ruff clean.

Part of #1417.

https://claude.ai/code/session_016UZ7pyvdBUP3cXa23r3qAd