### PR TITLE
fix(setuptools): don't require editable.mode for build_ext --inplace

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -128,3 +128,7 @@ equivalent of scikit-build-core's `inplace` editable mode, so redirect mode is
 not supported here.
 
 Because of that, `editable.rebuild` is not supported in setuptools mode.
+
+A direct `setup.py build_ext --inplace` builds into the source tree without
+producing an editable wheel, so it works without any `editable.mode` setting,
+just like scikit-build (classic).

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -85,7 +85,7 @@ def _apply_cmake_install_target(
 
 
 def _validate_settings(
-    settings: ScikitBuildSettings, *, editable_mode: bool = False
+    settings: ScikitBuildSettings, *, pep660_editable: bool = False
 ) -> None:
     if settings.wheel.expand_macos_universal_tags:
         msg = "wheel.expand_macos_universal_tags is not supported in setuptools mode"
@@ -99,7 +99,9 @@ def _validate_settings(
     if len(normalize_build_types(settings.cmake.build_type)) > 1:
         msg = "cmake.build-type lists (multi-config) are not supported in setuptools mode, use a single build type"
         raise SetupError(msg)
-    if editable_mode:
+    # A direct "build_ext --inplace" builds in-place regardless of
+    # editable.mode; only PEP 660 editable wheels require the opt-in.
+    if pep660_editable:
         if settings.editable.mode != "inplace":
             msg = "setuptools editable installs require editable.mode = 'inplace'"
             raise SetupError(msg)
@@ -425,11 +427,16 @@ class BuildCMake(setuptools.Command):
             ]
 
     def _get_editable_mode(self) -> bool:
-        # editable_mode is the PEP 660 path; inplace is "build_ext --inplace"
+        # Both PEP 660 editable wheels and "build_ext --inplace" install into
+        # the source tree.
         build_ext = self.distribution.get_command_obj("build_ext")
-        return bool(getattr(build_ext, "editable_mode", False)) or bool(
-            getattr(build_ext, "inplace", False)
-        )
+        return self._is_pep660_editable() or bool(getattr(build_ext, "inplace", False))
+
+    def _is_pep660_editable(self) -> bool:
+        # setuptools sets editable_mode only when building a PEP 660 editable
+        # wheel; a direct "build_ext --inplace" sets just inplace.
+        build_ext = self.distribution.get_command_obj("build_ext")
+        return bool(getattr(build_ext, "editable_mode", False))
 
     def _get_install_subdir(self) -> Path:
         dist_cmake_install_dir = (
@@ -572,7 +579,7 @@ class BuildCMake(setuptools.Command):
         # run() is always a wheel or editable build; pass the matching state so
         # overrides (if.state = "wheel"/"editable") are applied correctly.
         settings = _load_settings(state="editable" if self.editable_mode else "wheel")
-        _validate_settings(settings, editable_mode=self.editable_mode)
+        _validate_settings(settings, pep660_editable=self._is_pep660_editable())
         _apply_cmake_install_target(settings, self.distribution)
 
         build_tmp_folder = Path(self.build_temp)

--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -34,7 +34,7 @@ if hasattr(setuptools.build_meta, "build_editable"):
             config_settings,
             state=state,
         ).settings
-        _validate_settings(settings, editable_mode=True)
+        _validate_settings(settings, pep660_editable=True)
 
     def build_editable(
         wheel_directory: str,

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import subprocess
 import sys
 import tarfile
 import textwrap
@@ -203,6 +204,36 @@ def test_pep517_editable(virtualenv, tmp_path: Path):
     assert version.strip() == "0.0.1"
 
     add = virtualenv.execute("import cmake_example; print(cmake_example.add(1, 2))")
+    assert add.strip() == "3"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.broken_on_urct
+@pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
+def test_build_ext_inplace_without_editable_mode(package):
+    # A direct "setup.py build_ext --inplace" involves no editable wheel, so it
+    # must not require editable.mode = "inplace" (classic scikit-build didn't).
+    pyproject = package.workdir / "pyproject.toml"
+    contents = pyproject.read_text(encoding="utf-8")
+    assert 'editable.mode = "inplace"\n' in contents
+    pyproject.write_text(
+        contents.replace('editable.mode = "inplace"\n', ""), encoding="utf-8"
+    )
+
+    subprocess.run(
+        [sys.executable, "setup.py", "build_ext", "--inplace"],
+        cwd=package.workdir,
+        check=True,
+    )
+
+    add = subprocess.run(
+        [sys.executable, "-c", "import cmake_example; print(cmake_example.add(1, 2))"],
+        cwd=package.workdir / "src",
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
     assert add.strip() == "3"
 
 
@@ -587,6 +618,15 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     # aliasing (RUNNER~1 vs runneradmin) that resolve() misses on cygwin.
     assert install_dir.is_absolute()
     assert install_dir.samefile(tmp_path / "src" / "wrapper_example")
+
+
+def test_validate_settings_editable_mode_only_required_for_pep660():
+    settings = build_cmake._load_settings()
+    assert settings.editable.mode == "redirect"
+    # Plain builds (including build_ext --inplace) don't require the setting.
+    build_cmake._validate_settings(settings)
+    with pytest.raises(SetupError, match=r"editable\.mode = 'inplace'"):
+        build_cmake._validate_settings(settings, pep660_editable=True)
 
 
 def test_wrapper_setup_raises_setup_error():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Item 4 of https://github.com/scikit-build/scikit-build-core/issues/1417#issuecomment-4860351655.

A direct `setup.py build_ext --inplace` involves no editable wheel, but the `BuildExtWithCMake` hook routed it through `build_cmake`, where `_get_editable_mode()` treated it like a PEP 660 editable install — so default-config projects failed with `setuptools editable installs require editable.mode = 'inplace'`, a command scikit-build (classic) supported without configuration.

**Fix:** split PEP 660 detection (`build_ext.editable_mode`) from plain inplace (`build_ext.inplace`). The inplace install-into-source-tree behavior is unchanged for both; only PEP 660 editable-wheel builds still require the explicit `editable.mode = "inplace"` opt-in (the `build_meta` hooks already validate that up front, unchanged).

- Regression test runs a real `setup.py build_ext --inplace` on `simple_setuptools_ext` with the `editable.mode` setting stripped and imports the built extension from the source tree (fails with the quoted error before the fix).
- Unit test pins that the validation only fires for the PEP 660 path.
- Docs note added to the setuptools plugin page.