### PR TITLE
fix(settings): flag scalar config-settings assignment to dict fields

### DIFF
--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -649,10 +649,15 @@ class ConfSource(Source):
                 continue
             if dataclasses.is_dataclass(outer_option):
                 try:
-                    _dig_fields(outer_option, keys[-1])
+                    field_type = _dig_fields(outer_option, keys[-1])
                 except KeyError:
                     yield keystr
                     continue
+                # A dict-valued field is only read via subkeys
+                # (``cmake.define.FOO=1``); a bare scalar assignment
+                # (``cmake.define=FOO=1``) is silently dropped, so flag it.
+                if get_target_raw_type(field_type) is dict:
+                    yield keystr
                 continue
             if get_target_raw_type(outer_option) is dict:
                 continue

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -558,6 +558,22 @@ def test_unrecognized_conf_under_scalar():
     assert list(sources.unrecognized_options(NestedSettingChecker)) == ["one.extra"]
 
 
+def test_unrecognized_conf_scalar_to_dict_field():
+    # A scalar ``-C`` assignment to a dict-valued field (``two.nine=A=1``
+    # instead of ``two.nine.A=1``) can never be consumed, so it must be
+    # reported rather than silently dropped.
+    settings = {
+        "one": "one",
+        "two.nine": "A=1",
+    }
+    sources = SourceChain(
+        EnvSource("SKBUILD"),
+        ConfSource(settings=settings),
+        TOMLSource(settings={}),
+    )
+    assert list(sources.unrecognized_options(NestedSettingChecker)) == ["two.nine"]
+
+
 def test_unrecognized_conf_under_dict_of_dict():
     # Keys nested arbitrarily deep under a dict-typed field (``two.ten`` is
     # Dict[str, Any]) are free-form and must be accepted (no TypeError, no

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -721,6 +721,27 @@ def test_skbuild_settings_pyproject_conf_broken(
     ]
 
 
+def test_skbuild_settings_scalar_dict_conf(tmp_path: Path):
+    # Scalar ``-C`` assignment to a dict-valued field (e.g. ``cmake.define``
+    # or ``env``) is silently dropped by the loader; it must be flagged
+    # instead of accepted just because the field name is valid. The correct
+    # form is ``cmake.define.FOO=1``.
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text("", encoding="utf-8")
+
+    config_settings: dict[str, str | list[str]] = {
+        "cmake.define": "FOO=1",
+        "env": "BAR=2",
+        "cmake.define.OK": "3",
+    }
+
+    settings_reader = SettingsReader.from_file(pyproject_toml, config_settings)
+    assert list(settings_reader.unrecognized_options()) == [
+        "cmake.define",
+        "env",
+    ]
+
+
 def test_skbuild_settings_min_version_defaults_strip(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses item 5 from #1417.

### Problem
A scalar `-C` assignment to a dict-valued key is silently dropped:

```
-Ccmake.define=A=1        # dropped (should be -Ccmake.define.A=1)
-Cenv=FOO=bar             # dropped (should be -Cenv.FOO=bar)
```

Dict fields are read via dotted subkeys (`ConfSource.has_item(is_dict=True)` only matches `cmake.define.*`), so a bare scalar key is never consumed. `unrecognized_options` didn't flag it either, because `cmake.define` is a valid field name — so the mistake was completely silent. This is pre-existing (identical in v0.12.2) and now also applies to the new `env` table.

### Fix
In `ConfSource.unrecognized_options`, when a config key resolves exactly to a dataclass field whose type is a plain `dict`, report it as unrecognized — such a field can only be set via subkeys. Union-with-dict fields (e.g. `wheel.packages`, which legitimately accept a scalar `FOO=bar` string) have a non-`dict` raw type and are unaffected.

### Tests
- `test_unrecognized_conf_scalar_to_dict_field` — unit-level against the synthetic model.
- `test_skbuild_settings_scalar_dict_conf` — end-to-end, asserting `cmake.define` and `env` are flagged while the correct `cmake.define.OK` subkey form is not.

Both were confirmed failing before the fix.