### PR TITLE
feat(editable): serve force-include entries live via the redirect

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -442,6 +442,15 @@ destination. A force-included _directory_ stays subject to that exclude, so a
 bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
 directory and exclude `**/*.bzl` to drop the Bazel files from it).
 
+In an editable install using redirect mode (the default), platlib entries are
+served live from their sources through the import redirect instead of being
+copied, so edits to a force-included file take effect without reinstalling. This
+covers importable modules (even renamed ones) and data files that keep their
+filename and land inside a package. Anything the redirect cannot express — other
+wheel trees like `${SKBUILD_SCRIPTS_DIR}`, renamed data files, or top-level data
+files — is still copied at install time, so those snapshots only refresh on
+reinstall.
+
 #### Building a wheel from an SDist
 
 A common pattern vendors an external (`../`) source into the SDist and then

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -446,10 +446,11 @@ In an editable install using redirect mode (the default), platlib entries are
 served live from their sources through the import redirect instead of being
 copied, so edits to a force-included file take effect without reinstalling. This
 covers importable modules (even renamed ones) and data files that keep their
-filename and land inside a package. Anything the redirect cannot express — other
-wheel trees like `${SKBUILD_SCRIPTS_DIR}`, renamed data files, or top-level data
-files — is still copied at install time, so those snapshots only refresh on
-reinstall.
+filename and sit directly inside a top-level package. Anything the redirect
+cannot express — other wheel trees like `${SKBUILD_SCRIPTS_DIR}`, renamed or
+top-level data files, and data files nested below a package subdirectory (kept
+as real files so package-root resource lookups keep the wheel layout) — is still
+copied at install time, so those snapshots only refresh on reinstall.
 
 #### Building a wheel from an SDist
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -895,6 +895,12 @@ print(mk_skbuild_docs())
   that names an sdist output (vendored via :confval:`sdist.force-include`) build
   from both a source tree and an unpacked sdist.
 
+  In a redirect-mode editable install, platlib entries are served live from
+  their sources through the import redirect instead of being copied:
+  importable modules always, data files when they keep their filename and
+  land inside a package. Anything else (other wheel trees, renamed or
+  top-level data files) is still copied at install time.
+
   .. versionadded:: 1.0
 ```
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -898,8 +898,8 @@ print(mk_skbuild_docs())
   In a redirect-mode editable install, platlib entries are served live from
   their sources through the import redirect instead of being copied:
   importable modules always, data files when they keep their filename and
-  land inside a package. Anything else (other wheel trees, renamed or
-  top-level data files) is still copied at install time.
+  sit directly inside a top-level package. Anything else (other wheel trees;
+  renamed, top-level, or nested data files) is still copied at install time.
 
   .. versionadded:: 1.0
 ```

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -365,15 +365,17 @@ def editable_redirectable(src: Path, rel: Path) -> bool:
     ``rel`` is the destination relative to the platlib root. An importable
     destination is loaded from ``src`` directly (so a rename is fine), as long
     as ``src`` itself has a loadable suffix. A data file is only reachable
-    through its package's ``__path__`` (its source directory is registered
-    there), so it must keep its filename and sit inside a package; a renamed or
-    top-level data file must still be copied.
+    through its *immediate* parent package's ``__path__`` (its source directory
+    is registered there), so it must keep its filename and sit directly inside
+    a top-level package: any deeper and a package-root traversal like
+    ``files("pkg") / "sub/data.txt"``, which a real wheel supports, would not
+    find it. Renamed, top-level, or nested data files must still be copied.
     """
     if not is_trackable(rel):
         return False
     if is_module(rel):
         return is_module(src)
-    return len(rel.parts) > 1 and src.name == rel.name
+    return len(rel.parts) == 2 and src.name == rel.name
 
 
 def is_module(path: Path) -> bool:

--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 __all__ = [
     "NON_PLATLIB_REBUILD_MSG",
     "editable_rebuild_install_dir",
+    "editable_redirectable",
     "is_module",
     "is_trackable",
     "iter_force_include",
@@ -354,6 +355,25 @@ def module_loader_rank(path: Path) -> int:
         return _MODULE_SUFFIXES.index(suffix)
     except ValueError:
         return len(_MODULE_SUFFIXES)
+
+
+def editable_redirectable(src: Path, rel: Path) -> bool:
+    """
+    True if a force-include entry can be served live by the editable redirect
+    instead of a baked copy.
+
+    ``rel`` is the destination relative to the platlib root. An importable
+    destination is loaded from ``src`` directly (so a rename is fine), as long
+    as ``src`` itself has a loadable suffix. A data file is only reachable
+    through its package's ``__path__`` (its source directory is registered
+    there), so it must keep its filename and sit inside a package; a renamed or
+    top-level data file must still be copied.
+    """
+    if not is_trackable(rel):
+        return False
+    if is_module(rel):
+        return is_module(src)
+    return len(rel.parts) > 1 and src.name == rel.name
 
 
 def is_module(path: Path) -> bool:

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -22,6 +22,7 @@ __lazy_modules__ = {
     "packaging.tags",
     "packaging.utils",
     "pathlib",
+    "pathspec",
     "platform",
     "shutil",
     "tempfile",
@@ -38,6 +39,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
+import pathspec
 from packaging.requirements import Requirement
 from packaging.tags import Tag
 from packaging.utils import canonicalize_name
@@ -58,6 +60,7 @@ from ._editable import (
 from ._init import setup_logging
 from ._pathutil import (
     NON_PLATLIB_REBUILD_MSG,
+    editable_redirectable,
     iter_force_include,
     packages_to_file_mapping,
     resolve_from_sdist_force_include,
@@ -128,6 +131,8 @@ def _force_include_into_wheel(
     wheel_dirs: dict[str, Path],
     targetlib: str,
     only_metadata: bool = False,
+    redirect_mapping: dict[str, str] | None = None,
+    redirect_libdir: Path | None = None,
 ) -> set[Path]:
     """
     Copy ``wheel.force-include`` entries into the staged wheel trees.
@@ -137,12 +142,23 @@ def _force_include_into_wheel(
     metadata tree; the prepare-metadata path uses it so the prepared
     ``.dist-info`` matches the final wheel.
 
+    With ``redirect_mapping``/``redirect_libdir`` (a redirect-mode editable
+    build), platlib entries the redirect can serve live (see
+    :func:`editable_redirectable`) are added to the mapping instead of copied,
+    displacing a package file or CMake output at the same destination so the
+    force-include still wins. Everything else falls back to a baked copy.
+
     Returns the resolved target paths of force-included *files*, so the caller
     can exempt them from ``wheel.exclude`` (naming an exact file forces it past
     an exclude pattern). Files copied from a force-included *directory* are not
     returned, so a bulk directory copy stays subject to ``wheel.exclude``.
     """
     written: set[Path] = set()
+    exclude_spec = (
+        pathspec.GitIgnoreSpec.from_lines(settings.wheel.exclude)
+        if redirect_mapping is not None
+        else None
+    )
     for source, dest in settings.wheel.force_include.items():
         base, rest = resolve_wheel_tree(
             dest,
@@ -160,6 +176,28 @@ def _force_include_into_wheel(
         )
         source_is_file = Path(resolved).expanduser().is_file()
         for src_file, target in iter_force_include(resolved, rest, base):
+            if redirect_mapping is not None and base == wheel_dirs[targetlib]:
+                assert exclude_spec is not None
+                assert redirect_libdir is not None
+                rel = target.relative_to(base)
+                # Directory members stay subject to wheel.exclude; with no
+                # baked copy the zip-time filter never sees them, so filter
+                # here. (A file force-include overrides the exclude.)
+                if not source_is_file and exclude_spec.match_file(rel):
+                    continue
+                if editable_redirectable(src_file, rel):
+                    live_target = str(redirect_libdir / rel)
+                    # The force-include wins at its destination: drop a package
+                    # mapping entry and staged/installed file at the same spot,
+                    # since the finder checks installed files before sources.
+                    for key in [
+                        k for k, v in redirect_mapping.items() if v == live_target
+                    ]:
+                        del redirect_mapping[key]
+                    target.unlink(missing_ok=True)
+                    (redirect_libdir / rel).unlink(missing_ok=True)
+                    redirect_mapping[str(src_file)] = live_target
+                    continue
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
             if source_is_file:
@@ -537,13 +575,17 @@ def _build_wheel_impl_impl(
                 Path(package_dir).parent.mkdir(exist_ok=True, parents=True)
                 shutil.copy2(filepath, package_dir)
 
-        # Force-include into the wheel, always (even for editable installs, as
-        # these files are not redirectable) and after the package copy, so they
-        # override package files and CMake output at the same destination.
+        # Force-include into the wheel, after the package copy so entries
+        # override package files and CMake output at the same destination. In a
+        # redirect-mode editable, platlib entries the redirect can serve live
+        # join the mapping instead of being baked in as stale copies.
+        redirecting = editable and settings.editable.mode == "redirect"
         force_included = _force_include_into_wheel(
             settings,
             wheel_dirs=wheel_dirs,
             targetlib=targetlib,
+            redirect_mapping=mapping if redirecting else None,
+            redirect_libdir=targetlib_dir if redirecting else None,
         )
 
         # Normalize script shebangs after force-includes, so force-included

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -583,6 +583,12 @@ class WheelSettings:
     that names an sdist output (vendored via :confval:`sdist.force-include`) build
     from both a source tree and an unpacked sdist.
 
+    In a redirect-mode editable install, platlib entries are served live from
+    their sources through the import redirect instead of being copied:
+    importable modules always, data files when they keep their filename and
+    land inside a package. Anything else (other wheel trees, renamed or
+    top-level data files) is still copied at install time.
+
     .. versionadded:: 1.0
     """
 

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -586,8 +586,8 @@ class WheelSettings:
     In a redirect-mode editable install, platlib entries are served live from
     their sources through the import redirect instead of being copied:
     importable modules always, data files when they keep their filename and
-    land inside a package. Anything else (other wheel trees, renamed or
-    top-level data files) is still copied at install time.
+    sit directly inside a top-level package. Anything else (other wheel trees;
+    renamed, top-level, or nested data files) is still copied at install time.
 
     .. versionadded:: 1.0
     """

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -553,6 +553,20 @@ def editable_shim(dist: Path) -> str:
     return wheel_read(dist, "_editable_skbc_pkg.py").decode()
 
 
+def shim_path(*parts: str) -> str:
+    """
+    A source path as it appears in the editable shim.
+
+    The shim embeds repr()'d absolute paths built from os.getcwd()
+    (Path.absolute()), so expected values must come from Path.cwd() -- not
+    tmp_path, which cygwin spells with 8.3 short names -- and be repr()'d to
+    match Windows backslash escaping.
+    """
+    from pathlib import Path
+
+    return repr(str(Path.cwd().joinpath(*parts)))
+
+
 def test_force_include_editable_redirects_data(chdir_tmp: Path) -> None:
     """A same-name platlib data force-include is redirected, not baked in."""
     make_pure_pkg(
@@ -567,7 +581,7 @@ def test_force_include_editable_redirects_data(chdir_tmp: Path) -> None:
 
     assert "pkg/data.txt" not in wheel_names(dist)
     # The source directory joins pkg's __path__ so importlib.resources finds it.
-    assert str((chdir_tmp / "extra").resolve()) in editable_shim(dist)
+    assert shim_path("extra") in editable_shim(dist)
 
 
 def test_force_include_editable_redirects_module(chdir_tmp: Path) -> None:
@@ -585,7 +599,7 @@ def test_force_include_editable_redirects_module(chdir_tmp: Path) -> None:
     assert "pkg/_version.py" not in wheel_names(dist)
     shim = editable_shim(dist)
     assert "'pkg._version'" in shim
-    assert str((chdir_tmp / "gen" / "_ver.py").resolve()) in shim
+    assert shim_path("gen", "_ver.py") in shim
 
 
 def test_force_include_editable_top_level_module_redirected(chdir_tmp: Path) -> None:
@@ -663,8 +677,8 @@ def test_force_include_editable_overrides_package_module(chdir_tmp: Path) -> Non
 
     assert "pkg/__init__.py" not in wheel_names(dist)
     shim = editable_shim(dist)
-    assert str((chdir_tmp / "override.py").resolve()) in shim
-    assert str((chdir_tmp / "pkg" / "__init__.py").resolve()) not in shim
+    assert shim_path("override.py") in shim
+    assert shim_path("pkg", "__init__.py") not in shim
 
 
 def test_force_include_editable_directory_redirects_members(chdir_tmp: Path) -> None:
@@ -685,10 +699,34 @@ def test_force_include_editable_directory_redirects_members(chdir_tmp: Path) -> 
     dist = chdir_tmp / "dist"
     build_editable(str(dist), {})
 
-    assert not any(n.startswith("pkg/assets/") for n in wheel_names(dist))
+    names = wheel_names(dist)
+    # The module redirects; the nested data file stays a copy (so package-root
+    # resource lookups keep the wheel layout); the exclude still trims.
+    assert "pkg/assets/mod.py" not in names
+    assert "pkg/assets/a.txt" in names
+    assert "pkg/assets/drop.tmp" not in names
     shim = editable_shim(dist)
     assert "'pkg.assets.mod'" in shim
-    assert str(assets.resolve()) in shim
+    assert shim_path("assets") in shim
+
+
+def test_force_include_editable_nested_data_copied(chdir_tmp: Path) -> None:
+    """A data file below a package subdirectory stays a baked copy.
+
+    The redirect would only register it under 'pkg.sub', breaking
+    files("pkg").joinpath("sub/data.txt") lookups that a real wheel supports.
+    """
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"extra/data.txt" = "pkg/sub/data.txt"}',
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert wheel_read(dist, "pkg/sub/data.txt") == b"hello"
 
 
 def test_force_include_editable_redirect_removes_stale_copy(chdir_tmp: Path) -> None:

--- a/tests/test_force_include.py
+++ b/tests/test_force_include.py
@@ -549,8 +549,12 @@ def test_force_include_sdist_file_overrides_exclude(chdir_tmp: Path) -> None:
     assert "pkg-0.1.0/vendored/blob.tmp" in names
 
 
-def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
-    """Wheel-target force-includes are baked into the editable wheel (not redirected)."""
+def editable_shim(dist: Path) -> str:
+    return wheel_read(dist, "_editable_skbc_pkg.py").decode()
+
+
+def test_force_include_editable_redirects_data(chdir_tmp: Path) -> None:
+    """A same-name platlib data force-include is redirected, not baked in."""
     make_pure_pkg(
         chdir_tmp,
         extra='wheel.force-include = {"extra/data.txt" = "pkg/data.txt"}',
@@ -561,7 +565,167 @@ def test_force_include_into_editable_wheel(chdir_tmp: Path) -> None:
     dist = chdir_tmp / "dist"
     build_editable(str(dist), {})
 
-    assert "pkg/data.txt" in wheel_names(dist)
+    assert "pkg/data.txt" not in wheel_names(dist)
+    # The source directory joins pkg's __path__ so importlib.resources finds it.
+    assert str((chdir_tmp / "extra").resolve()) in editable_shim(dist)
+
+
+def test_force_include_editable_redirects_module(chdir_tmp: Path) -> None:
+    """A platlib module force-include is served live by the redirect, even renamed."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"gen/_ver.py" = "pkg/_version.py"}',
+    )
+    (chdir_tmp / "gen").mkdir()
+    (chdir_tmp / "gen" / "_ver.py").write_text("v = 1\n")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "pkg/_version.py" not in wheel_names(dist)
+    shim = editable_shim(dist)
+    assert "'pkg._version'" in shim
+    assert str((chdir_tmp / "gen" / "_ver.py").resolve()) in shim
+
+
+def test_force_include_editable_top_level_module_redirected(chdir_tmp: Path) -> None:
+    """A top-level module destination is importable by name, so it redirects."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"gen/_ver.py" = "toplevel_ver.py"}',
+    )
+    (chdir_tmp / "gen").mkdir()
+    (chdir_tmp / "gen" / "_ver.py").write_text("v = 1\n")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "toplevel_ver.py" not in wheel_names(dist)
+    assert "'toplevel_ver'" in editable_shim(dist)
+
+
+def test_force_include_editable_renamed_data_copied(chdir_tmp: Path) -> None:
+    """A renamed data file cannot be found through __path__, so it stays a copy."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"extra/data.txt" = "pkg/data.json"}',
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert wheel_read(dist, "pkg/data.json") == b"hello"
+
+
+def test_force_include_editable_top_level_data_copied(chdir_tmp: Path) -> None:
+    """A top-level data file has no package __path__ to ride on; it is copied."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"extra/data.txt" = "data.txt"}',
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "data.txt" in wheel_names(dist)
+
+
+def test_force_include_editable_module_dest_from_data_source_copied(
+    chdir_tmp: Path,
+) -> None:
+    """An importable destination with a non-importable source stays a copy."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"notes.txt" = "pkg/notes_mod.py"}',
+    )
+    (chdir_tmp / "notes.txt").write_text("x = 1\n")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "pkg/notes_mod.py" in wheel_names(dist)
+
+
+def test_force_include_editable_overrides_package_module(chdir_tmp: Path) -> None:
+    """A force-include over a package file wins in the redirect mapping too."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra='wheel.force-include = {"override.py" = "pkg/__init__.py"}',
+    )
+    (chdir_tmp / "override.py").write_text("FORCED = True\n")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "pkg/__init__.py" not in wheel_names(dist)
+    shim = editable_shim(dist)
+    assert str((chdir_tmp / "override.py").resolve()) in shim
+    assert str((chdir_tmp / "pkg" / "__init__.py").resolve()) not in shim
+
+
+def test_force_include_editable_directory_redirects_members(chdir_tmp: Path) -> None:
+    """Directory members redirect individually and stay subject to wheel.exclude."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'wheel.exclude = ["pkg/assets/*.tmp"]\n'
+            'wheel.force-include = {"assets" = "pkg/assets"}'
+        ),
+    )
+    assets = chdir_tmp / "assets"
+    assets.mkdir()
+    (assets / "mod.py").write_text("m = 1\n")
+    (assets / "a.txt").write_text("a")
+    (assets / "drop.tmp").write_text("drop")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert not any(n.startswith("pkg/assets/") for n in wheel_names(dist))
+    shim = editable_shim(dist)
+    assert "'pkg.assets.mod'" in shim
+    assert str(assets.resolve()) in shim
+
+
+def test_force_include_editable_redirect_removes_stale_copy(chdir_tmp: Path) -> None:
+    """A redirected entry removes an earlier staged file at the same destination."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            "wheel.force-include = "
+            '{"weird.txt" = "pkg/data.txt", "data.txt" = "pkg/data.txt"}'
+        ),
+    )
+    # The first entry is a renamed data file (copied); the second redirects the
+    # same destination and must drop the stale copy from the wheel.
+    (chdir_tmp / "weird.txt").write_text("stale")
+    (chdir_tmp / "data.txt").write_text("live")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
+    assert "pkg/data.txt" not in wheel_names(dist)
+
+
+def test_force_include_editable_inplace_still_copied(chdir_tmp: Path) -> None:
+    """Inplace mode has no redirect, so force-includes stay baked copies."""
+    make_pure_pkg(
+        chdir_tmp,
+        extra=(
+            'editable.mode = "inplace"\n'
+            'wheel.force-include = {"extra/data.txt" = "pkg/data.txt"}'
+        ),
+    )
+    (chdir_tmp / "extra").mkdir()
+    (chdir_tmp / "extra" / "data.txt").write_text("hello")
+
+    dist = chdir_tmp / "dist"
+    build_editable(str(dist), {})
+
     assert wheel_read(dist, "pkg/data.txt") == b"hello"
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Previously, `wheel.force-include` entries were copied into a redirect-mode editable wheel, so edits to those files silently did nothing until reinstall. Now the import redirect serves them live from their sources where it can:

- **Importable modules** — always, including renamed destinations (the finder loads the source path as the destination module).
- **Data files** — when they keep their filename and land inside a package (the source directory joins the package `__path__`, so `importlib.resources` sees the live file).

A redirected entry displaces a package file or CMake output at the same destination (the finder checks installed files before sources, so the stale staged file is removed), and force-included directory members remain subject to `wheel.exclude`.

Everything the redirect cannot express keeps the previous copy behavior: other wheel trees (`${SKBUILD_SCRIPTS_DIR}` etc.), renamed or top-level data files, and all of inplace mode.

No compatibility gate: `force-include` is unreleased (new in 1.0).

Beyond the new tests, verified end-to-end by building an editable wheel with a force-included renamed module and data file, importing through the shim from an extracted site-packages, editing the sources, and observing the changes in a fresh process without reinstalling.