### PR TITLE
feat: add {name} placeholder for template-formatted settings

### DIFF
--- a/docs/configuration/formatted.md
+++ b/docs/configuration/formatted.md
@@ -21,6 +21,9 @@ visibility
 .. autoattribute:: scikit_build_core.format.PyprojectFormatter.cache_tag
    :no-index:
 
+.. autoattribute:: scikit_build_core.format.PyprojectFormatter.name
+   :no-index:
+
 .. autoattribute:: scikit_build_core.format.PyprojectFormatter.root
    :no-index:
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1020,7 +1020,9 @@ speedups.
 ```
 
 There are several values you can access through Python's formatting syntax. See
-[](./formatted.md).
+[](./formatted.md). For example, `{name}` lets a single `build-dir` shared by
+every member of a uv or hatch workspace (e.g. via `SKBUILD_BUILD_DIR`) avoid
+collisions: `SKBUILD_BUILD_DIR=/path/to/cache/{name}/{cache_tag}`.
 
 Scikit-build-core also strictly validates configuration; if you need to disable
 this, you can:

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -118,17 +118,21 @@ def get_build_dir(
     editable: bool,
     has_cmake: bool,
     fallback: Path,
+    name: str,
 ) -> Path:
     """
     Where CMake configures and builds: the source dir for inplace editable
     builds, the (formatted) configured ``build-dir``, or ``fallback`` otherwise.
+
+    ``name`` is the normalized project name, used to fill a ``{name}``
+    placeholder in ``build-dir``.
     """
     if has_cmake and editable and settings.editable.mode == "inplace":
         build_dir = Path(settings.cmake.source_dir)
     elif settings.build_dir:
         build_dir = Path(
             settings.build_dir.format(
-                **pyproject_format(settings=settings, tags=tags, state=state)
+                **pyproject_format(settings=settings, tags=tags, state=state, name=name)
             )
         )
     else:
@@ -144,6 +148,7 @@ def get_editable_rebuild_dir(
     targetlib: TargetLib,
     tags: WheelTag,
     state: WheelState,
+    name: str,
 ) -> Path:
     """
     Persistent install tree for a rebuildable redirect editable.
@@ -156,7 +161,7 @@ def get_editable_rebuild_dir(
     if settings.editable.rebuild_dir:
         return Path(
             settings.editable.rebuild_dir.format(
-                **pyproject_format(settings=settings, tags=tags, state=state)
+                **pyproject_format(settings=settings, tags=tags, state=state, name=name)
             )
         ).resolve()
     return (build_dir / "install" / targetlib).resolve()

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -296,6 +296,8 @@ def _build_wheel_impl_impl(
 
     # Get the closest (normally) importable name
     normalized_name = metadata.name.replace("-", "_").replace(".", "_")
+    # Normalized like the wheel/sdist filename, for the {name} build-dir placeholder
+    placeholder_name = metadata.canonical_name.replace("-", "_")
 
     if settings.wheel.cmake:
         cmake = CMake.default_search(version=settings.cmake.version, env=os.environ)
@@ -334,6 +336,7 @@ def _build_wheel_impl_impl(
             editable=editable,
             has_cmake=cmake is not None,
             fallback=build_tmp_folder / "build",
+            name=placeholder_name,
         )
         wheel_dirs = prepare_wheel_dirs(wheel_dir, targetlib=targetlib)
         install_dir = get_install_dir(
@@ -363,6 +366,7 @@ def _build_wheel_impl_impl(
                 targetlib=targetlib,
                 tags=tags,
                 state=state,
+                name=placeholder_name,
             )
             prepare_editable_rebuild_dir(
                 targetlib_dir, guard=bool(settings.editable.rebuild_dir)

--- a/src/scikit_build_core/format.py
+++ b/src/scikit_build_core/format.py
@@ -39,6 +39,8 @@ class PyprojectFormatter(TypedDict, total=False):
 
     cache_tag: str
     """Tag used by the import machinery in the filenames of cached modules, i.e. ``sys.implementation.cache_tag``."""
+    name: str
+    """The normalized project name (canonicalized per :pep:`503`, then ``-`` replaced by ``_``), matching the wheel/sdist filename. Handy to disambiguate a shared ``build-dir`` across a workspace, e.g. ``build-dir = "build/{name}/{wheel_tag}"``. Not available while resolving ``build.requires``, since metadata is not read yet at that point."""
     wheel_tag: str
     """The tags as computed for the wheel."""
     build_type: str
@@ -74,6 +76,7 @@ def pyproject_format(
     state: Literal["sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"]
     | None = ...,
     tags: WheelTag | None = ...,
+    name: str | None = ...,
 ) -> PyprojectFormatter: ...
 
 
@@ -89,6 +92,7 @@ def pyproject_format(
         | None
     ) = None,
     tags: WheelTag | None = None,
+    name: str | None = None,
     dummy: bool = False,
 ) -> PyprojectFormatter | dict[str, str]:
     """Generate :py:class:`PyprojectFormatter` dictionary to use in f-string format."""
@@ -118,6 +122,8 @@ def pyproject_format(
         res["wheel_tag"] = str(tags)
     if state is not None:
         res["state"] = state
+    if name is not None:
+        res["name"] = name
     # Construct the final dict including the always known keys
     return res
 

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -15,6 +15,7 @@ __lazy_modules__ = {
     "importlib",
     "importlib.metadata",
     "packaging",
+    "packaging.utils",
     "packaging.version",
     "pathlib",
     "shutil",
@@ -32,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from .._check_extra import warn_missing_extra
@@ -207,6 +209,10 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         targetlib = get_targetlib(settings)
         assert targetlib == "platlib"
         tags = get_wheel_tag(settings, targetlib=targetlib)
+        # Normalized like the wheel/sdist filename, for the {name} build-dir placeholder
+        placeholder_name = canonicalize_name(
+            self.build_config.builder.metadata.name
+        ).replace("-", "_")
         build_dir = get_build_dir(
             settings,
             tags=tags,
@@ -214,6 +220,7 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             editable=editable,
             has_cmake=True,
             fallback=self.__tmp_dir / "build",
+            name=placeholder_name,
         )
         wheel_dirs = prepare_wheel_dirs(wheel_dir, targetlib=targetlib)
         install_dir = get_install_dir(

--- a/tests/test_common_wheel_helpers.py
+++ b/tests/test_common_wheel_helpers.py
@@ -92,7 +92,9 @@ def test_absolute_install_dir_rejects_unknown_subdir(tmp_path: Path) -> None:
         _install_dir(tmp_path, settings)
 
 
-def _build_dir(tmp_path: Path, settings: ScikitBuildSettings) -> Path:
+def _build_dir(
+    tmp_path: Path, settings: ScikitBuildSettings, *, name: str = "pkg"
+) -> Path:
     tags = get_wheel_tag(settings, targetlib="platlib")
     return get_build_dir(
         settings,
@@ -101,6 +103,7 @@ def _build_dir(tmp_path: Path, settings: ScikitBuildSettings) -> Path:
         editable=False,
         has_cmake=True,
         fallback=tmp_path / "build",
+        name=name,
     )
 
 
@@ -113,6 +116,15 @@ def test_build_dir_explicit(tmp_path: Path) -> None:
     settings.build_dir = "custom-build"
 
     assert _build_dir(tmp_path, settings) == Path("custom-build")
+
+
+def test_build_dir_name_placeholder(tmp_path: Path) -> None:
+    # A shared build-dir setting (e.g. across a uv/hatch workspace) is
+    # disambiguated per-project with {name}.
+    settings = ScikitBuildSettings()
+    settings.build_dir = "build/{name}"
+
+    assert _build_dir(tmp_path, settings, name="my_pkg") == Path("build/my_pkg")
 
 
 def test_build_dir_inplace_editable_uses_source_dir(tmp_path: Path) -> None:
@@ -128,6 +140,7 @@ def test_build_dir_inplace_editable_uses_source_dir(tmp_path: Path) -> None:
         editable=True,
         has_cmake=True,
         fallback=tmp_path / "build",
+        name="pkg",
     )
 
     assert build_dir == tmp_path / "src"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scikit_build_core.format import RootPathResolver, pyproject_format
+from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -51,6 +52,20 @@ def test_dummy_plain_keys() -> None:
     # All known keys are present and produce "*" for a plain format.
     assert dummy["wheel_tag"] == "*"
     assert "{wheel_tag}".format(**dummy) == "*"
+    assert dummy["name"] == "*"
+    assert "{name}".format(**dummy) == "*"
+
+
+def test_name_key_omitted_by_default() -> None:
+    settings = ScikitBuildSettings()
+    assert "name" not in pyproject_format(settings=settings)
+
+
+def test_name_key_present_when_given() -> None:
+    settings = ScikitBuildSettings()
+    formatted = pyproject_format(settings=settings, name="my_pkg")
+    assert formatted["name"] == "my_pkg"
+    assert "build/{name}".format(**formatted) == "build/my_pkg"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

In uv/hatch workspaces, users could set one build directory for all workspace members via `SKBUILD_BUILD_DIR` or a workspace-root `[tool.uv] config-settings` entry — those apply to every member uv builds, so all members currently collide in one CMake build dir. This adds a `{name}` placeholder (the normalized project name) to `build-dir` / `editable.rebuild-dir` / `build.requires` templating, so a single shared setting is safe, e.g.:

```
SKBUILD_BUILD_DIR=/path/to/cache/{name}/{cache_tag}
```

`{name}` is normalized like the wheel/sdist filename (PEP 503 canonicalized, then `-` replaced by `_`: lowercase, `_`-separated), matching the convention already used in `build/sdist.py` and `build/_wheelfile.py`.

`{name}` is available anywhere `build-dir` and `editable.rebuild-dir` are resolved (both the PEP 517 wheel/sdist backend and the hatchling plugin), since project metadata is loaded before those steps. It is **not** available when resolving `build.requires` (`GetRequires.dynamic_metadata`), since that runs before metadata is read; using `{name}` there raises a `KeyError`.