### PR TITLE
feat(metadata): honor the dynamic_wheel hook when building SDists

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -335,6 +335,9 @@ def dynamic_metadata(
 
 And several optional ones (`build_state`, `dynamic_wheel`, and
 `get_requires_for_dynamic_metadata`). You can optionally use a class, as well.
+Fields a plugin reports via `dynamic_wheel` as possibly changing between the
+SDist and a wheel built from it are marked `Dynamic` in the SDist's `PKG-INFO`
+(METADATA 2.2); `version` may never change in this sense.
 
 A plugin distributed as a package is referenced by the name it registers in the
 `dynamic_metadata.provider` entry-point group. A plugin that lives inside your

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -21,7 +21,9 @@ from .._vendor.pyproject_metadata import (
     extras_build_system,
     extras_top_level,
 )
+from .._vendor.pyproject_metadata.constants import PROJECT_TO_METADATA
 from ..builder._load_provider import (
+    dynamic_wheel_fields,
     process_dynamic_metadata,
     process_legacy_dynamic_metadata,
 )
@@ -67,6 +69,17 @@ def get_standard_metadata(
 
     new_pyproject_dict["project"] = project
 
+    # METADATA 2.2: fields a provider reports (via the optional dynamic_wheel
+    # hook) as possibly differing between the SDist and a wheel built from it
+    # are marked Dynamic. Only SDist metadata may carry Dynamic fields.
+    dynamic_metadata: list[str] = []
+    if entries and build_state == "sdist":
+        dynamic_metadata = sorted(
+            metadata_field
+            for project_field in dynamic_wheel_fields(entries)
+            for metadata_field in PROJECT_TO_METADATA[project_field]
+        )
+
     if settings.strict_config:
         extra_keys_top = extras_top_level(new_pyproject_dict)
         if extra_keys_top:
@@ -88,7 +101,10 @@ def get_standard_metadata(
         allow_extra_keys = None if settings.strict_config else False
 
     metadata = StandardMetadata.from_pyproject(
-        new_pyproject_dict, all_errors=True, allow_extra_keys=allow_extra_keys
+        new_pyproject_dict,
+        dynamic_metadata=dynamic_metadata,
+        all_errors=True,
+        allow_extra_keys=allow_extra_keys,
     )
 
     # For scikit-build-core < 0.5, we keep the normalized name for back-compat

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __lazy_modules__ = {
     "copy",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._vendor.pyproject_metadata.constants",
     "packaging",
     "packaging.version",
     "typing",

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -47,6 +47,7 @@ else:
 __all__ = [
     "BUILD_STATES",
     "BuildState",
+    "dynamic_wheel_fields",
     "load_dynamic_metadata",
     "load_entry_provider",
     "load_provider",
@@ -219,6 +220,31 @@ def load_dynamic_metadata(
         settings = {k: v for k, v in entry.items() if k != "provider"}
         provider = load_entry_provider(entry["provider"])
         yield provider, settings
+
+
+def dynamic_wheel_fields(entries: Sequence[Mapping[str, Any]]) -> frozenset[str]:
+    """Collect fields whose value may change between the SDist and a wheel.
+
+    Each ``[[tool.dynamic-metadata]]`` provider implementing the optional
+    ``dynamic_wheel`` hook reports a field -> bool map; a field a provider does
+    not mention defaults to not dynamic in this sense, and ``version`` may never
+    be. The returned fields are marked ``Dynamic`` in the SDist's PKG-INFO
+    (METADATA 2.2).
+    """
+    fields: dict[str, bool] = {}
+    for provider, settings in load_dynamic_metadata(entries):
+        if isinstance(provider, DynamicMetadataWheelProtocol):
+            fields.update(provider.dynamic_wheel(settings))
+
+    for field, is_dynamic in fields.items():
+        if field not in _ALL_FIELDS:
+            msg = f"{field!r} is not a valid dynamic-metadata field"
+            raise KeyError(msg)
+        if field == "version" and is_dynamic:
+            msg = "'version' may not change between the SDist and wheel"
+            raise ValueError(msg)
+
+    return frozenset(field for field, is_dynamic in fields.items() if is_dynamic)
 
 
 def _merge_dict(

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -520,6 +520,116 @@ def test_legacy_does_not_mutate_input(
     assert project == {"name": "p", "dynamic": ["version"]}
 
 
+def _write_dynamic_wheel_plugin(module: str, body: str) -> str:
+    # The module and directory names must be unique across tests: modules are
+    # cached in sys.modules, and relative directory names in sys.path_importer_cache.
+    path = f"plugins_{module}"
+    Path(path).mkdir()
+    Path(f"{path}/{module}.py").write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def test_dynamic_wheel_marks_sdist_fields_dynamic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider's dynamic_wheel fields are marked Dynamic in the SDist PKG-INFO."""
+    monkeypatch.chdir(tmp_path)
+    _write_dynamic_wheel_plugin(
+        "wheel_plugin_sdist",
+        """\
+        def dynamic_metadata(settings, project):
+            return {
+                "classifiers": ["Private :: Do Not Upload"],
+                "urls": {"Homepage": "https://example.com"},
+            }
+
+        def dynamic_wheel(settings):
+            return {"classifiers": True, "urls": False}
+        """,
+    )
+    Path("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "test-dynamic-wheel"
+            version = "0.1.0"
+            dynamic = ["classifiers", "urls"]
+
+            [[tool.dynamic-metadata]]
+            provider = {path = "plugins_wheel_plugin_sdist", module = "wheel_plugin_sdist"}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with Path("pyproject.toml").open("rb") as ft:
+        pyproject = tomllib.load(ft)
+    settings = SettingsReader(pyproject, {}, state="sdist").settings
+
+    metadata = get_standard_metadata(pyproject, settings, build_state="sdist")
+    assert metadata.dynamic_metadata == ["Classifier"]
+    pkg_info = bytes(metadata.as_rfc822())
+    assert b"Dynamic: Classifier" in pkg_info
+    assert b"Metadata-Version: 2.2" in pkg_info
+
+    # Dynamic is only valid in SDist metadata, not in a wheel's METADATA
+    metadata = get_standard_metadata(pyproject, settings, build_state="wheel")
+    assert not metadata.dynamic_metadata
+    assert b"Dynamic:" not in bytes(metadata.as_rfc822())
+
+
+@pytest.mark.parametrize(
+    ("returns", "match"),
+    [
+        pytest.param('{"version": True}', "version", id="version"),
+        pytest.param('{"not-a-field": True}', "not-a-field", id="unknown-field"),
+    ],
+)
+def test_dynamic_wheel_invalid_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, returns: str, match: str
+) -> None:
+    """'version' may never be dynamic between SDist and wheel; fields must be valid."""
+    from scikit_build_core.builder._load_provider import dynamic_wheel_fields
+
+    monkeypatch.chdir(tmp_path)
+    module = f"wheel_plugin_{match.replace('-', '_')}"
+    path = _write_dynamic_wheel_plugin(
+        module,
+        f"""\
+        def dynamic_metadata(settings, project):
+            return {{}}
+
+        def dynamic_wheel(settings):
+            return {returns}
+        """,
+    )
+    entries = [{"provider": {"path": path, "module": module}}]
+    with pytest.raises((KeyError, ValueError), match=match):
+        dynamic_wheel_fields(entries)
+
+
+def test_dynamic_wheel_defaults_to_static(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider without the hook, or a field mapped to false, adds no Dynamic fields."""
+    from scikit_build_core.builder._load_provider import dynamic_wheel_fields
+
+    monkeypatch.chdir(tmp_path)
+    path = _write_dynamic_wheel_plugin(
+        "wheel_plugin_no_hook",
+        """\
+        def dynamic_metadata(settings, project):
+            return {"description": "hi"}
+        """,
+    )
+    entries = [{"provider": {"path": path, "module": "wheel_plugin_no_hook"}}]
+    assert dynamic_wheel_fields(entries) == frozenset()
+
+
 def test_array_plugin_requires_field() -> None:
     """A bundled generic plugin in the array form needs a 'field' setting."""
     from scikit_build_core.builder._load_provider import process_dynamic_metadata


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Implements item 1 of the pre-release review in #1417 (see [this comment](https://github.com/scikit-build/scikit-build-core/issues/1417#issuecomment-4860351655)): `dynamic_wheel` was declared in `DynamicMetadataWheelProtocol` and documented as a supported [dynamic-metadata](https://github.com/scikit-build/dynamic-metadata) 0.3 hook, but never invoked.

### What the hook means

Per the 0.3 spec, `dynamic_wheel(settings) -> dict[str, bool]` is the METADATA 2.2 (PEP 643) feature: a provider reports which of its fields may legitimately differ between the SDist and a wheel built from it, and the backend marks those fields `Dynamic:` in the SDist's `PKG-INFO`. (It is *not* about skipping `prepare_metadata_for_build_*`, as the review comment speculated — PEP 643 also permits the computed value to appear alongside the marker as a hint.)

### Changes

- `builder/_load_provider.py`: new `dynamic_wheel_fields(entries)` implementing the spec's backend loop — unmentioned fields default to not-dynamic, unknown fields are rejected, and `version` may never be dynamic in this sense.
- `build/metadata.py`: for `build_state="sdist"`, the collected project fields are mapped to core-metadata names via the vendored `PROJECT_TO_METADATA` (e.g. `dependencies` → `Requires-Dist`) and passed to `StandardMetadata.from_pyproject(dynamic_metadata=...)`, which emits the `Dynamic:` headers and bumps to Metadata-Version 2.2. Wheel/editable/prepare states pass nothing; `Dynamic` is only valid in SDist metadata.
- Tests (written first, confirmed failing without the fix) and a doc sentence in `dynamic.md`.

### Scope note

The deprecated `tool.scikit-build.metadata` table does not get this: its historical `dynamic_wheel(field, settings)` shape was never called by any release, so the hook is honored only for the standard `[[tool.dynamic-metadata]]` form.

Verified end-to-end: a `build_sdist` with a plugin declaring `dependencies` dynamic produces a `PKG-INFO` with `Metadata-Version: 2.2`, `Requires-Dist: numpy`, and `Dynamic: Requires-Dist`.

Refs #1417