### PR TITLE
feat(hatch): reject wheel.exclude as unsupported

### DIFF
--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -139,6 +139,10 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             msg = "scikit-build.*.force-include is not supported, use hatch's force-include instead"
             raise ValueError(msg)
 
+        if settings.wheel.exclude:
+            msg = "wheel.exclude is not supported for hatch builds, use hatch's exclude instead"
+            raise ValueError(msg)
+
     # Requires Hatchling 1.22.0 to have an effect
     def dependencies(self) -> list[str]:
         settings = self._read_config().settings

--- a/tests/test_hatchling.py
+++ b/tests/test_hatchling.py
@@ -65,6 +65,17 @@ def test_hatchling_enable_by_default_ignored(tmp_path: Path, monkeypatch) -> Non
     reader.validate_may_exit()
 
 
+def test_hatchling_wheel_exclude_rejected() -> None:
+    pyproject = {
+        "project": {"name": "x", "version": "0.1.0"},
+        "tool": {"scikit-build": {"wheel": {"exclude": ["**/*.a"]}}},
+    }
+    with pytest.raises(
+        ValueError, match=r"wheel.exclude is not supported for hatch builds"
+    ):
+        _validate_settings(pyproject)
+
+
 def set_hatchling_editable_mode(mode: str) -> None:
     pyproject = Path("pyproject.toml")
     pyproject.write_text(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses item 3 from https://github.com/scikit-build/scikit-build-core/issues/1417#issuecomment-4860351655.

CMake-installed platlib files reach the wheel via hatchling's `build_data["force_include"]`, which bypasses hatchling's exclusion logic. As a result `wheel.exclude` was silently ignored for those files — e.g. `wheel.exclude = ["**/*.a"]` still shipped the static libs — and `_validate` didn't reject the setting either.

Following the decision noted in the issue, this rejects `wheel.exclude` in `_validate` like the plugin's other unsupported settings, pointing users at hatch's own `exclude` instead of failing silently.

- `src/scikit_build_core/hatch/plugin.py`: raise `ValueError` when `wheel.exclude` is set.
- `tests/test_hatchling.py`: add `test_hatchling_wheel_exclude_rejected`.

Refs #1417
