### PR TITLE
feat(sdist): "external" and "classic" resolve-symlinks modes; "none" stores directory symlinks

### DIFF
--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -795,6 +795,10 @@ print(mk_skbuild_docs())
   * "classic": Store file symlinks as-is, but follow directory symlinks,
     copying their contents (scikit-build-core 0.x behavior).
 
+  A symlink that can't be resolved (dangling, or a directory symlink loop)
+  is stored as a symlink in every mode, with a warning if it was supposed to
+  be resolved.
+
   If you don't set this, it will be "all" unless you set the minimum version
   below 1.0, in which case it will be "classic" to preserve backward
   compatibility.

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -778,7 +778,7 @@ print(mk_skbuild_docs())
 ```{eval-rst}
 .. confval:: sdist.resolve-symlinks
 
-  :Type: ``"all" | "none"``
+  :Type: ``"all" | "external" | "none" | "classic"``
   :Default: "all"
   :Config-settings: ``sdist.resolve-symlinks`` or ``skbuild.sdist.resolve-symlinks``
   :Environment variable: ``SKBUILD_SDIST_RESOLVE_SYMLINKS``
@@ -788,10 +788,16 @@ print(mk_skbuild_docs())
   The modes are:
 
   * "all": Resolve every symlink, copying its target's contents.
-  * "none": Store symlinks as-is.
+  * "external": Resolve only symlinks that point outside the project (those
+    would be broken once the SDist is extracted); store symlinks that stay
+    inside the project as-is.
+  * "none": Store every symlink as-is, including directory symlinks.
+  * "classic": Store file symlinks as-is, but follow directory symlinks,
+    copying their contents (scikit-build-core 0.x behavior).
 
   If you don't set this, it will be "all" unless you set the minimum version
-  below 1.0, in which case it will be "none" to preserve backward compatibility.
+  below 1.0, in which case it will be "classic" to preserve backward
+  compatibility.
 
   .. versionadded:: 1.0
 ```

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -23,7 +23,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
-__all__ = ["each_unignored_file"]
+__all__ = ["each_unignored_file", "symlink_escapes"]
 
 EXCLUDE_LINES = [
     ".git",
@@ -39,6 +39,23 @@ EXCLUDE_LINES = [
 
 def __dir__() -> list[str]:
     return __all__
+
+
+def symlink_escapes(path: Path) -> bool:
+    """
+    True if the symlink at ``path`` (relative to the project root, which must
+    be the current directory) has an immediate target pointing outside the
+    project: an absolute target, a Windows drive, or a relative target that
+    lexically escapes the root. Such a link would dangle once the SDist is
+    extracted somewhere else. Only the immediate target is checked, so a chain
+    of internal links to an eventually-external target stays consistent link
+    by link (the last link is the one that gets resolved).
+    """
+    target = os.readlink(path)
+    if os.path.isabs(target) or os.path.splitdrive(target)[0]:  # noqa: PTH117
+        return True
+    joined = os.path.normpath(os.path.join(os.path.dirname(path), target))  # noqa: PTH118, PTH120
+    return joined == os.pardir or joined.startswith(os.pardir + os.sep)
 
 
 def _dir_key(dirstr: str) -> tuple[int, int] | None:
@@ -61,9 +78,17 @@ def each_unignored_file(
     build_dir: str = "",
     *,
     mode: Literal["classic", "default", "manual", "explicit"],
+    resolve_symlinks: Literal["all", "external", "none", "classic"] = "all",
 ) -> Generator[Path, None, None]:
     """
     Runs through all non-ignored files. Must be run from the root directory.
+
+    ``resolve_symlinks`` controls directory symlinks: "all" and "classic"
+    follow them (their contents are walked); "none" yields the link itself as
+    a member instead of descending; "external" does the same only for links
+    staying inside the project, still following links that point outside it.
+    File symlinks are always yielded as-is here; whether they are stored
+    dereferenced is up to the caller.
     """
     # "manual" and "explicit" do not consult git ignore files at all.
     reads_gitignore = mode in {"classic", "default"}
@@ -126,6 +151,29 @@ def each_unignored_file(
             continue
         if key is not None:
             ancestor_keys[dirstr] = parent_keys | {key}
+        if resolve_symlinks in {"none", "external"}:
+            for dname in list(dirs):
+                dpath = dirpath / dname
+                if not dpath.is_symlink():
+                    continue
+                if resolve_symlinks == "external" and symlink_escapes(dpath):
+                    # Points outside the project; keep walking it so its
+                    # contents get stored instead of a dangling link.
+                    continue
+                # Store the link itself as a member instead of descending.
+                dirs.remove(dname)
+                if match_path(
+                    dirpath,
+                    dpath,
+                    include_spec,
+                    global_exclude_spec,
+                    builtin_exclude_spec,
+                    user_exclude_spec,
+                    nested_excludes,
+                    is_path=False,
+                    explicit=explicit,
+                ):
+                    yield dpath
         if mode != "classic":
             for dname in list(dirs):
                 if not match_path(

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -79,6 +79,7 @@ def each_unignored_file(
     *,
     mode: Literal["classic", "default", "manual", "explicit"],
     resolve_symlinks: Literal["all", "external", "none", "classic"] = "all",
+    yield_loop_symlinks: bool = False,
 ) -> Generator[Path, None, None]:
     """
     Runs through all non-ignored files. Must be run from the root directory.
@@ -89,6 +90,10 @@ def each_unignored_file(
     staying inside the project, still following links that point outside it.
     File symlinks are always yielded as-is here; whether they are stored
     dereferenced is up to the caller.
+
+    A directory symlink loop is never followed; with ``yield_loop_symlinks``
+    the link itself is yielded (the SDist stores it as a symlink member),
+    otherwise it is skipped (wheel copying can't represent it).
     """
     # "manual" and "explicit" do not consult git ignore files at all.
     reads_gitignore = mode in {"classic", "default"}
@@ -148,19 +153,24 @@ def each_unignored_file(
                 dirpath,
             )
             dirs.clear()
-            # A loop symlink can't be followed in any mode; store the link
-            # itself so it isn't silently dropped. (On Windows os.walk may
-            # classify it as a file instead, yielding it below.)
-            if dirpath.is_symlink() and match_path(
-                dirpath.parent,
-                dirpath,
-                include_spec,
-                global_exclude_spec,
-                builtin_exclude_spec,
-                user_exclude_spec,
-                nested_excludes,
-                is_path=False,
-                explicit=explicit,
+            # A loop symlink can't be followed in any mode; the SDist walk
+            # asks for the link itself so it isn't silently dropped. (On
+            # Windows os.walk may classify it as a file instead, yielding it
+            # below.)
+            if (
+                yield_loop_symlinks
+                and dirpath.is_symlink()
+                and match_path(
+                    dirpath.parent,
+                    dirpath,
+                    include_spec,
+                    global_exclude_spec,
+                    builtin_exclude_spec,
+                    user_exclude_spec,
+                    nested_excludes,
+                    is_path=False,
+                    explicit=explicit,
+                )
             ):
                 yield dirpath
             continue

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -45,16 +45,25 @@ def symlink_escapes(path: Path) -> bool:
     """
     True if the symlink at ``path`` (relative to the project root, which must
     be the current directory) has an immediate target pointing outside the
-    project: an absolute target, a Windows drive, or a relative target that
-    lexically escapes the root. Such a link would dangle once the SDist is
-    extracted somewhere else. Only the immediate target is checked, so a chain
-    of internal links to an eventually-external target stays consistent link
-    by link (the last link is the one that gets resolved).
+    subtree the SDist mirrors at that location: an absolute target, a Windows
+    drive, or a relative target that lexically escapes the containment root.
+    Such a link would dangle (or hit the wrong file) once the SDist is
+    extracted somewhere else. The containment root is the project root,
+    unless ``path`` was reached by following an external directory symlink --
+    then it is the nearest symlink ancestor, since only that subtree mirrors
+    the real directory the link resolves against. Only the immediate target
+    is checked, so a chain of internal links to an eventually-external target
+    stays consistent link by link (the last link is the one that gets
+    resolved).
     """
     target = os.readlink(path)
     if os.path.isabs(target) or os.path.splitdrive(target)[0]:  # noqa: PTH117
         return True
     joined = os.path.normpath(os.path.join(os.path.dirname(path), target))  # noqa: PTH118, PTH120
+    for parent in path.parents:
+        if parent != Path() and parent.is_symlink():
+            root = str(parent)
+            return joined != root and not joined.startswith(root + os.sep)
     return joined == os.pardir or joined.startswith(os.pardir + os.sep)
 
 
@@ -182,8 +191,8 @@ def each_unignored_file(
                 if not dpath.is_symlink():
                     continue
                 if resolve_symlinks == "external" and symlink_escapes(dpath):
-                    # Points outside the project; keep walking it so its
-                    # contents get stored instead of a dangling link.
+                    # Points outside the mirrored subtree; keep walking it so
+                    # its contents get stored instead of a dangling link.
                     continue
                 # Store the link itself as a member instead of descending.
                 dirs.remove(dname)

--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -148,6 +148,21 @@ def each_unignored_file(
                 dirpath,
             )
             dirs.clear()
+            # A loop symlink can't be followed in any mode; store the link
+            # itself so it isn't silently dropped. (On Windows os.walk may
+            # classify it as a file instead, yielding it below.)
+            if dirpath.is_symlink() and match_path(
+                dirpath.parent,
+                dirpath,
+                include_spec,
+                global_exclude_spec,
+                builtin_exclude_spec,
+                user_exclude_spec,
+                nested_excludes,
+                is_path=False,
+                explicit=explicit,
+            ):
+                yield dirpath
             continue
         if key is not None:
             ancestor_keys[dirstr] = parent_keys | {key}

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -103,13 +103,19 @@ def add_path_to_tar(
     ``tar.dereference`` (``sdist.resolve-symlinks = "all"``) makes ``tar.add``
     stat through symlinks; a dangling symlink then raises ``FileNotFoundError``
     instead of being archived (#1417). Fall back to storing the symlink itself
-    in that case, matching the pre-1.0 behavior, and warn.
+    in that case, matching the pre-1.0 behavior, and warn. The same applies to
+    a symlink resolving to a directory: the only ones that reach here are loop
+    symlinks pruned from the walk, and dereferencing one would recurse forever.
     """
-    if tar.dereference and filepath.is_symlink() and not filepath.exists():
+    if (
+        tar.dereference
+        and filepath.is_symlink()
+        and (not filepath.exists() or filepath.is_dir())
+    ):
         rich_warning(
-            f"{filepath} is a dangling symlink; storing it as a symlink instead "
-            'of resolving it. Set sdist.resolve-symlinks = "none" to silence '
-            "this warning."
+            f"{filepath} is a symlink that can't be resolved (dangling, or a "
+            "directory symlink loop); storing it as a symlink instead. Set "
+            'sdist.resolve-symlinks = "none" to silence this warning.'
         )
         tar.dereference = False
         try:

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -38,7 +38,7 @@ from .._compat import tomllib
 from .._logging import rich_print, rich_warning
 from .._reproducible import get_reproducible_epoch, normalize_file_permissions
 from ..settings.skbuild_read_settings import SettingsReader
-from ._file_processor import each_unignored_file
+from ._file_processor import each_unignored_file, symlink_escapes
 from ._init import setup_logging
 from ._pathutil import iter_force_include
 from .generate import generate_file_contents
@@ -168,12 +168,14 @@ def build_sdist(
                 sdist_dir / filename, mode="wb", compresslevel=9, mtime=timestamp
             )
         )
+        resolve_symlinks = settings.sdist.resolve_symlinks
+        assert resolve_symlinks is not None
         tar = stack.enter_context(
             tarfile.TarFile(
                 fileobj=gzip_container,
                 mode="w",
                 format=tarfile.PAX_FORMAT,
-                dereference=settings.sdist.resolve_symlinks == "all",
+                dereference=resolve_symlinks == "all",
             )
         )
         assert settings.sdist.inclusion_mode is not None
@@ -184,12 +186,22 @@ def build_sdist(
                 exclude=settings.sdist.exclude,
                 build_dir=settings.build_dir,
                 mode=settings.sdist.inclusion_mode,
+                resolve_symlinks=resolve_symlinks,
             )
         )
         for filepath in paths:
+            # In "external" mode, a file symlink pointing outside the project
+            # is stored dereferenced: add its target under the link's name.
+            name = filepath
+            if (
+                resolve_symlinks == "external"
+                and filepath.is_symlink()
+                and symlink_escapes(filepath)
+            ):
+                name = filepath.resolve()
             add_path_to_tar(
                 tar,
-                filepath,
+                name,
                 arcname=srcdirname / filepath,
                 tar_filter=normalize_tar_info if reproducible else lambda x: x,
             )

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -193,6 +193,7 @@ def build_sdist(
                 build_dir=settings.build_dir,
                 mode=settings.sdist.inclusion_mode,
                 resolve_symlinks=resolve_symlinks,
+                yield_loop_symlinks=True,
             )
         )
         for filepath in paths:

--- a/src/scikit_build_core/build/sdist.py
+++ b/src/scikit_build_core/build/sdist.py
@@ -192,13 +192,20 @@ def build_sdist(
         for filepath in paths:
             # In "external" mode, a file symlink pointing outside the project
             # is stored dereferenced: add its target under the link's name.
+            # A dangling one can't be resolved, so store it as-is and warn.
             name = filepath
             if (
                 resolve_symlinks == "external"
                 and filepath.is_symlink()
                 and symlink_escapes(filepath)
             ):
-                name = filepath.resolve()
+                if filepath.exists():
+                    name = filepath.resolve()
+                else:
+                    rich_warning(
+                        f"{filepath} is a dangling symlink pointing outside the "
+                        "project; storing it as a symlink instead of resolving it."
+                    )
             add_path_to_tar(
                 tar,
                 name,

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -209,7 +209,9 @@
         "resolve-symlinks": {
           "enum": [
             "all",
-            "none"
+            "external",
+            "none",
+            "classic"
           ],
           "description": "Which symlinks to resolve in the SDist, storing the target's contents instead."
         }

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -418,6 +418,10 @@ class SDistSettings:
     * "classic": Store file symlinks as-is, but follow directory symlinks,
       copying their contents (scikit-build-core 0.x behavior).
 
+    A symlink that can't be resolved (dangling, or a directory symlink loop)
+    is stored as a symlink in every mode, with a warning if it was supposed to
+    be resolved.
+
     If you don't set this, it will be "all" unless you set the minimum version
     below 1.0, in which case it will be "classic" to preserve backward
     compatibility.

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -399,9 +399,11 @@ class SDistSettings:
     .. versionadded:: 1.0
     """
 
-    resolve_symlinks: Optional[Literal["all", "none"]] = dataclasses.field(
-        default=None,
-        metadata=SettingsFieldMetadata(display_default='"all"'),
+    resolve_symlinks: Optional[Literal["all", "external", "none", "classic"]] = (
+        dataclasses.field(
+            default=None,
+            metadata=SettingsFieldMetadata(display_default='"all"'),
+        )
     )
     """
     Which symlinks to resolve in the SDist, storing the target's contents instead.
@@ -409,10 +411,16 @@ class SDistSettings:
     The modes are:
 
     * "all": Resolve every symlink, copying its target's contents.
-    * "none": Store symlinks as-is.
+    * "external": Resolve only symlinks that point outside the project (those
+      would be broken once the SDist is extracted); store symlinks that stay
+      inside the project as-is.
+    * "none": Store every symlink as-is, including directory symlinks.
+    * "classic": Store file symlinks as-is, but follow directory symlinks,
+      copying their contents (scikit-build-core 0.x behavior).
 
     If you don't set this, it will be "all" unless you set the minimum version
-    below 1.0, in which case it will be "none" to preserve backward compatibility.
+    below 1.0, in which case it will be "classic" to preserve backward
+    compatibility.
 
     .. versionadded:: 1.0
     """

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -569,7 +569,7 @@ class SettingsReader:
             self.settings.minimum_version is not None
             and self.settings.minimum_version < Version("1.0")
         ):
-            self.settings.sdist.resolve_symlinks = "none"
+            self.settings.sdist.resolve_symlinks = "classic"
         else:
             self.settings.sdist.resolve_symlinks = "all"
 

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -424,6 +424,43 @@ def test_packages_to_file_mapping_module_nested(
     }
 
 
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy" and sys.platform.startswith("win"),
+    reason="PyPy on Windows does not support symlinks",
+)
+def test_packages_to_file_mapping_loop_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A circular directory symlink in a package must not end up in the
+    # mapping: the wheel build shutil.copy2()s every mapped source, which
+    # raises IsADirectoryError on a directory symlink.
+    pkg = tmp_path / "pkg"
+    sub = pkg / "sub"
+    sub.mkdir(parents=True)
+    pkg.joinpath("__init__.py").write_text("", encoding="utf-8")
+    loop = sub / "pkg"
+    try:
+        loop.symlink_to(Path("..") / ".." / "pkg", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported on this platform")
+    if not loop.is_dir():
+        pytest.skip("Symlink support not available")
+    monkeypatch.chdir(tmp_path)
+
+    mapping = packages_to_file_mapping(
+        packages={"pkg": "pkg"},
+        platlib_dir=tmp_path / "out",
+        include=[],
+        src_exclude=[],
+        target_exclude=[],
+        build_dir="",
+        mode="classic",
+    )
+    assert mapping == {
+        str(Path("pkg/__init__.py")): str(tmp_path / "out" / "pkg" / "__init__.py")
+    }
+
+
 def test_packages_to_file_mapping_missing_source(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -192,6 +192,12 @@ def test_circular_symlink_terminates(
     assert result.count(pkg / "__init__.py") == 1
     assert not any("sub/pkg/sub/pkg" in p.as_posix() for p in result)
 
+    # By default the loop symlink itself is not yielded: the wheel package
+    # copy can't represent a directory symlink. The sdist walk opts in.
+    assert loop not in result
+    with_loops = set(each_unignored_file(Path(), mode=mode, yield_loop_symlinks=True))
+    assert loop in with_loops
+
 
 def test_dot_git_is_a_file(
     tmp_path: Path,

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sysconfig
 import tarfile
 from pathlib import Path
 
@@ -99,6 +100,11 @@ def can_symlink(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.skipif(
+    sysconfig.get_platform().startswith(("mingw", "msys")),
+    reason="MSYS Python resolves relative symlink targets lexically, so the"
+    " nested escaping links read as dangling",
+)
 @pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")
 @pytest.mark.parametrize("mode", [None, "all", "external", "none", "classic"])
 def test_pep517_sdist_symlink(tmp_path: Path, mode: str | None) -> None:

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -75,11 +75,11 @@ def test_pep517_sdist_symlink(tmp_path: Path, mode: str | None) -> None:
     # Targets outside the project directory.
     outside = tmp_path / "outside"
     outside.mkdir()
-    outside.joinpath("ext.txt").write_text("external file\n", encoding="utf-8")
+    # Bytes, not text: text mode would write \r\n on Windows and break the
+    # dereferenced-content check below.
+    outside.joinpath("ext.txt").write_bytes(b"external file\n")
     outside.joinpath("extdir").mkdir()
-    outside.joinpath("extdir", "data.txt").write_text(
-        "external data\n", encoding="utf-8"
-    )
+    outside.joinpath("extdir", "data.txt").write_bytes(b"external data\n")
 
     # Internal file and directory symlinks, external file and directory
     # symlinks, and a directory symlink loop.

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -11,7 +11,8 @@ from scikit_build_core.build import build_sdist
 PREFIX = "cmake_example-0.0.1"
 
 # Expected tar member type per resolve-symlinks mode: "reg", "sym", or None
-# (absent from the archive).
+# (absent from the archive). A directory symlink loop cannot be resolved, so
+# every mode stores it as a symlink member (on any platform).
 EXPECTED = {
     "all": {
         "CMakeLists_link.txt": "reg",
@@ -20,7 +21,7 @@ EXPECTED = {
         "ext_file.txt": "reg",
         "ext_dir": None,
         "ext_dir/data.txt": "reg",
-        "src/loop": None,
+        "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
     "external": {
@@ -50,7 +51,7 @@ EXPECTED = {
         "ext_file.txt": "sym",
         "ext_dir": None,
         "ext_dir/data.txt": "reg",
-        "src/loop": None,
+        "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
 }

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -12,7 +12,12 @@ PREFIX = "cmake_example-0.0.1"
 
 # Expected tar member type per resolve-symlinks mode: "reg", "sym", or None
 # (absent from the archive). A directory symlink loop cannot be resolved, so
-# every mode stores it as a symlink member (on any platform).
+# every mode stores it as a symlink member (on any platform). The
+# ext_dir/*_link entries are symlinks nested inside a followed external
+# directory: in "external" mode, ones whose target stays inside the followed
+# directory are kept as symlinks; ones escaping it must be resolved, even if
+# their target lexically lands inside the project when judged against the
+# archive path.
 EXPECTED = {
     "all": {
         "CMakeLists_link.txt": "reg",
@@ -21,6 +26,12 @@ EXPECTED = {
         "ext_file.txt": "reg",
         "ext_dir": None,
         "ext_dir/data.txt": "reg",
+        "ext_dir/data_link.txt": "reg",
+        "ext_dir/esc_link.txt": "reg",
+        "ext_dir/sub_link": None,
+        "ext_dir/sub_link/sub.txt": "reg",
+        "ext_dir/esc_dir": None,
+        "ext_dir/esc_dir/esc.txt": "reg",
         "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
@@ -31,6 +42,12 @@ EXPECTED = {
         "ext_file.txt": "reg",
         "ext_dir": None,
         "ext_dir/data.txt": "reg",
+        "ext_dir/data_link.txt": "sym",
+        "ext_dir/esc_link.txt": "reg",
+        "ext_dir/sub_link": "sym",
+        "ext_dir/sub_link/sub.txt": None,
+        "ext_dir/esc_dir": None,
+        "ext_dir/esc_dir/esc.txt": "reg",
         "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
@@ -41,6 +58,12 @@ EXPECTED = {
         "ext_file.txt": "sym",
         "ext_dir": "sym",
         "ext_dir/data.txt": None,
+        "ext_dir/data_link.txt": None,
+        "ext_dir/esc_link.txt": None,
+        "ext_dir/sub_link": None,
+        "ext_dir/sub_link/sub.txt": None,
+        "ext_dir/esc_dir": None,
+        "ext_dir/esc_dir/esc.txt": None,
         "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
@@ -51,6 +74,12 @@ EXPECTED = {
         "ext_file.txt": "sym",
         "ext_dir": None,
         "ext_dir/data.txt": "reg",
+        "ext_dir/data_link.txt": "sym",
+        "ext_dir/esc_link.txt": "sym",
+        "ext_dir/sub_link": None,
+        "ext_dir/sub_link/sub.txt": "reg",
+        "ext_dir/esc_dir": None,
+        "ext_dir/esc_dir/esc.txt": "reg",
         "src/loop": "sym",
         "src/loop/main.cpp": None,
     },
@@ -79,8 +108,23 @@ def test_pep517_sdist_symlink(tmp_path: Path, mode: str | None) -> None:
     # Bytes, not text: text mode would write \r\n on Windows and break the
     # dereferenced-content check below.
     outside.joinpath("ext.txt").write_bytes(b"external file\n")
-    outside.joinpath("extdir").mkdir()
-    outside.joinpath("extdir", "data.txt").write_bytes(b"external data\n")
+    outside.joinpath("secret.txt").write_bytes(b"external secret\n")
+    outside.joinpath("escdir").mkdir()
+    outside.joinpath("escdir", "esc.txt").write_bytes(b"escaped dir data\n")
+    extdir = outside / "extdir"
+    extdir.mkdir()
+    extdir.joinpath("data.txt").write_bytes(b"external data\n")
+    extdir.joinpath("subdir").mkdir()
+    extdir.joinpath("subdir", "sub.txt").write_bytes(b"sub data\n")
+    # Symlinks nested inside the external directory: two staying inside it,
+    # two escaping it (with targets that lexically land inside the project
+    # when judged against the archive path ext_dir/...).
+    extdir.joinpath("data_link.txt").symlink_to("data.txt")
+    extdir.joinpath("esc_link.txt").symlink_to(Path("..") / "secret.txt")
+    extdir.joinpath("sub_link").symlink_to("subdir", target_is_directory=True)
+    extdir.joinpath("esc_dir").symlink_to(
+        Path("..") / "escdir", target_is_directory=True
+    )
 
     # Internal file and directory symlinks, external file and directory
     # symlinks, and a directory symlink loop.
@@ -113,6 +157,18 @@ def test_pep517_sdist_symlink(tmp_path: Path, mode: str | None) -> None:
             fobj = tar.extractfile(f"{PREFIX}/ext_file.txt")
             assert fobj is not None
             assert fobj.read() == b"external file\n"
+            # Nested symlinks escaping the followed external directory are
+            # dereferenced too, judged against the followed link rather than
+            # the archive path (which lexically stays inside the project).
+            fobj = tar.extractfile(f"{PREFIX}/ext_dir/esc_link.txt")
+            assert fobj is not None
+            assert fobj.read() == b"external secret\n"
+            fobj = tar.extractfile(f"{PREFIX}/ext_dir/esc_dir/esc.txt")
+            assert fobj is not None
+            assert fobj.read() == b"escaped dir data\n"
+            # Nested symlinks staying inside it keep their targets.
+            assert members[f"{PREFIX}/ext_dir/data_link.txt"].linkname == "data.txt"
+            assert members[f"{PREFIX}/ext_dir/sub_link"].linkname == "subdir"
         if mode in {"none", "external"}:
             # Internal symlink targets are preserved as-is.
             link = members[f"{PREFIX}/CMakeLists_link.txt"]

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -8,6 +8,53 @@ import pytest
 from scikit_build_core._logging import rich_warning
 from scikit_build_core.build import build_sdist
 
+PREFIX = "cmake_example-0.0.1"
+
+# Expected tar member type per resolve-symlinks mode: "reg", "sym", or None
+# (absent from the archive).
+EXPECTED = {
+    "all": {
+        "CMakeLists_link.txt": "reg",
+        "src_link": None,
+        "src_link/main.cpp": "reg",
+        "ext_file.txt": "reg",
+        "ext_dir": None,
+        "ext_dir/data.txt": "reg",
+        "src/loop": None,
+        "src/loop/main.cpp": None,
+    },
+    "external": {
+        "CMakeLists_link.txt": "sym",
+        "src_link": "sym",
+        "src_link/main.cpp": None,
+        "ext_file.txt": "reg",
+        "ext_dir": None,
+        "ext_dir/data.txt": "reg",
+        "src/loop": "sym",
+        "src/loop/main.cpp": None,
+    },
+    "none": {
+        "CMakeLists_link.txt": "sym",
+        "src_link": "sym",
+        "src_link/main.cpp": None,
+        "ext_file.txt": "sym",
+        "ext_dir": "sym",
+        "ext_dir/data.txt": None,
+        "src/loop": "sym",
+        "src/loop/main.cpp": None,
+    },
+    "classic": {
+        "CMakeLists_link.txt": "sym",
+        "src_link": None,
+        "src_link/main.cpp": "reg",
+        "ext_file.txt": "sym",
+        "ext_dir": None,
+        "ext_dir/data.txt": "reg",
+        "src/loop": None,
+        "src/loop/main.cpp": None,
+    },
+}
+
 
 @pytest.fixture
 def can_symlink(tmp_path: Path) -> None:
@@ -23,32 +70,54 @@ def can_symlink(tmp_path: Path) -> None:
 
 
 @pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")
-@pytest.mark.parametrize(
-    ("config_settings", "expected_type"),
-    [
-        pytest.param({}, "reg", id="resolve_all_default"),
-        pytest.param({"sdist.resolve-symlinks": "none"}, "sym", id="resolve_none"),
-    ],
-)
-def test_pep517_sdist_symlink(
-    tmp_path: Path,
-    config_settings: dict[str, list[str] | str],
-    expected_type: str,
-) -> None:
-    Path("CMakeLists_link.txt").symlink_to("CMakeLists.txt")
+@pytest.mark.parametrize("mode", [None, "all", "external", "none", "classic"])
+def test_pep517_sdist_symlink(tmp_path: Path, mode: str | None) -> None:
+    # Targets outside the project directory.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside.joinpath("ext.txt").write_text("external file\n", encoding="utf-8")
+    outside.joinpath("extdir").mkdir()
+    outside.joinpath("extdir", "data.txt").write_text(
+        "external data\n", encoding="utf-8"
+    )
 
-    out = build_sdist(str(tmp_path), config_settings=config_settings or None)
+    # Internal file and directory symlinks, external file and directory
+    # symlinks, and a directory symlink loop.
+    Path("CMakeLists_link.txt").symlink_to("CMakeLists.txt")
+    Path("src_link").symlink_to("src", target_is_directory=True)
+    Path("ext_file.txt").symlink_to(outside / "ext.txt")
+    Path("ext_dir").symlink_to(outside / "extdir", target_is_directory=True)
+    Path("src", "loop").symlink_to(Path("..", "src"), target_is_directory=True)
+
+    config_settings: dict[str, list[str] | str] | None = (
+        {"sdist.resolve-symlinks": mode} if mode else None
+    )
+    out = build_sdist(str(tmp_path), config_settings=config_settings)
 
     with tarfile.open(tmp_path / out, "r:gz") as tar:
-        link_member = tar.getmember("cmake_example-0.0.1/CMakeLists_link.txt")
-        if expected_type == "reg":
-            assert link_member.isreg(), (
-                "The symlink should have been stored as a regular file"
-            )
-        else:
-            assert link_member.issym(), (
-                "The symlink should have been stored as a symlink"
-            )
+        members = {m.name: m for m in tar.getmembers()}
+        for name, expected in EXPECTED[mode or "all"].items():
+            member = members.get(f"{PREFIX}/{name}")
+            if expected is None:
+                assert member is None, f"{name} should not be in the SDist"
+            elif expected == "reg":
+                assert member is not None, f"{name} missing from the SDist"
+                assert member.isreg(), f"{name} should be a regular file"
+            else:
+                assert member is not None, f"{name} missing from the SDist"
+                assert member.issym(), f"{name} should be a symlink"
+
+        if mode == "external":
+            # The external file symlink is stored dereferenced.
+            fobj = tar.extractfile(f"{PREFIX}/ext_file.txt")
+            assert fobj is not None
+            assert fobj.read() == b"external file\n"
+        if mode in {"none", "external"}:
+            # Internal symlink targets are preserved as-is.
+            link = members[f"{PREFIX}/CMakeLists_link.txt"]
+            assert link.linkname == "CMakeLists.txt"
+            dir_link = members[f"{PREFIX}/src_link"]
+            assert dir_link.linkname == "src"
 
 
 @pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")

--- a/tests/test_pep517_sdist_symlink.py
+++ b/tests/test_pep517_sdist_symlink.py
@@ -144,3 +144,30 @@ def test_pep517_sdist_dangling_symlink(
     err = capsys.readouterr().err
     assert "dangling_link.txt" in err
     assert "sdist.resolve-symlinks" in err
+
+
+@pytest.mark.usefixtures("package_simple_pyproject_ext", "can_symlink")
+def test_pep517_sdist_dangling_external_symlink(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    In "external" mode, an escaping symlink is normally dereferenced; a
+    dangling one cannot be, so it must be stored as a symlink member instead
+    of crashing.
+    """
+    Path("dangling_ext.txt").symlink_to(tmp_path / "outside" / "gone.txt")
+
+    rich_warning.cache_clear()
+    out = build_sdist(
+        str(tmp_path), config_settings={"sdist.resolve-symlinks": "external"}
+    )
+
+    with tarfile.open(tmp_path / out, "r:gz") as tar:
+        link_member = tar.getmember("cmake_example-0.0.1/dangling_ext.txt")
+        assert link_member.issym(), (
+            "A dangling external symlink should be stored as a symlink"
+        )
+
+    err = capsys.readouterr().err
+    assert "dangling_ext.txt" in err

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -1390,7 +1390,7 @@ def test_backcompat_sdist_resolve_symlinks(
     )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, {})
-    assert settings_reader.settings.sdist.resolve_symlinks == "none"
+    assert settings_reader.settings.sdist.resolve_symlinks == "classic"
 
     pyproject_toml.write_text(
         textwrap.dedent(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes item 2 of #1417 (see [the findings comment](https://github.com/scikit-build/scikit-build-core/issues/1417#issuecomment-4860351655)).

`sdist.resolve-symlinks = "none"` documented "store symlinks as-is", but the walk followed directory symlinks unconditionally, so a `link -> dir` had its contents archived as duplicated regular files with no link member. This PR makes the option's modes match their contracts:

- **`"all"`** (default, unchanged): resolve every symlink, copying its target's contents.
- **`"external"`** (new): store symlinks that stay inside the project as-is (files *and* directories); resolve symlinks whose immediate target points outside the project (absolute target, Windows drive, or a relative target that lexically escapes the root), since those would dangle once the sdist is extracted. Checking only the immediate target keeps chains consistent link-by-link.
- **`"none"`** (fixed): store every symlink as-is, including directory symlinks (stored as link members, walk pruned).
- **`"classic"`** (new): the previous de-facto behavior — file symlinks as-is, directory symlinks followed with contents duplicated. `minimum-version < 1.0` now maps here instead of `"none"` (same observable behavior as 0.x). Named to match `sdist.inclusion-mode = "classic"`.

Symlinks that can't be resolved are stored as link members in **every** mode, with a warning when they were supposed to be resolved:
- dangling symlinks (extends the #1421 fallback to `"external"` mode's dereference path);
- directory symlink loops — previously silently dropped on POSIX but archived on Windows (where `os.walk` classifies the loop as a file), so storing the link uniformly also fixes platform-divergent sdist contents. `add_path_to_tar` refuses to dereference a symlink resolving to a directory (only pruned loops reach it), which would otherwise recurse forever under `"all"`.

Implementation: `each_unignored_file()` gains a `resolve_symlinks` parameter (default `"all"`, so the wheel-packages caller is unchanged) that yields internal directory symlinks — and pruned loop symlinks — as members instead of descending, plus a `symlink_escapes()` helper; `build_sdist` keeps tar-level `dereference` only for `"all"` and adds escaping file symlinks via their resolved target in `"external"` mode. Schema and config reference regenerated.

Tests: 5-way mode parametrization over internal/external file and dir symlinks plus a loop symlink, asserting each member's tar type and preserved link targets; dangling-symlink tests for `"all"` and `"external"`. Each fix had a failing regression test first. Also verified a round trip manually: a `"none"` sdist extracts with working relative symlinks, and an `"external"` sdist ships the outside-the-tree file dereferenced.