### PR TITLE
fix(requires): don't skip ninja when generator is forced to Ninja

### DIFF
--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -170,8 +170,11 @@ class GetRequires:
             logger.debug("Found system Ninja: {} - not requiring PyPI package", ninja)
             return
 
+        # Only fall back to Make if the generator wasn't explicitly set to
+        # Ninja - Make can't substitute for a forced Ninja generator (#953).
         if (
-            self.settings.ninja.make_fallback
+            use_ninja is None
+            and self.settings.ninja.make_fallback
             and not is_known_platform(known_wheels("ninja"))
             and list(get_make_programs())
         ):

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -240,3 +240,35 @@ def test_uses_ninja_generator(
         monkeypatch.setenv("CMAKE_ARGS", cmake_args)
     settings = ScikitBuildSettings(cmake=CMakeSettings(args=args))
     assert _uses_ninja_generator(settings) is expected
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        pytest.param(["-GNinja"], {"ninja>=1.5"}, id="forced-ninja"),
+        pytest.param([], set(), id="unset"),
+    ],
+)
+def test_ninja_make_fallback_respects_forced_generator(
+    args: list[str],
+    expected: set[str],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    The make fallback must not suppress the ninja requirement when the Ninja
+    generator is explicitly selected - make cannot substitute for it. See #953.
+    """
+    from scikit_build_core.builder import get_requires
+    from scikit_build_core.settings.skbuild_model import (
+        CMakeSettings,
+        ScikitBuildSettings,
+    )
+
+    monkeypatch.delenv("CMAKE_ARGS", raising=False)
+    # Force the make-fallback branch: unknown platform with make available.
+    monkeypatch.setattr(get_requires, "is_known_platform", lambda _: False)
+    monkeypatch.setattr(
+        get_requires, "get_make_programs", lambda: iter([Path("make/path")])
+    )
+    settings = ScikitBuildSettings(cmake=CMakeSettings(args=args))
+    assert set(GetRequires(settings).ninja()) == expected


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #953.

`GetRequires.ninja()` has a make-fallback path: on a platform without a known ninja wheel (e.g. Homebrew arm64 macOS, whose tags don't include `macosx_10_9_universal2`), if `ninja.make-fallback` is on and system `make` exists, scikit-build-core skips injecting ninja on the assumption make can substitute.

That path fired even when the user explicitly forced the Ninja generator (`-GNinja` in `cmake.args` or `CMAKE_GENERATOR`). Make can't substitute for a forced Ninja generator, so ninja was never injected into the isolated build env and configure failed with `NinjaNotFoundError` — which is why removing `ninja` from `build-system.requires` broke the reporter's build despite the "scikit-build-core will inject it as needed" warning.

The fallback is now gated on `use_ninja is None`, so it only applies when the generator wasn't explicitly set to Ninja.
