### PR TITLE
docs(settings): address post-merge review notes on entry-point config

### DIFF
--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -25,8 +25,10 @@ state, e.g. `"wheel"`) and `env` (the environment mapping) are matched by
 parameter name, and a `**kwargs` provider receives both. A provider may accept
 any subset -- both, either one, or none. The callable is invoked exactly once.
 
-It is registered under one of two groups; the **group** selects the precedence
-level, and the entry-point name is arbitrary:
+The callable is registered under either the `scikit-build-core.config.default`
+or the `scikit-build-core.config.override` entry-point group; the group selects
+the precedence level. The entry-point name is arbitrary (it only affects
+ordering, see below):
 
 ```{code-block} toml
 :caption: pyproject.toml of the provider package
@@ -60,10 +62,9 @@ The full precedence order, highest to lowest, is:
 6. `default` entry-point providers
 7. built-in defaults
 
-A package may register providers in both groups, and the entry-point name is
-free-form. When several providers are registered in the same group, they are
-applied in sorted name order and the alphabetically-first name wins on
-conflicts.
+A package may register providers in both groups. When several providers are
+registered in the same group, they are applied in sorted name order and the
+alphabetically-first name wins on conflicts.
 
 ## Validation
 
@@ -100,6 +101,12 @@ def config(*, state, env):
         ]
     }
 ```
+
+Note that `inherit.append`/`inherit.prepend` in a provider's `overrides` joins
+with the provider's _own_ table only. Merging with the project's configuration
+happens later, per the precedence order above: tables merge key-by-key across
+levels, but a list is taken wholesale from the highest-precedence level that
+sets it.
 
 ## Opting out
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -351,6 +351,12 @@ class SettingsReader:
                 state=state, env=environ
             ):
                 ep_skb = copy.deepcopy(ep_table)
+                # Any [[overrides]] in the provider table (including inherit
+                # append/prepend) resolve against the provider's own table
+                # here; cross-source merging happens later in SourceChain,
+                # which merges dicts but takes lists wholesale from the
+                # highest-precedence source. A future refactor could process
+                # overrides on the merged view instead.
                 ep_matched, ep_overridden = process_overrides(
                     ep_skb, state=state, env=env, retry=retry
                 )


### PR DESCRIPTION
Ahh, it was PR-happy. I'll undraft when I've reviewed, as usual.

A little wordy still, but overall better.

:robot: _AI text below_ :robot:

Addresses the post-merge review comments from @LecrisUT on #1406:

- Reword the registration paragraph to name both entry-point groups explicitly ([comment](https://github.com/scikit-build/scikit-build-core/pull/1406#discussion_r3511535024)).
- Drop the redundant "name is free-form" sentence ([comment](https://github.com/scikit-build/scikit-build-core/pull/1406#discussion_r3511549072)).
- Add a docs caveat and a code note that `inherit.append`/`prepend` in a provider's `overrides` joins with the provider's own table only, with cross-source list resolution being winner-takes-all — flagged for a future refactor ([comment](https://github.com/scikit-build/scikit-build-core/pull/1406#discussion_r3511717150)).

The signature-dispatch concern in the [remaining thread](https://github.com/scikit-build/scikit-build-core/pull/1406#discussion_r3511506037) was already fixed by #1424 (`inspect.signature`-based per-argument binding, no `TypeError` retry).