### PR TITLE
chore(skill): add test-downstream A/B regression-check skill

### DIFF
--- a/.agents/skills/test-downstream/SKILL.md
+++ b/.agents/skills/test-downstream/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: test-downstream
+description: >-
+  Test a downstream project against scikit-build-core to check whether the
+  current checkout regresses it versus a released baseline. Builds the project
+  twice per mode — once against a released tag (baseline, via a git worktree)
+  and once against the working tree — in both a normal wheel build and an
+  editable install, then reports parity, wheel-content, and warning diffs. Use
+  this whenever the user wants to test/build/try a downstream or real-world
+  project against their changes, check that a fix or PR doesn't break
+  downstream, run `nox -s downstream`, compare current-vs-released behavior,
+  reproduce a downstream build issue, or validate against projects in
+  docs/data/projects.toml — even if they only name a project (e.g. "test
+  iminuit", "does gemmi still build").
+---
+
+# Test a downstream project (baseline vs current)
+
+## What this does and why
+
+scikit-build-core is a build backend, so the failure mode that matters most is
+_breaking a project that used to build_. This skill answers one question: does
+the current checkout (your uncommitted changes included) build a given
+downstream project as well as the last released version did?
+
+It builds the project **twice per mode**, each side in its own detached git
+worktree:
+
+- **baseline** — a worktree checked out at a released tag, so installing `.`
+  reproduces the released backend.
+- **current** — a worktree at HEAD with your uncommitted changes replayed onto
+  it (tracked diff vs HEAD + untracked, non-ignored files), so dirty changes are
+  still what's on trial.
+
+Both sides get a **private worktree** on purpose. The `downstream` session
+installs scikit-build-core into `.nox/downstream/` and clones the project under
+`.nox/downstream/tmp/`; two runs sharing one checkout would `rm -rf` and
+reinstall over each other mid-build. Separate worktrees give each run its own
+`.nox`, so **A/B runs on the same repo are safe to run in parallel**.
+
+…across **both modes** the backend supports: a normal wheel build
+(`python -m build`) and an editable install (`pip install -e`). Everything goes
+through `nox -s downstream`, the same harness a human uses, so results are
+trustworthy and easy to reproduce by hand.
+
+The primary signal is **parity**: a mode that built on the baseline but fails on
+the current checkout is a regression you introduced. Wheel-content and warning
+diffs are secondary, heuristic signals — full logs are always kept so you can
+dig in.
+
+## Preconditions
+
+- Run from inside the scikit-build-core repo (or a worktree of it). The
+  "current" side is materialized from whatever `git rev-parse --show-toplevel`
+  resolves to — its committed HEAD plus uncommitted changes — so if the user is
+  testing changes in a worktree, run there.
+- `nox` and `git` on PATH; network access to clone the project; a compiler
+  toolchain (these builds actually compile). CMake/Ninja are auto-installed by
+  the session if missing.
+- Don't stash or commit the user's changes — testing the dirty tree is the
+  point.
+
+## Step 1 — Resolve the project
+
+The user usually names a project, not a URL. Resolve it via
+`docs/data/projects.toml`, the curated list of known-good downstream projects.
+Each entry has:
+
+```toml
+[[project]]
+pypi = "iminuit"            # what the user is likely to say
+github = "scikit-hep/iminuit"   # -> https://github.com/scikit-hep/iminuit
+path = "awkward-cpp/pyproject.toml"   # optional -> --subdir awkward-cpp
+```
+
+- The `project` argument to nox is a git URL: `https://github.com/<github>`.
+- If `path` is present, pass `--subdir <dirname of path>` (strip the trailing
+  `/pyproject.toml`).
+
+If the user gives a full URL or local path, use it directly. If a named project
+isn't in the list, use the obvious GitHub URL and mention it wasn't in the
+curated set (it may need submodules or extra clone args).
+
+## Step 2 — Run the A/B check
+
+The bundled script does the whole dance — pick the baseline tag, create and tear
+down the worktree, run all four builds, capture logs, and diff results:
+
+```bash
+python3 <skill>/scripts/downstream_ab.py <project-url> [--subdir DIR] [-C key=val ...]
+```
+
+The baseline tag defaults to the latest published release (via `gh`, falling
+back to the newest non-prerelease `v*` tag). Override with `--tag v0.11.6` when
+the user names a specific version to compare against.
+
+Useful options (all forwarded to `nox -s downstream`):
+
+- `--subdir DIR` — build a subdirectory (from `path` in projects.toml).
+- `-C key=val` — a config-setting, repeatable (e.g. `-C cmake.verbose=true`).
+- `-c "import foo; foo.test()"` — import/smoke check, editable mode only.
+- `--mode build` or `--mode editable` — run just one mode instead of both.
+- `extra` positional args are forwarded to `git clone` (e.g. `--branch v2`).
+- `--keep` — keep the baseline worktree for inspection; `--out DIR` — choose the
+  log directory.
+
+Exit code is non-zero if any mode regressed (baseline ok, current failed).
+
+**Example** — test `iminuit` (in projects.toml, no subdir) against the current
+checkout, both modes:
+
+```bash
+python3 <skill>/scripts/downstream_ab.py https://github.com/scikit-hep/iminuit
+```
+
+## Step 3 — Interpret and report
+
+The script prints (and writes to `<out>/summary.md`) a parity table like:
+
+```
+| mode     | baseline | current | verdict       |
+| build    | ok       | FAIL(1) | 🔴 REGRESSION |
+| editable | ok       | ok      | ✅ parity     |
+```
+
+Report back to the user concisely:
+
+- **Lead with regressions.** A 🔴 REGRESSION is the headline — the current
+  checkout broke a build the release handled. Open the relevant
+  `<out>/current-<mode>.log`, find the actual error (not just the nox exit
+  line), and quote it. This is where your change is on trial.
+- **⚪ both fail** usually means the project needs something the environment
+  lacks (a submodule, a system lib) or is already broken upstream — not your
+  fault, but say so rather than staying silent.
+- **Wheel-content diff** (build mode): files added/removed between baseline and
+  current wheels. Often intentional (you changed packaging) — flag it and let
+  the user judge.
+- **Warning diff** is a keyword heuristic over the logs; treat new lines as
+  leads to verify in the full log, not conclusions.
+
+Point the user at the log directory so they can inspect anything you didn't
+quote.
+
+## Manual fallback
+
+If the script doesn't fit (a project needs bespoke setup, or you want to iterate
+on one mode), the underlying commands are simple. Current checkout — run it
+directly in the repo only if nothing else is using its `.nox/downstream/` at the
+same time:
+
+```bash
+nox -s downstream -- <project-url> [--subdir DIR] [--editable] [-C key=val]
+```
+
+Baseline is the same command run from a worktree at the tag:
+
+```bash
+git worktree add --detach /tmp/skbc-base v0.12.2
+( cd /tmp/skbc-base && nox -s downstream -- <project-url> ... )
+git worktree remove --force /tmp/skbc-base
+```
+
+The script does this dance for **both** sides (current in a worktree at HEAD
+with your dirty changes replayed onto it) so each run has a private `.nox` and
+parallel runs don't clobber one another.
+
+`--editable` switches to `pip install -e`; `-c CODE` runs a Python snippet after
+an editable install (it errors in build mode). Built wheels land under
+`.nox/downstream/tmp/<slug>/[subdir]/dist/`.
+
+## Things that bite
+
+- **Large projects are slow.** Each of the four runs clones fresh and compiles
+  from scratch — a big C++ project can take many minutes ×4. Warn the user for
+  heavy projects; offer `--mode build` to halve the work, or a smaller project
+  to smoke-test first.
+- **Submodules.** The session clones with `--recurse-submodules`, but projects
+  not in projects.toml may still need extra clone args (pass them as trailing
+  `extra` args).
+- **Old baseline tags** carry their own noxfile; if a very old tag's
+  `downstream` session lacks a flag you passed, the baseline run may fail on
+  args — pick a newer `--tag` or drop the flag.

--- a/.agents/skills/test-downstream/evals/evals.json
+++ b/.agents/skills/test-downstream/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "test-downstream",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I've got some uncommitted changes to the wheel-writing code. Can you check they don't break a downstream project? Try deflate (it's small) both as a normal build and an editable install, compared against the last release.",
+      "expected_output": "Resolves deflate -> https://github.com/dcwatson/deflate via projects.toml, runs downstream_ab.py for both modes against the latest release tag, reports a parity table and points at logs.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "does gemmi still build with my branch?",
+      "expected_output": "Resolves gemmi -> https://github.com/project-gemmi/gemmi, runs the A/B check against the current checkout vs latest release, leads with any regression and quotes the real error from the log if it fails.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I changed how packages get copied into the wheel. Run a downstream build against v0.12.1 and tell me if the wheel contents changed at all. Use the astyle project.",
+      "expected_output": "Resolves astyle -> https://github.com/Freed-Wu/astyle-wheel, runs downstream_ab.py with --tag v0.12.1, focuses on the wheel-contents diff section, and reports added/removed files.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/test-downstream/scripts/downstream_ab.py
+++ b/.agents/skills/test-downstream/scripts/downstream_ab.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""A/B downstream build check for scikit-build-core.
+
+Builds one downstream project twice per mode: once against a released tag
+(baseline) and once against the current checkout (your working tree, dirty
+changes included). Both go through `nox -s downstream` so the harness matches
+what a human would run by hand.
+
+Both sides run in their own detached git worktree, so each gets a private
+`.nox/downstream/` venv and clone tree. That isolation matters: the downstream
+session installs scikit-build-core into `.nox` and clones the project under
+`.nox/downstream/tmp/`, so two A/B runs sharing a checkout would `rm -rf` and
+reinstall over each other mid-build. The current worktree is a faithful copy of
+the working tree — the tracked diff vs HEAD plus untracked (non-ignored) files
+are replayed into it — so dirty changes are still what's on trial.
+
+The signal that matters is *parity*: a mode that built on the baseline but
+fails on the current checkout is a regression your change introduced. Wheel
+contents and log warnings are secondary, heuristic signals — full logs are
+always kept so nothing is hidden.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def run(
+    cmd: list[str], *, check: bool = False, **kw: object
+) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, text=True, check=check, **kw)
+
+
+def capture(cmd: list[str], **kw: object) -> str:
+    return subprocess.run(
+        cmd, text=True, capture_output=True, check=True, **kw
+    ).stdout.strip()
+
+
+def add_worktree(repo: Path, dest: Path, ref: str) -> None:
+    run(
+        ["git", "-C", str(repo), "worktree", "add", "--detach", str(dest), ref],
+        check=True,
+    )
+
+
+def remove_worktree(repo: Path, dest: Path) -> None:
+    run(["git", "-C", str(repo), "worktree", "remove", "--force", str(dest)])
+
+
+def replay_working_tree(repo: Path, dest: Path) -> None:
+    """Make `dest` (a worktree at HEAD) match the repo's dirty working tree.
+
+    Applies uncommitted tracked changes (staged + unstaged vs HEAD) and copies
+    untracked, non-ignored files. Ignored paths like `.nox` are left out.
+    """
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", "HEAD", "--binary"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    if diff.strip():
+        applied = subprocess.run(
+            ["git", "-C", str(dest), "apply", "--whitespace=nowarn"],
+            input=diff,
+            text=True,
+            check=False,
+        )
+        if applied.returncode != 0:
+            sys.exit(
+                "failed to replay uncommitted tracked changes into current worktree"
+            )
+
+    listing = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "--others", "--exclude-standard", "-z"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    for rel in filter(None, listing.split("\0")):
+        src, dst = repo / rel, dest / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_symlink() or src.is_file():
+            shutil.copy2(src, dst, follow_symlinks=False)
+
+
+def latest_release_tag(repo: Path) -> str:
+    """Latest published release (not a prerelease). Prefer gh, fall back to tags."""
+    try:
+        return capture(
+            ["gh", "release", "view", "--json", "tagName", "-q", ".tagName"], cwd=repo
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    tags = capture(
+        ["git", "tag", "-l", "v*", "--sort=-v:refname"], cwd=repo
+    ).splitlines()
+    for tag in tags:
+        # Skip prereleases (rc/a/b/dev suffixes after the version).
+        if not any(x in tag for x in ("rc", "a", "b", "dev")):
+            return tag
+    if tags:
+        return tags[0]
+    sys.exit("No version tags found; pass --tag explicitly.")
+
+
+def nox_downstream(
+    workdir: Path,
+    project: str,
+    *,
+    editable: bool,
+    subdir: str | None,
+    config_settings: list[str],
+    code: str | None,
+    extra: list[str],
+    logpath: Path,
+) -> int:
+    """Run one `nox -s downstream` invocation, teeing combined output to logpath."""
+    posargs: list[str] = [project]
+    if subdir:
+        posargs += ["--subdir", subdir]
+    if editable:
+        posargs.append("--editable")
+        if code:
+            posargs += ["-c", code]
+    for c in config_settings:
+        posargs += ["-C", c]
+    posargs += extra
+    cmd = ["nox", "-s", "downstream", "--", *posargs]
+
+    with logpath.open("w") as log:
+        log.write(f"$ (cwd={workdir}) {' '.join(cmd)}\n\n")
+        log.flush()
+        proc = subprocess.Popen(
+            cmd,
+            cwd=workdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            log.write(line)
+        return proc.wait()
+
+
+def find_wheel(workdir: Path) -> Path | None:
+    tmp = workdir / ".nox" / "downstream" / "tmp"
+    wheels = sorted(tmp.rglob("*.whl"), key=lambda p: p.stat().st_mtime)
+    return wheels[-1] if wheels else None
+
+
+def wheel_names(wheel: Path) -> set[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        return set(zf.namelist())
+
+
+def heuristic_warnings(log: Path) -> set[str]:
+    """Lines that look like scikit-build-core / cmake diagnostics, for eyeballing."""
+    out: set[str] = set()
+    keys = ("scikit_build_core", "scikit-build", "skbuild", "cmake")
+    signals = ("warn", "deprecated", "deprecation", "error")
+    for raw in log.read_text(errors="replace").splitlines():
+        low = raw.lower()
+        if any(s in low for s in signals) and any(k in low for k in keys):
+            out.add(raw.strip())
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("project", help="git URL or local path (forwarded to nox)")
+    p.add_argument("--tag", help="baseline tag (default: latest release)")
+    p.add_argument("--subdir", help="subdirectory to build (nox --subdir)")
+    p.add_argument(
+        "--mode",
+        default="build,editable",
+        help="comma list: build,editable (default both)",
+    )
+    p.add_argument("-C", dest="config_settings", action="append", default=[])
+    p.add_argument("-c", dest="code", help="import check code (editable mode only)")
+    p.add_argument(
+        "--repo", type=Path, help="scikit-build-core repo (default: git root of cwd)"
+    )
+    p.add_argument(
+        "--out", type=Path, help="output dir for logs/summary (default: temp)"
+    )
+    p.add_argument(
+        "--keep", action="store_true", help="keep both worktrees for inspection"
+    )
+    p.add_argument(
+        "extra", nargs="*", help="extra args forwarded to git clone (e.g. --branch X)"
+    )
+    args = p.parse_args()
+
+    repo = (
+        args.repo or Path(capture(["git", "rev-parse", "--show-toplevel"]))
+    ).resolve()
+    tag = args.tag or latest_release_tag(repo)
+    modes = [m.strip() for m in args.mode.split(",") if m.strip()]
+    out = (args.out or Path(tempfile.mkdtemp(prefix="downstream-ab-"))).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"repo:     {repo}")
+    print(f"baseline: {tag}")
+    print(f"project:  {args.project}")
+    print(f"modes:    {', '.join(modes)}")
+    print(f"logs:     {out}\n")
+
+    base_wt = out / "_baseline_worktree"
+    cur_wt = out / "_current_worktree"
+    add_worktree(repo, base_wt, tag)
+    add_worktree(repo, cur_wt, "HEAD")
+    replay_working_tree(repo, cur_wt)
+
+    results: dict[tuple[str, str], int] = {}
+    wheels: dict[str, set[str]] = {}
+    try:
+        for label, workdir in (("baseline", base_wt), ("current", cur_wt)):
+            for mode in modes:
+                print(f"\n===== {label} / {mode} =====")
+                rc = nox_downstream(
+                    workdir,
+                    args.project,
+                    editable=(mode == "editable"),
+                    subdir=args.subdir,
+                    config_settings=args.config_settings,
+                    code=args.code,
+                    extra=args.extra,
+                    logpath=out / f"{label}-{mode}.log",
+                )
+                results[(label, mode)] = rc
+                if mode == "build" and rc == 0:
+                    wheel = find_wheel(workdir)
+                    if wheel:
+                        wheels[label] = wheel_names(wheel)
+    finally:
+        if not args.keep:
+            remove_worktree(repo, base_wt)
+            remove_worktree(repo, cur_wt)
+
+    # ---- Report ----
+    lines: list[str] = ["# Downstream A/B report", ""]
+    lines.append(f"- project: `{args.project}`")
+    lines.append(f"- baseline tag: `{tag}`  vs  current checkout")
+    lines.append("")
+    lines.append("| mode | baseline | current | verdict |")
+    lines.append("| --- | --- | --- | --- |")
+    regressed = False
+    for mode in modes:
+        b = results.get(("baseline", mode))
+        c = results.get(("current", mode))
+        bs = "ok" if b == 0 else f"FAIL({b})"
+        cs = "ok" if c == 0 else f"FAIL({c})"
+        if b == 0 and c != 0:
+            verdict = "🔴 REGRESSION"
+            regressed = True
+        elif b != 0 and c == 0:
+            verdict = "🟢 fixed"
+        elif b != 0 and c != 0:
+            verdict = "⚪ both fail"
+        else:
+            verdict = "✅ parity"
+        lines.append(f"| {mode} | {bs} | {cs} | {verdict} |")
+    lines.append("")
+
+    if "baseline" in wheels and "current" in wheels:
+        added = sorted(wheels["current"] - wheels["baseline"])
+        removed = sorted(wheels["baseline"] - wheels["current"])
+        if added or removed:
+            lines.append("## Wheel contents changed (build mode)")
+            lines += [f"- + `{f}` (only in current)" for f in added]
+            lines += [f"- - `{f}` (only in baseline)" for f in removed]
+        else:
+            lines.append("## Wheel contents: identical file list ✅")
+        lines.append("")
+
+    for mode in modes:
+        bl = out / f"baseline-{mode}.log"
+        cl = out / f"current-{mode}.log"
+        if bl.exists() and cl.exists():
+            new = sorted(heuristic_warnings(cl) - heuristic_warnings(bl))
+            if new:
+                lines.append(
+                    f"## New scikit-build-core diagnostics in current ({mode}) — heuristic"
+                )
+                lines += [f"- {w}" for w in new[:40]]
+                lines.append("")
+
+    lines.append(f"Full logs: `{out}`")
+    report = "\n".join(lines)
+    (out / "summary.md").write_text(report + "\n")
+    print("\n" + report)
+    return 1 if regressed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,6 +373,7 @@ docstring-code-format = true
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20", "ANN", "FBT001", "INP"]
 "noxfile.py" = ["T20", "TID251"]
+".agents/skills/**/*.py" = ["T20"]
 "src/scikit_build_core/resources/*.py" = ["PTH", "ARG002", "FBT", "TID251"]
 "src/scikit_build_core/_compat/**.py" = ["TID251"]
 "src/scikit_build_core/settings/**.py" = ["FBT001", "FA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ docs = [
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/scikit_build_core/_version.py"
-build.targets.sdist.exclude = [".git"]
+build.targets.sdist.exclude = [".git", ".agents/", ".distro/", ".fmf/", ".github/", ".packit.yaml", ".readthedocs.yaml"]
 
 
 [tool.uv]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Adds a `test-downstream` agent skill that answers one question: does the current
checkout regress a downstream project versus the last release? It builds the
project twice per mode — baseline tag vs working tree, in both a wheel build and
an editable install — through `nox -s downstream` and reports a parity table
plus wheel-content and warning diffs. The primary signal is **parity**: a mode
that built on the baseline but fails on the current checkout is a regression.

Both sides run in their own detached git worktree, so each gets a private
`.nox/downstream/` venv and clone tree. The current worktree faithfully replays
the dirty working tree (tracked diff vs HEAD + untracked, non-ignored files)
onto HEAD, so uncommitted changes are still what's tested. That isolation lets
multiple A/B runs execute concurrently on one checkout without clobbering each
other's `.nox`.

## Projects exercised (current `main` vs `v0.12.2`)

Ran the skill against **20** downstream projects. Recorded here so future runs
can pick up where this left off (the curated list is `docs/data/projects.toml`).

**✅ parity (16):** iminuit, spglib, rapidfuzz, gemmi, gdstk, boost-histogram,
h3, Levenshtein, nanobind, osqp, pyzmq, tetgen, pygram11, deflate, pyhmmer,
highspy

**🔴 regression (2):**
- **manifold3d** — `build/_pathutil.py` (from #1395) now hard-raises when a
  `wheel.packages` entry's source doesn't exist on disk. manifold's `manifold3d`
  module is produced by CMake install, so v0.12.2 skipped it silently, current
  aborts. Fix in #1440.
- **coreforecast** — `settings/skbuild_read_settings.py` (from #1399) turns a
  renamed field set without `minimum-version` into an error. coreforecast uses
  `cmake.verbose` (renamed to `build.verbose`) without pinning `minimum-version`,
  so a WARNING became an aborting ERROR. Intended behavior of #1399, but it
  breaks any project using an old field name without a pinned minimum-version.

**⚪ upstream-only failure, not us (2):** astyle (malformed author email rejected
by its setuptools root), symusic (C++20 structured-bindings error in its vendored
`zpp_bits.h`) — both fail identically on baseline and current.

**Not yet run** (rest of `docs/data/projects.toml`): adios2, afdko, antspyx,
awkward-cpp, celerite2, clang-format, cmake, ducc0, faiss-cpu, freud-analysis,
imgui-bundle, islpy, kiss-icp, lammps, laszip, libigl, librapid, lightgbm,
llama-cpp-python, llamacpp, MaterialX, mqt-core, ncrystal, ninja, nodejs-wheel,
ompl, OpenEXR, OpenImageIO, osmium, phik, phono3py, phonopy, polyscope, pyarrow,
pyhmmer, pylibmagic, pyopencl, pyresidfp, pyslang, s5cmd, SimpleITK, simsopt,
sparse-dot-topn, spherely, stormpy, tiledb, tomotopy, viennals, viennaps,
xgrammar, xtgeo.

The regressions are reported here for visibility; this PR only adds the skill —
no backend changes.

https://claude.ai/code/session_01TYR256sU3ujMvmRJwga3rK
