### PR TITLE
fix(metadata): combine same-field dynamic_wheel reports with OR

### DIFF
--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -242,20 +242,23 @@ def dynamic_wheel_fields(entries: Sequence[Mapping[str, Any]]) -> frozenset[str]
     be. The returned fields are marked ``Dynamic`` in the SDist's PKG-INFO
     (METADATA 2.2).
     """
-    fields: dict[str, bool] = {}
+    fields: set[str] = set()
     for provider, settings in load_dynamic_metadata(entries):
-        if isinstance(provider, DynamicMetadataWheelProtocol):
-            fields.update(provider.dynamic_wheel(settings))
+        if not isinstance(provider, DynamicMetadataWheelProtocol):
+            continue
+        for field, is_dynamic in provider.dynamic_wheel(settings).items():
+            if field not in _ALL_FIELDS:
+                msg = f"{field!r} is not a valid dynamic-metadata field"
+                raise KeyError(msg)
+            if field == "version" and is_dynamic:
+                msg = "'version' may not change between the SDist and wheel"
+                raise ValueError(msg)
+            # A field's merged value can change if any contributing provider's
+            # part may, so reports combine with OR: one True can't be retracted.
+            if is_dynamic:
+                fields.add(field)
 
-    for field, is_dynamic in fields.items():
-        if field not in _ALL_FIELDS:
-            msg = f"{field!r} is not a valid dynamic-metadata field"
-            raise KeyError(msg)
-        if field == "version" and is_dynamic:
-            msg = "'version' may not change between the SDist and wheel"
-            raise ValueError(msg)
-
-    return frozenset(field for field, is_dynamic in fields.items() if is_dynamic)
+    return frozenset(fields)
 
 
 def _merge_dict(

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -630,6 +630,43 @@ def test_dynamic_wheel_defaults_to_static(
     assert dynamic_wheel_fields(entries) == frozenset()
 
 
+def test_dynamic_wheel_same_field_combines_with_or(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two providers reporting the same field combine with OR; True is not retracted."""
+    from scikit_build_core.builder._load_provider import dynamic_wheel_fields
+
+    monkeypatch.chdir(tmp_path)
+    path_true = _write_dynamic_wheel_plugin(
+        "wheel_plugin_or_true",
+        """\
+        def dynamic_metadata(settings, project):
+            return {}
+
+        def dynamic_wheel(settings):
+            return {"dependencies": True}
+        """,
+    )
+    path_false = _write_dynamic_wheel_plugin(
+        "wheel_plugin_or_false",
+        """\
+        def dynamic_metadata(settings, project):
+            return {}
+
+        def dynamic_wheel(settings):
+            return {"dependencies": False}
+        """,
+    )
+    # A later False must not retract an earlier True (and vice versa).
+    entries = [
+        {"provider": {"path": path_true, "module": "wheel_plugin_or_true"}},
+        {"provider": {"path": path_false, "module": "wheel_plugin_or_false"}},
+    ]
+    assert dynamic_wheel_fields(entries) == frozenset({"dependencies"})
+    entries.reverse()
+    assert dynamic_wheel_fields(entries) == frozenset({"dependencies"})
+
+
 def test_array_plugin_requires_field() -> None:
     """A bundled generic plugin in the array form needs a 'field' setting."""
     from scikit_build_core.builder._load_provider import process_dynamic_metadata


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1436.

## Problem

`dynamic_wheel_fields` in `builder/_load_provider.py` merged provider reports with `dict.update`, making same-field reports **last-wins**: a later `[[tool.dynamic-metadata]]` entry returning `{"dependencies": False}` could retract an earlier entry's `{"dependencies": True}`. Because contributions to a list/table field merge across entries, if *any* provider's part may change between the SDist and a wheel, the final value may change and PEP 643 requires it be marked `Dynamic`. Over-marking is allowed; under-marking is a spec violation.

A second consequence: validation ran over the merged dict after the loop, so a `{"version": True}` from one provider was silently masked by a later `{"version": False}` instead of raising.

## Fix

Accumulate into a `set` and validate each fragment as it is collected:
- Same-field reports combine with **OR** (any `True` wins) — a `True` can't be retracted.
- The `version` and unknown-field checks run per-fragment, so a masked `{"version": True}` still raises.

Aligns with the reference implementation in scikit-build/dynamic-metadata#78.

## Tests

Added `test_dynamic_wheel_same_field_combines_with_or`, exercising both orderings of a `True`/`False` pair. Confirmed it fails against the old last-wins code (`frozenset()` instead of `{"dependencies"}`) and passes with the fix. All existing `dynamic_wheel` tests still pass.