### PR TITLE
docs: dedupe, simplify, and restructure the documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,5 @@
+/* Let the sidebar scroll past the last entry, so the bottom menu items can sit
+   higher than the viewport edge. */
+.sidebar-tree {
+  padding-bottom: 8rem;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,6 +182,7 @@ html_static_path = ["_static"]
 # it (and the box) from furo's theme variables. tippy.css must come last so its
 # overrides win. sphinx-tippy already loads tippy.js itself from this CDN.
 html_css_files = [
+    "custom.css",
     "https://unpkg.com/tippy.js@6/themes/light-border.css",
     "tippy.css",
 ]

--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -1,0 +1,14 @@
+# Advanced
+
+Special-purpose configuration topics: string substitution in settings, how CMake
+search paths are injected from installed packages, backend entry-point
+configuration, and the experimental wheel-variant support.
+
+```{toctree}
+:maxdepth: 1
+
+formatted
+search_paths
+entrypoint_config
+variants
+```

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -5,11 +5,8 @@ Scikit-build-core supports dynamic metadata with four built-in plugins.
 :::{note}
 
 Beyond the built-in plugins, your package and third parties can provide their
-own. These are fully supported through the standard `[[tool.dynamic-metadata]]`
-interface described below. The legacy `tool.scikit-build.metadata` table was
-provisional: there, plugins not shipped with scikit-build-core require
-`tool.scikit-build.experimental=true`, since that interface was not stable (now
-replaced by the new one). We are providing backward compatibility for now.
+own; they are fully supported through the standard `[[tool.dynamic-metadata]]`
+interface described below.
 
 :::
 
@@ -55,16 +52,18 @@ it; the single-value fields (`version`, `description`, `requires-python`,
 :::{warning}
 
 The older `[tool.scikit-build.metadata.<field>]` table (a field-keyed mapping
-rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]`. It
-still works and is shown in the examples below, but the two forms **cannot be
-combined** in one project; use one or the other.
+rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]`, and
+since 1.0 it emits a deprecation warning unless `minimum-version` is set below
+`1.0`. It still works, but the two forms **cannot be combined** in one project,
+and plugins not shipped with scikit-build-core additionally require
+`tool.scikit-build.experimental = true` in the legacy form. Every example below
+translates the same way; the example above would be spelled:
 
-:::
-
-:::{versionchanged} 1.0
-
-The legacy `tool.scikit-build.metadata` table now emits a deprecation warning
-unless `minimum-version` is set below `1.0`.
+```toml
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "src/mypackage/__init__.py"
+```
 
 :::
 
@@ -72,20 +71,15 @@ unless `minimum-version` is set below `1.0`.
 
 We provide some built-in plugins in `scikit_build_core.metadata`. These work in
 either mode with the same `provider` string (e.g.
-`scikit_build_core.metadata.regex`). In the modern `[[tool.dynamic-metadata]]`
-mode, a `field =` key is normally required, but it can be omitted for
-fixed-target plugins that declare a default: `setuptools_scm` defaults to
-`field = "version"` and `fancy_pypi_readme` defaults to `field = "readme"`.
-
-Third party plugins (like those inside the `dynamic-metadata` package) and
-custom plugins are fully supported in the new mode.
+`scikit_build_core.metadata.regex`). A `field =` key is normally required, but
+it can be omitted for fixed-target plugins that declare a default:
+`setuptools_scm` defaults to `field = "version"` and `fancy_pypi_readme`
+defaults to `field = "readme"`.
 
 ### `version`: Setuptools-scm
 
 You can use [setuptools-scm](https://github.com/pypa/setuptools-scm) to pull the
 version from VCS:
-
-````{tab} `[[tool.dynamic-metadata]]`
 
 ```toml
 [project]
@@ -103,30 +97,13 @@ field = "version"
 write_to = "src/package/_version.py"
 ```
 
-`````
-
-````{tab} `tool.scikit-build.metadata`
-
-```toml
-[project]
-name = "mypackage"
-dynamic = ["version"]
-
-[tool.scikit-build]
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/package/_version.py"]
-
-[tool.setuptools_scm]  # Section required
-write_to = "src/package/_version.py"
-```
-
-`````
-
 This sets the python project version according to
 [git tags](https://github.com/pypa/setuptools-scm/blob/fb261332d9b46aa5a258042d85baa5aa7b9f4fa2/README.rst#default-versioning-scheme)
 or a
 [`.git_archival.txt`](https://github.com/pypa/setuptools-scm/blob/fb261332d9b46aa5a258042d85baa5aa7b9f4fa2/README.rst#git-archives)
 file, or equivalents for other VCS systems.
+
+:::{tip}
 
 If you need to set the CMake project version without scikit-build-core (which
 provides `${SKBUILD_PROJECT_VERSION}`), you can use something like
@@ -144,40 +121,13 @@ dynamic_version()
 project(MyPackage VERSION ${PROJECT_VERSION})
 ```
 
+:::
+
 ### Regex
 
 If you want to pull a string-valued expression (usually version) from an
-existing file, you can use the integrated `regex` plugin to pull the
-information.
-
-````{tab} `[[tool.dynamic-metadata]]`
-
-```toml
-[project]
-name = "mypackage"
-dynamic = ["version"]
-
-[[tool.dynamic-metadata]]
-provider = "scikit_build_core.metadata.regex"
-field = "version"
-input = "src/mypackage/__init__.py"
-```
-
-`````
-
-````{tab} `tool.scikit-build.metadata`
-
-```toml
-[project]
-name = "mypackage"
-dynamic = ["version"]
-
-[tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.regex"
-input = "src/mypackage/__init__.py"
-```
-
-`````
+existing file, you can use the integrated `regex` plugin, as shown in the first
+example on this page.
 
 You can set a custom regex with `regex=`. By default when targeting version, you
 get a reasonable regex for python files,
@@ -186,8 +136,6 @@ can set `result` to a format string to process the matches; the default is
 `"{value}"`. You can also specify a regex for `remove=` which will strip any
 matches from the final result. A more complex example:
 
-````{tab} `[[tool.dynamic-metadata]]`
-
 ```toml
 [[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.regex"
@@ -202,26 +150,6 @@ regex = '''(?sx)
 result = "{major}.{minor}.{patch}dev{dev}"
 remove = "dev0"
 ```
-
-`````
-
-````{tab} `tool.scikit-build.metadata`
-
-```toml
-[tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.regex"
-input = "src/mypackage/version.hpp"
-regex = '''(?sx)
-\#define \s+ VERSION_MAJOR \s+ (?P<major>\d+) .*?
-\#define \s+ VERSION_MINOR \s+ (?P<minor>\d+) .*?
-\#define \s+ VERSION_PATCH \s+ (?P<patch>\d+) .*?
-\#define \s+ VERSION_DEV   \s+ (?P<dev>\d+)   .*?
-'''
-result = "{major}.{minor}.{patch}dev{dev}"
-remove = "dev0"
-```
-
-`````
 
 This will remove the "dev" tag when it is equal to 0.
 
@@ -237,8 +165,6 @@ You can use
 [hatch-fancy-pypi-readme](https://github.com/hynek/hatch-fancy-pypi-readme) to
 render your README:
 
-````{tab} `[[tool.dynamic-metadata]]`
-
 ```toml
 [project]
 name = "mypackage"
@@ -250,23 +176,6 @@ field = "readme"
 
 # tool.hatch.metadata.hooks.fancy-pypi-readme options here
 ```
-
-`````
-
-````{tab} `tool.scikit-build.metadata`
-
-```toml
-[project]
-name = "mypackage"
-dynamic = ["readme"]
-
-[tool.scikit-build]
-metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
-
-# tool.hatch.metadata.hooks.fancy-pypi-readme options here
-```
-
-`````
 
 In order to use the version number in readme feature, this must be listed after
 the version in the `[[tool.dynamic-metadata]]` mode.
@@ -280,26 +189,12 @@ The version number feature now works.
 
 You can access other metadata fields and produce templated outputs.
 
-````{tab} `[[tool.dynamic-metadata]]`
-
 ```toml
 [[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.template"
 field = "optional-dependencies"
 result = {"dev" = ["{project[name]}=={project[version]}"]}
 ```
-
-`````
-
-````{tab} `tool.scikit-build.metadata`
-
-```toml
-[tool.scikit-build.metadata.optional-dependencies]
-provider = "scikit_build_core.metadata.template"
-result = {"dev" = ["{project[name]}=={project[version]}"]}
-```
-
-`````
 
 You can use `project` to access the current metadata values. You can use
 `result` to specify the output. The result must match the type of the metadata
@@ -360,9 +255,8 @@ If you need to inject and manipulate additional `build-system.requires`, you can
 use the `build.requires`. This is intended to be used in combination with
 [](./overrides.md).
 
-This is not technically a dynamic metadata and thus does not have to have the
-`dynamic` field defined, and it is not defined under the `metadata` table, but
-similar to the other dynamic metadata it injects the additional
+This is not project metadata — nothing is listed in `[project]` `dynamic` — but
+like the plugins above it resolves at build time, injecting the additional
 `build-system.requires`.
 
 ```toml

--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -14,7 +14,7 @@ interface described below.
 
 ```{versionadded} 1.0
 Support for the standard
-[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.3 specification.
+[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.4 specification.
 ```
 
 The standard, cross-backend way to configure plugins is the top-level
@@ -56,8 +56,9 @@ rather than an ordered array) is superseded by `[[tool.dynamic-metadata]]`, and
 since 1.0 it emits a deprecation warning unless `minimum-version` is set below
 `1.0`. It still works, but the two forms **cannot be combined** in one project,
 and plugins not shipped with scikit-build-core additionally require
-`tool.scikit-build.experimental = true` in the legacy form. Every example below
-translates the same way; the example above would be spelled:
+`tool.scikit-build.experimental = true` in the legacy form. The plugin examples
+below show both spellings as Modern/Classic tabs; the example above would be
+spelled:
 
 ```toml
 [tool.scikit-build.metadata.version]
@@ -81,6 +82,8 @@ defaults to `field = "readme"`.
 You can use [setuptools-scm](https://github.com/pypa/setuptools-scm) to pull the
 version from VCS:
 
+````{tab} Modern
+
 ```toml
 [project]
 name = "mypackage"
@@ -96,6 +99,25 @@ field = "version"
 [tool.setuptools_scm]  # Section required
 write_to = "src/package/_version.py"
 ```
+
+````
+
+````{tab} Classic
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["version"]
+
+[tool.scikit-build]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["src/package/_version.py"]
+
+[tool.setuptools_scm]  # Section required
+write_to = "src/package/_version.py"
+```
+
+````
 
 This sets the python project version according to
 [git tags](https://github.com/pypa/setuptools-scm/blob/fb261332d9b46aa5a258042d85baa5aa7b9f4fa2/README.rst#default-versioning-scheme)
@@ -136,6 +158,8 @@ can set `result` to a format string to process the matches; the default is
 `"{value}"`. You can also specify a regex for `remove=` which will strip any
 matches from the final result. A more complex example:
 
+````{tab} Modern
+
 ```toml
 [[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.regex"
@@ -151,6 +175,26 @@ result = "{major}.{minor}.{patch}dev{dev}"
 remove = "dev0"
 ```
 
+````
+
+````{tab} Classic
+
+```toml
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "src/mypackage/version.hpp"
+regex = '''(?sx)
+\#define \s+ VERSION_MAJOR \s+ (?P<major>\d+) .*?
+\#define \s+ VERSION_MINOR \s+ (?P<minor>\d+) .*?
+\#define \s+ VERSION_PATCH \s+ (?P<patch>\d+) .*?
+\#define \s+ VERSION_DEV   \s+ (?P<dev>\d+)   .*?
+'''
+result = "{major}.{minor}.{patch}dev{dev}"
+remove = "dev0"
+```
+
+````
+
 This will remove the "dev" tag when it is equal to 0.
 
 ```{versionchanged} 0.10
@@ -165,6 +209,8 @@ You can use
 [hatch-fancy-pypi-readme](https://github.com/hynek/hatch-fancy-pypi-readme) to
 render your README:
 
+````{tab} Modern
+
 ```toml
 [project]
 name = "mypackage"
@@ -176,6 +222,23 @@ field = "readme"
 
 # tool.hatch.metadata.hooks.fancy-pypi-readme options here
 ```
+
+````
+
+````{tab} Classic
+
+```toml
+[project]
+name = "mypackage"
+dynamic = ["readme"]
+
+[tool.scikit-build]
+metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
+
+# tool.hatch.metadata.hooks.fancy-pypi-readme options here
+```
+
+````
 
 In order to use the version number in readme feature, this must be listed after
 the version in the `[[tool.dynamic-metadata]]` mode.
@@ -189,12 +252,26 @@ The version number feature now works.
 
 You can access other metadata fields and produce templated outputs.
 
+````{tab} Modern
+
 ```toml
 [[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.template"
 field = "optional-dependencies"
 result = {"dev" = ["{project[name]}=={project[version]}"]}
 ```
+
+````
+
+````{tab} Classic
+
+```toml
+[tool.scikit-build.metadata.optional-dependencies]
+provider = "scikit_build_core.metadata.template"
+result = {"dev" = ["{project[name]}=={project[version]}"]}
+```
+
+````
 
 You can use `project` to access the current metadata values. You can use
 `result` to specify the output. The result must match the type of the metadata
@@ -214,7 +291,7 @@ static in `[project]`).
 
 ```{versionadded} 1.0
 Writing a custom dynamic-metadata plugin through the standard
-[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.3 interface.
+[dynamic-metadata](https://dynamic-metadata.readthedocs.io) 0.4 interface.
 ```
 
 You can write your own plugins. Full details are in the

--- a/docs/configuration/editable.md
+++ b/docs/configuration/editable.md
@@ -1,0 +1,143 @@
+# Editable installs
+
+Support for editable installs is provided, with some caveats and configuration.
+Recommendations:
+
+- Use `--no-build-isolation` when doing an editable install is recommended; you
+  should preinstall your dependencies.
+- Automatic rebuilds do not have the original isolated build dir (pip deletes
+  it), so select a `build-dir` when using editable installs, especially if you
+  also enable automatic rebuilds.
+- You need to reinstall to pick up new files.
+
+Resources (via `importlib.resources`) are supported and tested on all supported
+Python versions. On Python 3.8, use the `importlib_resources` backport, since
+`importlib.resources.files` was added to the standard library in Python 3.9.
+
+```console
+# Very experimental rebuild on initial import feature
+$ pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=build -ve.
+```
+
+The automatic rebuild-on-import feature (`editable.rebuild`) is still
+experimental and subject to change.
+
+You can disable the verbose rebuild output with `editable.verbose=false` if you
+want. (Also available as the `SKBUILD_EDITABLE_VERBOSE` envvar when importing;
+this will override if non-empty, and `"0"` will disable verbose output).
+
+When `editable.rebuild` is enabled together with a persistent `build-dir`, the
+CMake install targets a tree inside the build directory and the redirecting
+finder loads the compiled artifacts from there directly, rather than from copies
+in site-packages. This means `SKBUILD_PLATLIB_DIR` (or `SKBUILD_PURELIB_DIR`)
+and `CMAKE_INSTALL_PREFIX` are baked at their final location when the editable
+wheel is first built, so import-triggered rebuilds re-install in place with no
+extra reconfigure -- including projects that install to an absolute
+`${SKBUILD_PLATLIB_DIR}/...` destination. Deleting the build directory breaks
+the install, but a rebuildable editable already depends on it.
+
+As a newer, parallel alternative, `editable.rebuild-dir` selects the install
+tree directly and turns on rebuild-on-import by itself (the `editable.rebuild`
+flag is ignored when it is set). It accepts the same template substitutions as
+`build-dir`, and the path must be absolute, or relative to the source directory,
+and stable between build and run time, since it is baked at configure time and
+referenced by absolute path on rebuild. This only moves the install tree;
+`build-dir` is still required and still hosts the CMake build that the rebuild
+re-runs.
+
+:::{versionadded} 1.0
+
+`editable.rebuild-dir`, a persistent install tree for editable rebuilds.
+
+:::
+
+The default `editable.mode`, `"redirect"`, uses a custom redirecting finder to
+combine the static CMake install dir with the original source code. Python code
+added via scikit-build-core's package discovery will be found in the original
+location, so changes there are picked up on import, regardless of the
+`editable.rebuild` setting.
+
+:::{versionchanged} 1.0
+
+[PEP 829][] `.start` files are emitted for the redirecting finder on Python
+3.15+. Older interpreters emit only `.pth` files.
+
+:::
+
+[PEP 829]: https://peps.python.org/pep-0829/
+
+## Inplace mode
+
+A second mode, `"inplace"`, is also available. Scikit-build-core will simply
+install a `.pth` file that points at your source package(s) and do an inplace
+CMake build. With all the caveats below, this is very logically simple (one
+directory) and a near identical replacement for
+`python setup.py build_ext --inplace`; some third party tooling might work
+better with this mode.
+
+On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
+Inplace installs support both automatic (`editable.rebuild`) and manual rebuilds
+(see below); since the source directory doubles as the build directory, no
+separate `build-dir` is needed (the `build-dir` setting is ignored).
+
+All the usual in-place build caveats apply -- only one build per source
+directory, you can't change to an out-of-source build without removing the build
+artifacts, and your source directory will be littered with build artifacts.
+Also, to make your binaries importable, you should set
+`LIBRARY_OUTPUT_DIRECTORY` to place them inside your source directory inside the
+Python packages (append the empty generator expression `$<0:>` for multi-config
+generator support; see [the MSVC FAQ](#msvc-multi-config)); they will be run
+from the build directory, rather than installed. You can detect this mode by
+checking for an in-place build and checking `SKBUILD` being set.
+
+(triggering-a-rebuild-manually)=
+
+## Triggering a rebuild manually
+
+You don't have to enable `editable.rebuild` to rebuild on demand. Both editable
+modes install a loader that exposes a `rebuild()` method, so you can recompile
+whenever you like:
+
+```python
+import some_package
+
+some_package.__loader__.rebuild()
+```
+
+For redirect installs this runs the same `cmake --build`/`--install` cycle used
+by the automatic rebuild, and works for any importable object the install
+provides -- a package, a plain module, or a compiled extension. A redirect
+rebuild needs a persistent build directory, so install with a `build-dir` set:
+
+```console
+$ pip install --no-build-isolation -Cbuild-dir=build -ve .
+```
+
+If a redirect editable was built without a persistent `build-dir`, there is
+nothing to rebuild and the call raises `RuntimeError`.
+
+For inplace installs, `rebuild()` runs `cmake --build` in the source tree (there
+is no install step); the source directory is always the build directory, so no
+`build-dir` is required.
+
+If you don't have a handle on a redirected module, the finder itself is on
+`sys.meta_path` and carries the same method (`ScikitBuildRedirectingFinder` for
+redirect installs, `ScikitBuildInplaceFinder` for inplace):
+
+```python
+import sys
+
+finder = next(
+    f
+    for f in sys.meta_path
+    if type(f).__name__ in {"ScikitBuildRedirectingFinder", "ScikitBuildInplaceFinder"}
+)
+finder.rebuild()
+```
+
+:::{versionadded} 1.0
+
+Manual `__loader__.rebuild()` for redirect installs, and both manual and
+automatic (`editable.rebuild`) rebuilds for inplace installs.
+
+:::

--- a/docs/configuration/entrypoint_config.md
+++ b/docs/configuration/entrypoint_config.md
@@ -1,8 +1,16 @@
 # Entry-point configuration
 
-> [!CAUTION] This is an advanced feature primarily for Linux distributions and
-> other packagers that need to set build defaults, like the CMake build type or
-> symbol stripping.
+:::{versionadded} 1.0
+
+:::
+
+:::{caution}
+
+This is an advanced feature primarily for Linux distributions and other
+packagers that need to set build defaults, like the CMake build type or symbol
+stripping.
+
+:::
 
 An installed package can contribute scikit-build-core configuration to _every_
 build in the environment through two entry-point groups. This can affect all

--- a/docs/configuration/formatted.md
+++ b/docs/configuration/formatted.md
@@ -10,9 +10,15 @@ The following configure keys are formatted as Python `str.format` templates:
 `editable.rebuild-dir` is formattable.
 ```
 
-The available variables are documented in the members of
-{py:class}`scikit_build_core.format.PyprojectFormatter` copied here for
-visibility
+For example, to get a persistent build directory per wheel tag:
+
+```toml
+[tool.scikit-build]
+build-dir = "build/{wheel_tag}"
+```
+
+The available variables are the members of
+{py:class}`scikit_build_core.format.PyprojectFormatter`:
 
 ```{eval-rst}
 .. autoattribute:: scikit_build_core.format.PyprojectFormatter.build_type

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -170,9 +170,8 @@ will fall back on ">=3.15" if it can't read it.
 
 You can also enforce ninja to be required even if make is present on Unix:
 
-```toml
-[tool.scikit-build]
-ninja.make-fallback = false
+```{conftabs} ninja.make-fallback False
+
 ```
 
 You can also control the FindPython backport; by default, a backport of CMake
@@ -225,9 +224,8 @@ sdist.reproducible = false
 
 You can also request CMake to run during this step:
 
-```toml
-[tool.scikit-build]
-sdist.cmake = true
+```{conftabs} sdist.cmake True
+
 ```
 
 :::{note}
@@ -330,9 +328,8 @@ The install directory is normally site-packages; however, you can manually set
 that to a different directory if you'd like to avoid changing your CMake files.
 For example, to mimic scikit-build classic:
 
-```toml
-[tool.scikit-build]
-wheel.install-dir = "mypackage"
+```{conftabs} wheel.install-dir "mypackage"
+
 ```
 
 You can target a different wheel tree by prefixing the install dir with the
@@ -400,121 +397,36 @@ assume `wheel.platlib = false` (purelib targeted instead).
 
 :::
 
-### Force-including files
-
-:::{versionadded} 1.0
-
-:::
-
-Sometimes you need to place a specific file (or directory) at a specific path in
-a distribution, even if it lives outside your package tree or is produced
-elsewhere. Each distribution has its own `force-include` table mapping source
-paths to destinations:
-
-```toml
-[tool.scikit-build.sdist.force-include]
-"../shared/data.json" = "mypackage/data.json"
-
-[tool.scikit-build.wheel.force-include]
-"vendor/lib.so" = "mypackage/_lib.so"
-"tools/run.sh"  = "${SKBUILD_SCRIPTS_DIR}/run.sh"
-```
-
-The keys are source paths relative to the project root; they may point outside
-it (e.g. `../shared`) or be absolute, and `~` is expanded. A source may be a
-file or a directory, and directories are copied recursively (skipping VCS and
-`__pycache__` junk). A missing source is an error.
-
-`sdist.force-include` destinations are relative to the SDist root.
-`wheel.force-include` destinations are relative to the platlib (the package
-area), and also accept a `${SKBUILD_<TREE>_DIR}` prefix (e.g.
-`${SKBUILD_DATA_DIR}`, `${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_HEADERS_DIR}`,
-`${SKBUILD_METADATA_DIR}`) to target that wheel tree instead, matching the
-`SKBUILD_*_DIR` CMake cache variables. The older leading-slash spelling
-(`/data`, `/scripts`, ...) does the same but requires `experimental = true`.
-Force-included wheel files are placed last, so they override discovered package
-files and CMake output at the same destination.
-
-A force-included _file_ also overrides the matching exclude list
-(`wheel.exclude` for wheels, `sdist.exclude` for SDists): naming an exact source
-is an explicit request, so it wins even if an exclude pattern matches its
-destination. A force-included _directory_ stays subject to that exclude, so a
-bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
-directory and exclude `**/*.bzl` to drop the Bazel files from it).
-
-In an editable install using redirect mode (the default), platlib entries are
-served live from their sources through the import redirect instead of being
-copied, so edits to a force-included file take effect without reinstalling. This
-covers importable modules (even renamed ones) and data files that keep their
-filename and sit directly inside a top-level package. Anything the redirect
-cannot express — other wheel trees like `${SKBUILD_SCRIPTS_DIR}`, renamed or
-top-level data files, and data files nested below a package subdirectory (kept
-as real files so package-root resource lookups keep the wheel layout) — is still
-copied at install time, so those snapshots only refresh on reinstall.
-
-#### Building a wheel from an SDist
-
-A common pattern vendors an external (`../`) source into the SDist and then
-ships that output in the wheel. Reference the SDist destination as the wheel
-source and it works in both build modes:
-
-```toml
-[tool.scikit-build.sdist.force-include]
-"../shared/data.json" = "mypackage/data.json"   # vendor it into the SDist
-
-[tool.scikit-build.wheel.force-include]
-"mypackage/data.json" = "mypackage/data.json"    # ship the SDist output
-```
-
-When the wheel is built from the unpacked SDist, `mypackage/data.json` exists
-and is used directly. When it is built from the source tree (or an editable
-install) the file was never materialized; a `wheel.force-include` source missing
-on disk is then resolved through `sdist.force-include` (by exact destination, or
-under a force-included directory) and read from that original source instead. An
-on-disk file always wins, so the vendored copy is preferred when present.
-
-For cases the automatic resolution cannot express — e.g. the wheel source is the
-_original_ external path rather than the SDist output — use
-[overrides](#overrides) keyed on `from-sdist`, with a separate
-`wheel.force-include` entry gated on each build mode (source tree vs.
-wheel-from-SDist):
-
-```toml
-[tool.scikit-build.sdist.force-include]
-"../outside.txt" = "vendored/blob.txt"   # vendor it into the SDist
-
-[[tool.scikit-build.overrides]]
-if.from-sdist = false                     # source-tree build: read the original
-wheel.force-include."../outside.txt" = "mypackage/blob.txt"
-
-[[tool.scikit-build.overrides]]
-if.from-sdist = true                      # wheel-from-SDist: read the vendored copy
-wheel.force-include."vendored/blob.txt" = "mypackage/blob.txt"
-```
-
 ## Customizing the output wheel
 
 The python API tags for your wheel will be correct assuming you are building a
-CPython extension. If you are building a Limited ABI extension, you should set
-the wheel tags for the version you support:
+normal CPython extension. For anything else, set `wheel.py-api` to the tag you
+support:
 
-```toml
-[tool.scikit-build]
-wheel.py-api = "cp38"
+```{conftabs} wheel.py-api "cp38"
+
 ```
+
+| `wheel.py-api`   | Use for                                           | Resulting tags     |
+| ---------------- | ------------------------------------------------- | ------------------ |
+| `"cp38"`         | Limited API / Stable ABI extension (CPython 3.8+) | `cp38-abi3`        |
+| `"py3"`          | Extension not using the Python API                | `py3-none`         |
+| `"py2.py3"`      | Same, but installable on Python 2 as well         | `py2.py3-none`     |
+| `"cp315t"`       | Free-threaded stable ABI ([PEP 803][])            | `cp315-abi3t`      |
+| `"cp315.cp315t"` | Both stable ABIs from one free-threaded build     | `cp315-abi3.abi3t` |
 
 Scikit-build-core will only target ABI3 if the version of Python is equal to or
 newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
 `Development.SABIModule` when targeting ABI3 or ABI3T, and is an empty string
-otherwise. For free-threaded Python (PEP 703), you can use `cp315t` to target
-the free-threaded stable ABI, which sets `Py_TARGET_ABI3T` (if using CMake
-4.4+). The emitted wheel tag is `cp315-abi3t-*` following [PEP 803][].
+otherwise. `cp315t` also sets `Py_TARGET_ABI3T` (if using CMake 4.4+). For
+`py3`/`py2.py3`, you still need a version of Python scikit-build-core supports
+to build the initial wheel.
 
-You can request both stable ABIs with `cp315.cp315t`. On a free-threaded build
-this emits a combined `cp315-abi3.abi3t-*` tag: `abi3t` is a subset of `abi3`
-(PEP 803), so the single free-threaded binary also loads under a GIL-enabled
-CPython 3.15+, and the one wheel is installable on every CPython 3.15+. On a GIL
-build only `abi3` can be produced, so it falls back to `cp315-abi3-*`.
+With `cp315.cp315t`, a free-threaded build emits the combined `cp315-abi3.abi3t`
+tag: `abi3t` is a subset of `abi3` (PEP 803), so the single free-threaded binary
+also loads under a GIL-enabled CPython 3.15+, and the one wheel is installable
+on every CPython 3.15+. On a GIL build only `abi3` can be produced, so it falls
+back to `cp315-abi3`.
 
 :::{versionadded} 1.0
 
@@ -523,29 +435,12 @@ The free-threaded stable ABI (`cp315t`, [PEP 803][]) and the combined
 
 :::
 
-If you are not using CPython at all, you can specify any version of Python is
-fine:
-
-```toml
-[tool.scikit-build]
-wheel.py-api = "py3"
-```
-
-Or even Python 2 + 3 (you still will need a version of Python scikit-build-core
-supports to build the initial wheel):
-
-```toml
-[tool.scikit-build]
-wheel.py-api = "py2.py3"
-```
-
 Some older versions of pip are unable to load standard universal tags;
 scikit-build-core can expand the macOS universal tags for you for maximum
 historic compatibility if you'd like:
 
-```toml
-[tool.scikit-build]
-wheel.expand-macos-universal-tags = true
+```{conftabs} wheel.expand-macos-universal-tags True
+
 ```
 
 You can also specify a build tag:
@@ -580,6 +475,95 @@ recent compiler and flags like `-ffile-prefix-map`.
 :::{versionadded} 1.0
 
 :::
+
+## Force-including files
+
+:::{versionadded} 1.0
+
+:::
+
+Sometimes you need to place a specific file (or directory) at a specific path in
+a distribution, even if it lives outside your package tree or is produced
+elsewhere. Each distribution has its own `force-include` table mapping source
+paths to destinations:
+
+```toml
+[tool.scikit-build.sdist.force-include]
+"../shared/data.json" = "mypackage/data.json"
+
+[tool.scikit-build.wheel.force-include]
+"vendor/lib.so" = "mypackage/_lib.so"
+"tools/run.sh"  = "${SKBUILD_SCRIPTS_DIR}/run.sh"
+```
+
+The keys are source paths relative to the project root; they may point outside
+it (e.g. `../shared`) or be absolute, and `~` is expanded. A source may be a
+file or a directory, and directories are copied recursively (skipping VCS and
+`__pycache__` junk). A missing source is an error.
+
+`sdist.force-include` destinations are relative to the SDist root.
+`wheel.force-include` destinations are relative to the platlib (the package
+area), and also accept a `${SKBUILD_<TREE>_DIR}` prefix to target a different
+wheel tree, exactly as with [`wheel.install-dir`](#customizing-the-built-wheel)
+above. Force-included wheel files are placed last, so they override discovered
+package files and CMake output at the same destination.
+
+A force-included _file_ also overrides the matching exclude list
+(`wheel.exclude` for wheels, `sdist.exclude` for SDists): naming an exact source
+is an explicit request, so it wins even if an exclude pattern matches its
+destination. A force-included _directory_ stays subject to that exclude, so a
+bulk tree copy can still be trimmed by an exclude pattern (e.g. force-include a
+directory and exclude `**/*.bzl` to drop the Bazel files from it).
+
+In an editable install using redirect mode (the default), platlib entries are
+served live from their sources through the import redirect instead of being
+copied, so edits to a force-included file take effect without reinstalling. This
+covers importable modules (even renamed ones) and data files that keep their
+filename and sit directly inside a top-level package. Anything the redirect
+cannot express — other wheel trees like `${SKBUILD_SCRIPTS_DIR}`, renamed or
+top-level data files, and data files nested below a package subdirectory (kept
+as real files so package-root resource lookups keep the wheel layout) — is still
+copied at install time, so those snapshots only refresh on reinstall.
+
+### Building a wheel from an SDist
+
+A common pattern vendors an external (`../`) source into the SDist and then
+ships that output in the wheel. Reference the SDist destination as the wheel
+source and it works in both build modes:
+
+```toml
+[tool.scikit-build.sdist.force-include]
+"../shared/data.json" = "mypackage/data.json"   # vendor it into the SDist
+
+[tool.scikit-build.wheel.force-include]
+"mypackage/data.json" = "mypackage/data.json"    # ship the SDist output
+```
+
+When the wheel is built from the unpacked SDist, `mypackage/data.json` exists
+and is used directly. When it is built from the source tree (or an editable
+install) the file was never materialized; a `wheel.force-include` source missing
+on disk is then resolved through `sdist.force-include` (by exact destination, or
+under a force-included directory) and read from that original source instead. An
+on-disk file always wins, so the vendored copy is preferred when present.
+
+For cases the automatic resolution cannot express — e.g. the wheel source is the
+_original_ external path rather than the SDist output — use
+[overrides](./overrides.md) keyed on `from-sdist`, with a separate
+`wheel.force-include` entry gated on each build mode (source tree vs.
+wheel-from-SDist):
+
+```toml
+[tool.scikit-build.sdist.force-include]
+"../outside.txt" = "vendored/blob.txt"   # vendor it into the SDist
+
+[[tool.scikit-build.overrides]]
+if.from-sdist = false                     # source-tree build: read the original
+wheel.force-include."../outside.txt" = "mypackage/blob.txt"
+
+[[tool.scikit-build.overrides]]
+if.from-sdist = true                      # wheel-from-SDist: read the vendored copy
+wheel.force-include."vendored/blob.txt" = "mypackage/blob.txt"
+```
 
 ## Configuring CMake arguments and defines
 
@@ -623,7 +607,9 @@ Passing a list of build types.
 
 :::
 
-You can specify CMake defines as strings or bools:
+You can specify CMake defines as strings, bools, or lists of strings (list
+elements are joined with `;`, with semicolons inside an element escaped with a
+backslash):
 
 ````{tab} pyproject.toml
 
@@ -631,35 +617,10 @@ You can specify CMake defines as strings or bools:
 [tool.scikit-build.cmake.define]
 SOME_DEFINE = "Foo"
 SOME_OPTION = true
+FOOD_GROUPS = ["Apple", "Lemon;Lime", "Banana"]
 ```
 
 ````
-
-You can even specify a CMake define as a list of strings:
-
-````{tab} pyproject.toml
-
-```toml
-[tool.scikit-build.cmake.define]
-FOOD_GROUPS = [
-    "Apple",
-    "Lemon;Lime",
-    "Banana",
-    "Pineapple;Mango",
-]
-```
-
-````
-
-Semicolons inside the list elements will be escaped with a backslash (`\`) and
-the resulting list elements will be joined together with semicolons (`;`) before
-being converted to command-line arguments.
-
-:::{versionchanged} 0.11
-
-Support for list of strings.
-
-:::
 
 `````{tab} config-settings
 
@@ -698,6 +659,12 @@ SKBUILD_CMAKE_DEFINE: SOME_DEFINE=ON
 ```
 
 ````
+
+:::{versionchanged} 0.11
+
+Support for list of strings.
+
+:::
 
 You can also (`pyproject.toml` only) specify a dict, with `env=` to load a
 define from an environment variable, with optional `default=`.
@@ -1006,14 +973,11 @@ need them. Currently, there are several formatter-style keywords available:
 `sys`, `platform` (parenthesis will be added for items like `platform.platform`
 for you), `__version__` for scikit-build-core's version, and style keywords.
 
-For styles, the colors are `default`, `red`, `green`, `yellow`, `blue`,
-`magenta`, `cyan`, and `white`. These can be accessed as `fg.*` or `bg.*`,
-without a qualifier the foreground is assumed. Styles like `normal`, `bold`,
-`italic`, `underline`, `reverse` are also provided. A full clearing of all
-styles is possible with `reset`. These all can be chained, as well, so
-`bold.red.bg.blue` is valid, and will produce an optimized escape code. Remember
-that you need to set the environment variable `FORCE_COLOR` to see colors with
-pip.
+The style keywords are the standard ANSI colors (`red`, `green`, `blue`, ...)
+and styles (`normal`, `bold`, `italic`, `underline`, `reverse`), chainable with
+dots: `bold.red.bg.blue` is valid (`fg.`/`bg.` select foreground/background,
+foreground being the default, and `reset` clears all styles). Remember that you
+need to set the environment variable `FORCE_COLOR` to see colors with pip.
 
 ```{versionadded} 0.10
 
@@ -1081,11 +1045,8 @@ dependencies like `"cmake"` will not be requested.
 
 ```
 
-## Overrides
+## See also
 
-The overrides system allows you to customize for a wide variety of situations.
-It is described at [](#overrides).
-
-## Full Schema
-
-You can see the full schema at [](#schema).
+- [Overrides](./overrides.md): customize settings for a wide variety of
+  situations.
+- [Full schema](#schema) for all settings.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -340,10 +340,9 @@ matching `SKBUILD_*_DIR` CMake variable name:
 wheel.install-dir = "${SKBUILD_DATA_DIR}/mypackage"
 ```
 
-The available trees are `${SKBUILD_PLATLIB_DIR}` (the default),
-`${SKBUILD_PURELIB_DIR}`, `${SKBUILD_DATA_DIR}`, `${SKBUILD_HEADERS_DIR}`,
-`${SKBUILD_SCRIPTS_DIR}`, `${SKBUILD_METADATA_DIR}`, and `${SKBUILD_NULL_DIR}`.
-This matches the cache variables available from within CMake.
+The available trees match the `SKBUILD_*_DIR` cache variables available from
+within CMake, described in
+[install directories](../guide/cmakelists.md#install-directories).
 
 :::{versionadded} 1.0
 
@@ -416,11 +415,11 @@ support:
 | `"cp315.cp315t"` | Both stable ABIs from one free-threaded build     | `cp315-abi3.abi3t` |
 
 Scikit-build-core will only target ABI3 if the version of Python is equal to or
-newer than the one you set. `${SKBUILD_SABI_COMPONENT}` is set to
-`Development.SABIModule` when targeting ABI3 or ABI3T, and is an empty string
-otherwise. `cp315t` also sets `Py_TARGET_ABI3T` (if using CMake 4.4+). For
-`py3`/`py2.py3`, you still need a version of Python scikit-build-core supports
-to build the initial wheel.
+newer than the one you set. `cp315t` also sets `Py_TARGET_ABI3T` (if using CMake
+4.4+). For `py3`/`py2.py3`, you still need a version of Python scikit-build-core
+supports to build the initial wheel. The CMake side — the
+`${SKBUILD_SABI_COMPONENT}` variable and the `USE_SABI` idiom — is covered in
+[Limited API / Stable ABI](#limited-api).
 
 With `cp315.cp315t`, a free-threaded build emits the combined `cp315-abi3.abi3t`
 tag: `abi3t` is a subset of `abi3` (PEP 803), so the single free-threaded binary
@@ -803,6 +802,10 @@ locating dependencies, set `CMAKE_PREFIX_PATH`:
 CMAKE_PREFIX_PATH = "/opt/mydeps;/usr/local"
 ```
 
+For dependencies installed as Python packages in the same environment, the
+search paths are populated automatically through entry-points; see
+[search paths](./search_paths.md).
+
 ## Editable installs
 
 Support for editable installs is provided, with some caveats and configuration.
@@ -881,14 +884,13 @@ build, so all the caveats there apply too -- only one build per source
 directory, you can't change to an out-of-source builds without removing the
 build artifacts, your source directory will be littered with build artifacts,
 etc. Also, to make your binaries importable, you should set
-`LIBRARY_OUTPUT_DIRECTORY` (include a generator expression, like the empty one
-`$<0:>` for multi-config generator support, like MSVC, so you don't have to set
-all possible `*_<CONFIG>` variations) to make sure they are placed inside your
-source directory inside the Python packages; this will be run from the build
-directory, rather than installed. The build directory setting will be ignored if
-you use this and perform an editable install (the source directory doubles as
-the build directory). You can detect this mode by checking for an in-place build
-and checking `SKBUILD` being set.
+`LIBRARY_OUTPUT_DIRECTORY` to place them inside your source directory inside the
+Python packages (append the empty generator expression `$<0:>` for multi-config
+generator support; see [the MSVC FAQ](#msvc-multi-config)); this will be run
+from the build directory, rather than installed. The build directory setting
+will be ignored if you use this and perform an editable install (the source
+directory doubles as the build directory). You can detect this mode by checking
+for an in-place build and checking `SKBUILD` being set.
 
 With all the caveats, this is very logically simple (one directory) and a near
 identical replacement for `python setup.py build_ext --inplace`. Some third

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -913,16 +913,6 @@ dependencies like `"cmake"` will not be requested.
 
 ## See also
 
-```{toctree}
-:maxdepth: 1
-
-editable
-overrides
-dynamic
-formatted
-search_paths
-entrypoint_config
-variants
-```
-
-The [full schema](#schema) documents every setting.
+- [Overrides](./overrides.md): customize settings for a wide variety of
+  situations.
+- [Full schema](#schema) for all settings.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -170,8 +170,9 @@ will fall back on ">=3.15" if it can't read it.
 
 You can also enforce ninja to be required even if make is present on Unix:
 
-```{conftabs} ninja.make-fallback False
-
+```toml
+[tool.scikit-build]
+ninja.make-fallback = false
 ```
 
 You can also control the FindPython backport; by default, a backport of CMake
@@ -224,8 +225,9 @@ sdist.reproducible = false
 
 You can also request CMake to run during this step:
 
-```{conftabs} sdist.cmake True
-
+```toml
+[tool.scikit-build]
+sdist.cmake = true
 ```
 
 :::{note}
@@ -328,8 +330,9 @@ The install directory is normally site-packages; however, you can manually set
 that to a different directory if you'd like to avoid changing your CMake files.
 For example, to mimic scikit-build classic:
 
-```{conftabs} wheel.install-dir "mypackage"
-
+```toml
+[tool.scikit-build]
+wheel.install-dir = "mypackage"
 ```
 
 You can target a different wheel tree by prefixing the install dir with the
@@ -402,8 +405,9 @@ The python API tags for your wheel will be correct assuming you are building a
 normal CPython extension. For anything else, set `wheel.py-api` to the tag you
 support:
 
-```{conftabs} wheel.py-api "cp38"
-
+```toml
+[tool.scikit-build]
+wheel.py-api = "cp38"
 ```
 
 | `wheel.py-api`   | Use for                                           | Resulting tags     |
@@ -438,8 +442,9 @@ Some older versions of pip are unable to load standard universal tags;
 scikit-build-core can expand the macOS universal tags for you for maximum
 historic compatibility if you'd like:
 
-```{conftabs} wheel.expand-macos-universal-tags True
-
+```toml
+[tool.scikit-build]
+wheel.expand-macos-universal-tags = true
 ```
 
 You can also specify a build tag:
@@ -450,8 +455,9 @@ You can also specify a build tag:
 
 You can select only specific components to install:
 
-```{conftabs} install.components ["python"]
-
+```toml
+[tool.scikit-build]
+install.components = ["python"]
 ```
 
 And you can turn off binary stripping:
@@ -467,8 +473,9 @@ compilers that honor it can produce deterministic output. This cannot make the
 compiled binaries themselves reproducible on its own — that also depends on a
 recent compiler and flags like `-ffile-prefix-map`.
 
-```{conftabs} wheel.reproducible True
-
+```toml
+[tool.scikit-build]
+wheel.reproducible = true
 ```
 
 :::{versionadded} 1.0
@@ -906,6 +913,16 @@ dependencies like `"cmake"` will not be requested.
 
 ## See also
 
-- [Overrides](./overrides.md): customize settings for a wide variety of
-  situations.
-- [Full schema](#schema) for all settings.
+```{toctree}
+:maxdepth: 1
+
+editable
+overrides
+dynamic
+formatted
+search_paths
+entrypoint_config
+variants
+```
+
+The [full schema](#schema) documents every setting.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -808,154 +808,12 @@ search paths are populated automatically through entry-points; see
 
 ## Editable installs
 
-Support for editable installs is provided, with some caveats and configuration.
-Recommendations:
+Editable installs (`pip install -e .`) are supported, including an optional
+(experimental) rebuild-on-import mode and an inplace mode; see the dedicated
+[editable installs](./editable.md) page.
 
-- Use `--no-build-isolation` when doing an editable install is recommended; you
-  should preinstall your dependencies.
-- Automatic rebuilds do not have the original isolated build dir (pip deletes
-  it), so select a `build-dir` when using editable installs, especially if you
-  also enable automatic rebuilds.
-- You need to reinstall to pick up new files.
-
-Resources (via `importlib.resources`) are supported and tested on all supported
-Python versions. On Python 3.8, use the `importlib_resources` backport, since
-`importlib.resources.files` was added to the standard library in Python 3.9.
-
-```console
-# Very experimental rebuild on initial import feature
-$ pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=build -ve.
-```
-
-The automatic rebuild-on-import feature (`editable.rebuild`) is still
-experimental and subject to change.
-
-You can disable the verbose rebuild output with `editable.verbose=false` if you
-want. (Also available as the `SKBUILD_EDITABLE_VERBOSE` envvar when importing;
-this will override if non-empty, and `"0"` will disable verbose output).
-
-When `editable.rebuild` is enabled together with a persistent `build-dir`, the
-CMake install targets a tree inside the build directory and the redirecting
-finder loads the compiled artifacts from there directly, rather than from copies
-in site-packages. This means `SKBUILD_PLATLIB_DIR` (or `SKBUILD_PURELIB_DIR`)
-and `CMAKE_INSTALL_PREFIX` are baked at their final location when the editable
-wheel is first built, so import-triggered rebuilds re-install in place with no
-extra reconfigure -- including projects that install to an absolute
-`${SKBUILD_PLATLIB_DIR}/...` destination. Deleting the build directory breaks
-the install, but a rebuildable editable already depends on it.
-
-As a newer, parallel alternative, `editable.rebuild-dir` selects the install
-tree directly and turns on rebuild-on-import by itself (the `editable.rebuild`
-flag is ignored when it is set). It accepts the same template substitutions as
-`build-dir`, and the path must be absolute, or relative to the source directory,
-and stable between build and run time, since it is baked at configure time and
-referenced by absolute path on rebuild. This only moves the install tree;
-`build-dir` is still required and still hosts the CMake build that the rebuild
-re-runs. The classic `editable.rebuild` (which installs into a tree inside
-`build-dir`) is left as-is, so the two approaches can be compared.
-
-:::{versionadded} 1.0
-
-`editable.rebuild-dir`, a persistent install tree for editable rebuilds.
-
-:::
-
-The default `editable.mode`, `"redirect"`, uses a custom redirecting finder to
-combine the static CMake install dir with the original source code. Python code
-added via scikit-build-core's package discovery will be found in the original
-location, so changes there are picked up on import, regardless of the
-`editable.rebuild` setting.
-
-:::{versionchanged} 1.0
-
-[PEP 829][] `.start` files are emitted for the redirecting finder on Python
-3.15+. Older interpreters emit only `.pth` files.
-
-:::
-
-[PEP 829]: https://peps.python.org/pep-0829/
 [PEP 817]: https://peps.python.org/pep-0817/
 [PEP 803]: https://peps.python.org/pep-0803/
-
-:::{note}
-
-A second mode, `"inplace"`, is also available. This does an in-place CMake
-build, so all the caveats there apply too -- only one build per source
-directory, you can't change to an out-of-source builds without removing the
-build artifacts, your source directory will be littered with build artifacts,
-etc. Also, to make your binaries importable, you should set
-`LIBRARY_OUTPUT_DIRECTORY` to place them inside your source directory inside the
-Python packages (append the empty generator expression `$<0:>` for multi-config
-generator support; see [the MSVC FAQ](#msvc-multi-config)); this will be run
-from the build directory, rather than installed. The build directory setting
-will be ignored if you use this and perform an editable install (the source
-directory doubles as the build directory). You can detect this mode by checking
-for an in-place build and checking `SKBUILD` being set.
-
-With all the caveats, this is very logically simple (one directory) and a near
-identical replacement for `python setup.py build_ext --inplace`. Some third
-party tooling might work better with this mode. Scikit-build-core will simply
-install a `.pth` file that points at your source package(s) and do an inplace
-CMake build.
-
-On the command line, you can pass `-Ceditable.mode=inplace` to enable this mode.
-Inplace installs support both automatic (`editable.rebuild`) and manual rebuilds
-(see below); since the source directory doubles as the build directory, no
-separate `build-dir` is needed.
-
-:::
-
-(triggering-a-rebuild-manually)=
-
-### Triggering a rebuild manually
-
-You don't have to enable `editable.rebuild` to rebuild on demand. Both editable
-modes install a loader that exposes a `rebuild()` method, so you can recompile
-whenever you like:
-
-```python
-import some_package
-
-some_package.__loader__.rebuild()
-```
-
-For redirect installs this runs the same `cmake --build`/`--install` cycle used
-by the automatic rebuild, and works for any importable object the install
-provides -- a package, a plain module, or a compiled extension. A redirect
-rebuild needs a persistent build directory, so install with a `build-dir` set:
-
-```console
-$ pip install --no-build-isolation -Cbuild-dir=build -ve .
-```
-
-If a redirect editable was built without a persistent `build-dir`, there is
-nothing to rebuild and the call raises `RuntimeError`.
-
-For inplace installs, `rebuild()` runs `cmake --build` in the source tree (there
-is no install step); the source directory is always the build directory, so no
-`build-dir` is required.
-
-If you don't have a handle on a redirected module, the finder itself is on
-`sys.meta_path` and carries the same method (`ScikitBuildRedirectingFinder` for
-redirect installs, `ScikitBuildInplaceFinder` for inplace):
-
-```python
-import sys
-
-finder = next(
-    f
-    for f in sys.meta_path
-    if type(f).__name__ in {"ScikitBuildRedirectingFinder", "ScikitBuildInplaceFinder"}
-)
-finder.rebuild()
-```
-
-:::{versionadded} 1.0
-
-Manual `__loader__.rebuild()` for redirect installs, and both manual and
-automatic (`editable.rebuild`) rebuilds for inplace installs.
-
-:::
 
 ## Messages
 
@@ -1021,8 +879,7 @@ experimental = true
 The following features currently require this flag:
 
 - **Wheel variants**: [PEP 817][] variant support (`variant`, `variant-name`,
-  `variant-label`, and `null-variant`), added in 1.0. See
-  [](../guide/faqs.md#building-wheel-variants-experimental).
+  `variant-label`, and `null-variant`), added in 1.0. See [](./variants.md).
 - **Legacy `tool.scikit-build.metadata` plugins**: dynamic metadata providers
   not shipped with scikit-build-core (anything using `provider-path` or a
   provider outside the `scikit_build_core.*` namespace) used through the
@@ -1035,8 +892,8 @@ The following features currently require this flag:
   `${SKBUILD_<TREE>_DIR}` prefix is the non-experimental replacement. See
   [`wheel.install-dir`](../reference/configs.md).
 
-The [rebuild-on-import feature](#editable-installs) for editable installs is
-also considered experimental and subject to change, but is not gated behind this
+The [rebuild-on-import feature](./editable.md) for editable installs is also
+considered experimental and subject to change, but is not gated behind this
 flag.
 
 You can also fail the build with `fail = true`. This is useful with overrides if

--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -8,19 +8,16 @@ override if the `if` condition is true.
 
 ## If conditions
 
-There are three types of conditions. Booleans, strings, and version numbers.
-Booleans take a bool; if the boolean matches the bool you give, the override
-matches. If the value is a string (such as an environment variable), it will
-match non false-like values, and if the variable is unset or empty, that counts
-as false. Strings take a regex which will try to match. Version numbers take a
-specifier set, like `>=1.0`.
+At least one condition must be provided; if multiple conditions are given, all
+must be true (see [`if.any`](#any-matching-condition) to match on any one
+instead). Overrides match top to bottom, overriding previous matches. Each
+condition is one of three types:
 
-If multiple conditions are given, they all must be true. Use `if.any` (below) if
-you would rather matching on any one of multiple conditions being true.
-
-At least one must be provided. Then you can specify any collection of valid
-options, and those will override if all the items in the `if` are true. They
-will match top to bottom, overriding previous matches.
+| Type    | Takes           | Matches when                                                                                            |
+| ------- | --------------- | ------------------------------------------------------------------------------------------------------- |
+| bool    | a boolean       | the value matches the boolean you give                                                                  |
+| string  | a regex         | the regex matches; for env vars, a boolean instead matches non false-like values (unset/empty is false) |
+| version | a specifier set | the version satisfies the specifier set, like `>=1.0`                                                   |
 
 If an override does not match, its contents are ignored, including invalid
 options. Combined with the `if.scikit-build-version` override, this allows using
@@ -143,8 +140,11 @@ The `metadata_wheel` and `metadata_editable` states correspond to the
 517 hooks, respectively; these are metadata-only preparation passes that a
 frontend may run without building the full wheel.
 
-Note that you can build directly to wheel; you don't have to go through an
-SDist.
+:::{note}
+
+You can build directly to wheel; you don't have to go through an SDist.
+
+:::
 
 :::{versionadded} 0.8
 
@@ -216,9 +216,13 @@ wheel.cmake = false
 
 :::
 
+:::{note}
+
 If this override is present in your pyproject.toml file, scikit-build-core will
 not provide the `prepare_metadata_*` hooks, as it can't know without building if
 the build will fail.
+
+:::
 
 ## Any matching condition
 

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -2,7 +2,13 @@
 
 Scikit-build-core populates CMake search paths to take into account any other
 CMake project installed in the same environment. In order to take advantage of
-this the dependent project must populate a `cmake.*` entry-point.
+this the dependent project must populate a `cmake.*` entry-point:
+
+| Entry-point group | CMake variable populated | Typical use                                               |
+| ----------------- | ------------------------ | --------------------------------------------------------- |
+| `cmake.root`      | `<PackageName>_ROOT`     | `find_package(MyProject)` (recommended)                   |
+| `cmake.prefix`    | `CMAKE_PREFIX_PATH`      | catch-all for `find_package`, `find_program`, `find_path` |
+| `cmake.module`    | `CMAKE_MODULE_PATH`      | CMake modules loaded with `include(...)`                  |
 
 ## `<PackageName>_ROOT`
 

--- a/docs/configuration/search_paths.md
+++ b/docs/configuration/search_paths.md
@@ -71,6 +71,9 @@ isolation's `site-packages` folder. This default can be disabled by setting
 search.site-packages = false
 ```
 
+You can also extend `CMAKE_PREFIX_PATH` with arbitrary paths through the
+[env table](index.md#environment-variables-for-the-build).
+
 Additionally, scikit-build-core reads the entry-point `cmake.prefix` of the
 dependent projects, which is similarly exported as
 

--- a/docs/configuration/variants.md
+++ b/docs/configuration/variants.md
@@ -1,0 +1,55 @@
+# Building wheel variants
+
+```{versionadded} 1.0
+
+```
+
+```{warning}
+This is an early preview of [PEP 817][] wheel variant support. The interface may
+change, and it must be opted into with `experimental = true`.
+```
+
+Scikit-build-core can attach variant metadata to a wheel, producing a
+variant-labeled filename (the label becomes the final field of the wheel name)
+and a `variant.json` file inside `*.dist-info`. This lets you ship several
+wheels for the same version that differ by hardware or library features (CPU
+ABI, CUDA version, BLAS implementation, etc.).
+
+Because each variant of a build needs different settings, the variant options
+are **only allowed in config-settings or `[[tool.scikit-build.overrides]]`** —
+they cannot be hard-coded at the top level of `pyproject.toml`. The relevant
+settings are:
+
+- `variant` / `variant-name`: variant properties in
+  `namespace :: feature :: value` form (repeatable).
+- `variant-label`: override the computed label used in the wheel filename.
+- `null-variant`: build the null variant (mutually exclusive with the above).
+
+When any of these are set, [`variantlib`][] is automatically injected as a build
+requirement, and the experimental flag must be enabled. For example, to build a
+CPU-ABI variant with `pip`:
+
+```bash
+pip wheel . \
+  -Cexperimental=true \
+  -Cvariant="cpu :: abi :: cp313" \
+  -Cvariant-label=cpu
+```
+
+Or to enable it for everyone via an override (still keeping the per-build values
+in config-settings), put the experimental flag in `pyproject.toml`:
+
+```toml
+[tool.scikit-build]
+experimental = true
+```
+
+Pass `-Cvariant=...` (and friends) at build time to select which variant to
+produce.
+
+<!-- prettier-ignore-start -->
+
+[pep 817]: https://peps.python.org/pep-0817
+[`variantlib`]: https://github.com/wheelnext/variantlib
+
+<!-- prettier-ignore-end -->

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -45,83 +45,61 @@ You can inspect any SDist or wheel on PyPI at <https://inspector.pypi.io>.
 
 ## In-depth
 
-Modern Python build procedure is as follows:
-
-### SDist
-
-The SDist is a tarfile with all the code required to build the project, along
-with a little bit of metadata. To build an SDist, you use the `build` tool with
-the `--sdist` flag. For example, `pipx run build --sdist`. This:
+SDists and wheels are produced by the same hook sequence. Building either one
+(`pipx run build --sdist` or `--wheel`):
 
 1. Reads `pyproject.toml` to get the `build-system` table.
-2. Set up a new isolated environment with the packages listed in
+2. Sets up a new isolated environment with the packages listed in
    `build-system.requires`.
-3. Run `.get_requires_for_build_sdist(...)` inside the module listed in
-   `build-system.build-backend`, if it exists. If this returns a list, install
-   all the packages requested. This allows a backend to dynamically declare
-   dependencies.
-4. Run `.build_sdist(...)` inside the module listed in
-   `build-system.build-backend`. The backend produces an SDist file and returns
-   the filename.
+3. Runs `.get_requires_for_build_sdist(...)` or
+   `.get_requires_for_build_wheel(...)` inside the module listed in
+   `build-system.build-backend`, if it exists. If this returns a list, all the
+   packages requested are installed. This allows a backend to dynamically
+   declare dependencies.
+4. Runs `.build_sdist(...)` or `.build_wheel(...)` inside the module listed in
+   `build-system.build-backend`. The backend produces the file and returns the
+   filename.
 
 Details of the arguments are skipped above, but they allow arbitrary settings
 (called config-settings) to be passed to all the hook functions and handle
 directories. If you turn off isolated environment building (`--no-isolation` in
-`build`), then steps 2 and 3 are skipped. Note that pip cannot build SDists.
+`build` or `--no-build-isolation` in `pip`), then steps 2 and 3 are skipped.
 
-Without build isolation, you can build an SDist manually with
-`python -c "from scikit_build_core.build import build_sdist; build_sdist('dist')"`.
-This will produce an SDist in the `dist` directory. For any other backend,
-substitute the backend above.
-
-#### File structure in the SDist
-
-Since you can build a wheel from the source or from the SDist, the structure
-should be identical to the source, though some files (like CI files) may be
-omitted. Files from git submodules should be included. It is best if the SDist
-can be installed without internet connection, but that's not always the case.
-
-There also is a `PKG-INFO` file with metadata in SDists.
-
-### Wheel
-
-The wheel is a zip file (ending in `.whl`) with the built code of the project,
-along with required metadata. There is no code that executes on install; it is a
-simple unpack with a few rules about directories. Wheels do not contain
-`pyproject.toml` or other configuration files. To build a wheel, you use the
-`build` tool with the `--wheel` flag. For example, `pipx run build --wheel`.
-This:
-
-1. Reads `pyproject.toml` to get the `build-system` table.
-2. Set up a new isolated environment with the packages listed in
-   `build-system.requires`.
-3. Run `.get_requires_for_build_wheel(...)` inside the module listed in
-   `build-system.build-backend`, if it exists. If this returns a list, install
-   all the packages requested. This allows a backend to dynamically declare
-   dependencies.
-4. Run `.build_wheel(...)` inside the module listed in
-   `build-system.build-backend`. The backend produces a wheel file and returns
-   the filename.
-
-Details of the arguments are skipped above, but they allow arbitrary settings
-(called config-settings) to be passed to all the hook functions and handle
-directories. If you turn off isolated environment building
-(`--no-build-isolation` in `pip` or `--no-isolation` in `build`), then steps 2
-and 3 are skipped.
+There are a few other hooks as well; one to allow metadata to be produced
+without building a wheel, and editable versions of the wheel build. Editable
+"wheels" are temporary wheels that are only produced to immediately install and
+discard, and are expected to provide mechanisms to link back to the source code.
 
 :::{note}
 
 If you run build without arguments, it will build an SDist first, then will
 build a wheel from the SDist. This will error if you do not have a valid SDist.
 If you pass `--sdist --wheel`, it will build both directly from the source
-instead.
+instead. Note that pip cannot build SDists.
 
 :::
 
-There are a few other hooks as well; one to allow metadata to be produced
-without building a wheel, and editable versions of the wheel build. Editable
-"wheels" are temporary wheels that are only produced to immediately install and
-discard, and are expected to provide mechanisms to link back to the source code.
+### SDist
+
+The SDist is a tarfile with all the code required to build the project, along
+with a little bit of metadata (a `PKG-INFO` file).
+
+Without build isolation, you can build an SDist manually with
+`python -c "from scikit_build_core.build import build_sdist; build_sdist('dist')"`.
+This will produce an SDist in the `dist` directory. For any other backend,
+substitute the backend above.
+
+Since you can build a wheel from the source or from the SDist, the structure
+should be identical to the source, though some files (like CI files) may be
+omitted. Files from git submodules should be included. It is best if the SDist
+can be installed without internet connection, but that's not always the case.
+
+### Wheel
+
+The wheel is a zip file (ending in `.whl`) with the built code of the project,
+along with required metadata. There is no code that executes on install; it is a
+simple unpack with a few rules about directories. Wheels do not contain
+`pyproject.toml` or other configuration files.
 
 #### File structure in the wheel
 
@@ -162,14 +140,6 @@ standalone tool that is designed entirely to install wheels.
 If you want to run code on install, you either have to use an SDist, or depend
 on a package that is SDist only. However, this is quite rarely required.
 
-There are several directories supported, at least. Besides unpacking to the
-site-packages directory, wheels can also have folders that get unpacked to the
-root of the environment and the Python header locations. But these are generally
-discouraged, with including files in the package's site-package directory and
-using `importlib.resources` to access them is preferred. If someone is not
-working in a virtual environment, having items installed to `/` or `/usr/local`
-for example might be surprising!
-
 ## Binary wheels and distributing
 
 A wheel filename has several components:
@@ -205,23 +175,14 @@ The `abi3t` tag for free-threaded stable ABI wheels.
 The wheels produced by default are not designed to be redistributable. Making
 them redistributable depends on platform:
 
-- Linux: The `linux_*` tags cannot be uploaded to PyPI. You have to build the
-  wheels in a restricted environment (like the manylinux images) and run the
-  wheels through `auditwheel` to produce redistributable wheels. This will
-  verify you are only using the correct GLibC and restricted set of system
-  libraries, and will bundle external libraries into the wheel with mangled
-  symbols to avoid conflicts. These will have a `manylinux_*` or `musllinux_*`
-  tag, and can be uploaded to PyPI.
-- macOS: The wheels should be build with the official CPython releases, and
-  target a reasonable `MACOSX_DEPLOYMENT_TARGET` value (10.9 or newer). You
-  should run the wheels through `delocate` to bundle external dependencies.
-  You'll also want to (carefully) cross compile for Apple Silicon or build on
-  Apple Silicon runners (`macos-14`+ on GHA).
-- Windows: this is the easiest, usually, as the wheels don't have special rules
-  on what Python or OS is being used. However, if you want to bundle
-  dependencies, you'll need `delvewheel`, which is a bit younger than the other
-  two packages, and has to do a few more intrusive workarounds, but otherwise
-  works like those packages.
+| Platform | Repair tool    | Notes                                                                                                                                                         |
+| -------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux    | [auditwheel][] | `linux_*` tags can't go to PyPI; build in a restricted environment (like the manylinux images) so the repaired wheel earns a `manylinux_*`/`musllinux_*` tag. |
+| macOS    | [delocate][]   | Build with the official CPython releases and a reasonable `MACOSX_DEPLOYMENT_TARGET` (10.9+); (carefully) cross compile for Apple Silicon or use `macos-14`+. |
+| Windows  | [delvewheel][] | Only needed if you bundle dependencies; younger than the others and uses a few more intrusive workarounds.                                                    |
+
+Repair tools verify you only use allowed system libraries and bundle external
+libraries into the wheel with mangled symbols to avoid conflicts.
 
 The easiest way to handle all the above for all Python versions, OSs,
 architectures, including testing, is to use [cibuildwheel][]. There's also a
@@ -232,14 +193,12 @@ the current workaround).
 
 <!-- prettier-ignore-start -->
 
-[^1]: This is the modern build mechanism. If no `pyproject.toml` is present,
-      pip/build will trigger a legacy build/install that either pretends a basic
-      `pyproject.toml` is present (build) or using legacy `setup.py ...` commands
-      (pip). If **both** `pyproject.toml` is not provide and `wheel` is not
-      present, `pip` will even fall back on using `setup.py install` instead of
-      `setup.py bdist_wheel`! You can avoid this whole mess with
-      scikit-build-core.
+[^1]: If no `pyproject.toml` is present, pip and build fall back on legacy
+      `setup.py`-based builds; using scikit-build-core avoids this entirely.
 
+[auditwheel]: https://github.com/pypa/auditwheel
+[delocate]: https://github.com/matthew-brett/delocate
+[delvewheel]: https://github.com/adang1345/delvewheel
 [repairwheel]: https://github.com/jvolkman/repairwheel
 [cibuildwheel]: https://cibuildwheel.pypa.io
 [compatibility tags]: https://packaging.python.org/en/latest/specifications/binary-distribution-format

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -123,6 +123,8 @@ configuration, with the variables:
 - `${SKBUILD_NULL_DIR}`: Anything installed here will not be placed in the
   wheel.
 
+(limited-api)=
+
 ## Limited API / Stable ABI
 
 You can activate the Stable ABI by setting `tool.scikit-build.wheel.py-api`
@@ -134,6 +136,10 @@ in your `pyproject.toml`:
 [tool.scikit-build]
 wheel.py-api = "cp38"
 ```
+
+The possible values and the resulting wheel tags are covered in
+[customizing the output wheel](../configuration/index.md#customizing-the-output-wheel);
+this section covers the CMake side.
 
 When you do that, `${SKBUILD_SABI_COMPONENT}` will be set to
 `Development.SABIModule` if you can target this (new enough CPython), and will

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -192,18 +192,5 @@ than being built into scikit-build-core: [cython-cmake][] (`include(UseCython)`)
 and [f2py-cmake][] (`include(UseF2Py)`). Add them to your `build.requires` and
 see the [getting started guide](getting_started.md) for full examples.
 
-## Related guides
-
-```{toctree}
-:maxdepth: 1
-
-dynamic_link
-ctypes
-crosscompile
-migration_guide
-workspaces
-debugging
-```
-
 [cython-cmake]: https://github.com/scikit-build/cython-cmake
 [f2py-cmake]: https://github.com/scikit-build/f2py-cmake

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -192,5 +192,18 @@ than being built into scikit-build-core: [cython-cmake][] (`include(UseCython)`)
 and [f2py-cmake][] (`include(UseF2Py)`). Add them to your `build.requires` and
 see the [getting started guide](getting_started.md) for full examples.
 
+## Related guides
+
+```{toctree}
+:maxdepth: 1
+
+dynamic_link
+ctypes
+crosscompile
+migration_guide
+workspaces
+debugging
+```
+
 [cython-cmake]: https://github.com/scikit-build/cython-cmake
 [f2py-cmake]: https://github.com/scikit-build/f2py-cmake

--- a/docs/guide/cmakelists.md
+++ b/docs/guide/cmakelists.md
@@ -75,11 +75,14 @@ this variable is used when creating targets.
 
 :::
 
+:::{note}
+
 If you want to use the old, deprecated FindPythonInterp and FindPythonLibs
-instead, you can. Though it should be noted that FindPythonLibs requires a trick
-to make it work properly if a Python library is not preset (like in manylinux):
-you have to set `PYTHON_LIBRARY` to something (doesn't matter what) to make it
+instead, you can. FindPythonLibs requires a trick to work when no Python library
+is present (like in manylinux): set `PYTHON_LIBRARY` to anything to make it
 succeed.
+
+:::
 
 ## Finding other packages
 

--- a/docs/guide/crosscompile.md
+++ b/docs/guide/crosscompile.md
@@ -4,29 +4,20 @@ Generally scikit-build-core will try to account for environment variables that
 specify to CMake directly how to cross-compile. Alternatively, you can define
 manually how to cross-compile as detailed in [manual cross compilation] section.
 
-## macOS
+```{tab} macOS
 
 Unlike the other platforms, macOS has the ability to target older operating
 systems with the `MACOSX_DEPLOYMENT_TARGET` variable. If that is not set, you
 will get a wheel optimized for the current operating system. Popular
 redistributable builders like cibuildwheel will set this for you.
 
-:::{warning}
+**Intel to Apple Silicon:** AppleClang has excellent support for making Apple
+Silicon and Universal2 binaries (both architectures in one binary).
+Scikit-build-core respects `ARCHFLAGS` if `CMAKE_SYSTEM_PROCESSOR` is not in
+the cmake args. These values are set by most redistributable builders like
+cibuildwheel when cross-compiling.
 
-While CMake also allows you to specify this a few other ways, scikit-build-core
-will not know you've set this and won't get the correct wheel name.
-
-:::
-
-### Intel to AppleSilicon
-
-On macOS, AppleClang has excellent support for making Apple Silicon and
-Universal2 binaries (both architectures in one binary). Scikit-build-core
-respects `ARCHFLAGS` if `CMAKE_SYSTEM_PROCESSOR` is not in the cmake args. These
-values are set by most redistributable builders like cibuildwheel when
-cross-compiling.
-
-:::{warning}
+:::{note}
 
 If you link to any binaries, they need to be Universal2, so that you get the
 Apple Silicon component. This means you cannot use homebrew binaries (which are
@@ -38,29 +29,32 @@ Universal2.
 
 :::{warning}
 
-If you manually set the arch flags in other ways besides `ARCHFLAGS`, or the one
-special case above, scikit-build-core will not get the right wheel name.
+Scikit-build-core only knows about `MACOSX_DEPLOYMENT_TARGET` and `ARCHFLAGS`;
+if you set the target OS version or architectures any other way (CMake allows
+several), it won't know and the wheel will not get the correct name.
 
 :::
 
-## Windows
+```
 
-### Intel to ARM
+```{tab} Windows
 
-Scikit-build-core respects setuptools-style `DIST_EXTRA_CONFIG`. If is set to a
-file, then scikit-build-core reads the `build_ext.library_dirs` paths to find
-the library to link to. You will also need to set `SETUPTOOLS_EXT_SUFFIX` to the
-correct suffix. These values are set by cibuildwheel when cross-compiling.
+**Intel to ARM:** Scikit-build-core respects setuptools-style
+`DIST_EXTRA_CONFIG`. If it is set to a file, then scikit-build-core reads the
+`build_ext.library_dirs` paths to find the library to link to. You will also
+need to set `SETUPTOOLS_EXT_SUFFIX` to the correct suffix. These values are set
+by cibuildwheel when cross-compiling.
 
-## Linux
+```
+
+```{tab} Linux
 
 See [manual cross compilation] section for the general approach.
 
-### Intel to Emscripten (Pyodide)
-
-When using pyodide-build, Python is set up to report the cross-compiling values
-by setting `_PYTHON_SYSCONFIGDATA_NAME`. This causes values like `SOABI` and
-`EXT_SUFFIX` to be reported by `sysconfig` as the cross-compiling values.
+**Intel to Emscripten (Pyodide):** When using pyodide-build, Python is set up
+to report the cross-compiling values by setting `_PYTHON_SYSCONFIGDATA_NAME`.
+This causes values like `SOABI` and `EXT_SUFFIX` to be reported by `sysconfig`
+as the cross-compiling values.
 
 This is unfortunately incorrectly stripped from the cmake wrapper pyodide uses,
 so FindPython will report the wrong values, but pyodide-build will rename the
@@ -69,7 +63,9 @@ so FindPython will report the wrong values, but pyodide-build will rename the
 pyodide-build will also set `_PYTHON_HOST_PLATFORM` to the target Pyodide
 platform, so scikit-build-core can use that to compute the correct wheel name.
 
-## Android
+```
+
+```{tab} Android
 
 To build for Android, you'll need the following items, all of which will be
 provided automatically if you use cibuildwheel:
@@ -89,6 +85,8 @@ provided automatically if you use cibuildwheel:
     active.
 - Compiler paths and flags, either in the toolchain file or in environment
   variables.
+
+```
 
 ## Manual cross compilation
 

--- a/docs/guide/crosscompile.md
+++ b/docs/guide/crosscompile.md
@@ -43,7 +43,8 @@ several), it won't know and the wheel will not get the correct name.
 `DIST_EXTRA_CONFIG`. If it is set to a file, then scikit-build-core reads the
 `build_ext.library_dirs` paths to find the library to link to. You will also
 need to set `SETUPTOOLS_EXT_SUFFIX` to the correct suffix. These values are set
-by cibuildwheel when cross-compiling.
+by cibuildwheel when cross-compiling. In your CMakeLists, use
+`${SKBUILD_SOABI}` for the extension suffix; see [the SOABI note](#soabi).
 
 ```
 

--- a/docs/guide/ctypes.md
+++ b/docs/guide/ctypes.md
@@ -1,0 +1,87 @@
+# Shipping a library for `ctypes`
+
+If your package is a thin `ctypes` (or `cffi`) wrapper around a CMake-built
+shared library, rather than a compiled Python extension, the goal is to install
+the library alongside your Python code and then locate it at runtime without
+hard-coding a path. This has the nice property that a single wheel works on
+every Python version, since the library does not touch the Python ABI. The
+tradeoff is that you have to find and load the library yourself.
+
+## Install the library next to your Python code
+
+Point the install destination at your package directory so the library lands in
+`site-packages/mypackage/` next to `__init__.py`:
+
+```cmake
+install(TARGETS mylib DESTINATION mypackage)
+```
+
+The destination is relative to the platlib (`${SKBUILD_PLATLIB_DIR}`) by
+default; you can name any of the [install trees](#install-directories)
+explicitly if you need to. If you set `wheel.install-dir = "mypackage"`, then
+the destination is relative to that instead, and a bare `DESTINATION .` works.
+
+## Find it at runtime with `importlib.resources`
+
+Do **not** compute the path relative to `__file__` — that assumes the package
+lives on a real filesystem, which is not guaranteed (it could be in a zip, and
+in an editable install the Python source and the compiled library live in
+different directories). Use `importlib.resources` instead, which
+scikit-build-core's editable installs fully support:
+
+```python
+import ctypes
+import sys
+from importlib.resources import files
+
+# Pick the right suffix for the platform.
+_suffix = {"win32": ".dll", "darwin": ".dylib"}.get(sys.platform, ".so")
+_lib = files("mypackage") / f"libmylib{_suffix}"
+
+lib = ctypes.CDLL(str(_lib))
+```
+
+For the general (zip-safe) case, wrap the traversable in
+`importlib.resources.as_file`, which extracts the resource to a real path if
+necessary. Because `ctypes` needs the file to remain on disk for the lifetime of
+the process, keep the context manager open — for example with an
+`contextlib.ExitStack` closed at interpreter exit:
+
+```python
+import atexit, ctypes
+from contextlib import ExitStack
+from importlib.resources import files, as_file
+
+_files = ExitStack()
+atexit.register(_files.close)
+_lib = _files.enter_context(as_file(files("mypackage") / f"libmylib{_suffix}"))
+lib = ctypes.CDLL(str(_lib))
+```
+
+## Editable installs and rebuilds
+
+In redirect-mode editable installs (the default), `importlib.resources` finds
+the compiled library through the redirecting finder, so the code above works
+unchanged. Note that accessing a resource does **not** trigger a rebuild — plain
+libraries are not importable modules, so the automatic `editable.rebuild`
+on-import hook does not fire for them. To pick up C/C++ changes, either request
+a rebuild explicitly (this works whenever a persistent `build-dir` is set, with
+or without `editable.rebuild`)…
+
+```python
+import mypackage
+
+mypackage.__loader__.rebuild()
+```
+
+…or import a real extension module from the same project first, which does fire
+the on-import hook when `editable.rebuild` is enabled. See
+[](#triggering-a-rebuild-manually) for the details and the `build-dir`
+requirement.
+
+## Runtime search paths
+
+If your shipped library links against _other_ shared libraries, you still need
+to make those discoverable at load time (`RPATH` on Linux/macOS,
+`os.add_dll_directory` on Windows). See [](#dynamic-linking) for the full set of
+options, including wheel-repair tools.

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -1,0 +1,106 @@
+# Debugging and IDE integration
+
+Coverage tools (`gcov`/`gcovr`), debuggers (GDB), and editor tooling (the VSCode
+C/C++ extension, clangd) all depend on paths recorded at compile time. Two
+scikit-build-core defaults make those paths disappear:
+
+- **The build directory is temporary.** Without {confval}`build-dir` set,
+  scikit-build-core builds in a temporary directory that is deleted after the
+  build — taking coverage data, debug artifacts, and `compile_commands.json`
+  with it.
+- **Build isolation hides everything else.** `pip install .`, `python -m build`,
+  `uv build`, and `uv sync` copy your project and install the build dependencies
+  into throwaway environments, so recorded source paths and include paths no
+  longer exist after the build.
+
+The shared fix is a persistent build directory with isolation disabled (after
+preinstalling your build dependencies), so everything stays in place:
+
+```bash
+pip install --no-build-isolation -Cbuild-dir=build -ve .
+```
+
+You can set the build directory in `pyproject.toml` instead of on the command
+line:
+
+```toml
+[tool.scikit-build]
+build-dir = "build"
+```
+
+## Coverage and debugging (gcov / gcovr / GDB)
+
+gcov records the source path and compilation directory in the `.gcno`
+(compile-time) and `.gcda` (run-time) files, and DWARF debug info records the
+source path in the compiled extension. If those paths no longer exist when you
+run the tool, you get errors such as
+
+```console
+$ gcovr --xml coverage.xml -r .
+(ERROR) Trouble processing '.../CMakeFiles/foo.dir/_foo.c.gcda' with working directory '/home'.
+```
+
+or GDB that cannot show source lines even with debug flags enabled.
+
+With the persistent-tree install above, run gcovr against the persistent tree,
+pointing the root at your source:
+
+```bash
+gcovr -r . build
+```
+
+If you would rather not depend on the paths staying put, make the recorded paths
+relocatable with compiler flags — `-fprofile-abs-path` for gcov and
+`-ffile-prefix-map=<build>=<src>` (or `-fdebug-prefix-map=...` for debug info
+only) — for example via {confval}`cmake.define` or `CFLAGS`.
+
+(compile-commands)=
+
+## IDE IntelliSense (`compile_commands.json`)
+
+Editor tooling resolves headers like `pybind11/pybind11.h` from your include
+paths. With build isolation, binding libraries such as pybind11 and nanobind
+live in a throwaway overlay — CMake reports a path such as
+`.../Temp/pip-build-env-xxxx/overlay/Lib/site-packages/pybind11/include`, which
+no longer exists when your editor looks for it.
+
+Extend the shared fix by having CMake export a compile database:
+
+````{tab} pip
+
+```bash
+pip install scikit-build-core pybind11
+pip install --no-build-isolation --check-build-dependencies -ve . \
+  -Cbuild-dir=build \
+  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
+```
+
+````
+
+````{tab} uv
+
+```bash
+uv pip install scikit-build-core pybind11
+uv pip install --no-build-isolation -ve . \
+  -Cbuild-dir=build \
+  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
+```
+
+In a uv-managed project, disable isolation for your package instead, so
+`uv sync` reuses the environment's build dependencies rather than a discarded
+overlay:
+
+```toml
+[tool.uv]
+no-build-isolation-package = ["mypackage"]
+```
+
+````
+
+This writes `build/compile_commands.json` with real, persistent paths. Then
+point your editor at the file. For clangd, add `--compile-commands-dir=build`
+(or a `.clangd` with a `CompileFlags.CompilationDatabase: build` entry); for the
+VSCode C/C++ extension, set
+`"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"`.
+See [editable installs](../configuration/editable.md) for the related
+`--no-build-isolation` recommendations.

--- a/docs/guide/dynamic_link.md
+++ b/docs/guide/dynamic_link.md
@@ -6,7 +6,9 @@ libraries/python bindings work after the wheel is created and the python project
 is installed on the system. The most common issues are the missing hints
 pointing to where the runtime libraries are located, specifically `RPATH` on
 Linux and MacOS systems, and `PATH`/`os.add_dll_directory` on Windows systems.
-Here are some recommendations on how to address them.
+Here are some recommendations on how to address them. If you got here because a
+vendored dependency's library landed in `site-packages/bin` or `lib`, see
+[that FAQ entry](#dependency-in-site-packages) for the specific fix.
 
 ## Link to the static libraries
 
@@ -22,16 +24,11 @@ For example for [Boost][FindBoost] this is controlled via the variable
 
 ## Wheel repair tools
 
-There are wheel repair tools for each operating system that bundle any dynamic
-libraries used and patch the libraries/python bindings to point to prioritize
-those libraries. The most common tools for these are [auditwheel] for Linux,
-[delocate] for MacOS and [delvewheel] for Windows. [cibuildwheel] incorporates
-these tools in its [repair wheel] feature.
-
-These tools also rename the library with a unique hash to avoid any potential
-name collision if the same library is being bundled by a different package, and
-check if the packages conform to standards like [PEP600] (`manylinux_X_Y`).
-These tools do not allow cross-wheel library dependencies.
+The per-platform wheel repair tools ([auditwheel], [delocate], [delvewheel]; see
+[repairing wheels](#repairing-wheels)) bundle any dynamic libraries used and
+patch the libraries/python bindings to prioritize them. They rename each bundled
+library with a unique hash to avoid collisions if another package bundles the
+same library, and they do not allow cross-wheel library dependencies.
 
 ## Manual patching
 
@@ -68,8 +65,5 @@ os.add_dll_directory(str(dependency_dll_path))
 [auditwheel]: https://pypi.org/project/auditwheel/
 [delocate]: https://pypi.org/project/delocate/
 [delvewheel]: https://pypi.org/project/delvewheel/
-[cibuildwheel]: https://cibuildwheel.pypa.io/en/stable/
-[repair wheel]: https://cibuildwheel.pypa.io/en/stable/options/#repair-wheel-command
-[PEP600]: https://peps.python.org/pep-0600
 
 <!-- prettier-ignore-end -->

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -1,7 +1,5 @@
 # FAQs
 
-This section covers common needs.
-
 ## Starting a new project
 
 The quickest way is the built-in `init` command:
@@ -83,7 +81,7 @@ When cross compiling, FindPython may not get the correct SOABI extension.
 Scikit-build-core does know the correct extension, however, and sets it as
 `SKBUILD_SOABI`. See [the SOABI docs](#soabi).
 
-## Things to try
+## Debugging a build
 
 If you want to debug a scikit-build-core build, you have several options. If you
 are using `pip`, make sure you are passing the `-v` flag, otherwise `pip`

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -71,112 +71,17 @@ This is now a subcommand of the unified `scikit-build` CLI (previously
 
 ## Coverage and debugging (gcov / gcovr / GDB)
 
-Tools like `gcov`/`gcovr` and debuggers like GDB rely on **absolute paths**
-baked into the build artifacts: gcov records the source path and compilation
-directory in the `.gcno` (compile-time) and `.gcda` (run-time) files, and DWARF
-debug info records the source path in the compiled extension. If those paths no
-longer exist when you run the tool, you get errors such as
-
-```console
-$ gcovr --xml coverage.xml -r .
-(ERROR) Trouble processing '.../CMakeFiles/foo.dir/_foo.c.gcda' with working directory '/home'.
-```
-
-or GDB that cannot show source lines even with debug flags enabled. Two default
-behaviors are usually responsible:
-
-- **The build directory is temporary.** Without {confval}`build-dir` set,
-  scikit-build-core builds in a temporary directory that is deleted after the
-  build, taking the `.gcno` files and the compiled extension with it. Set a
-  persistent `build-dir`.
-- **Build isolation copies the source.** `pip install .` and `python -m build`
-  copy your project into a temporary directory before invoking the backend, so
-  the compiler bakes those temporary source paths into the coverage and debug
-  data. After the build the temporary source tree is gone.
-
-The most reliable workflow is a persistent build directory with isolation
-disabled, so both the build tree and the source tree stay in place:
-
-```bash
-pip install --no-build-isolation -Cbuild-dir=build -ve .
-```
-
-Then run gcovr against the persistent tree, pointing the root at your source:
-
-```bash
-gcovr -r . build
-```
-
-If you would rather not depend on the paths staying put, make the recorded paths
-relocatable with compiler flags — `-fprofile-abs-path` for gcov and
-`-ffile-prefix-map=<build>=<src>` (or `-fdebug-prefix-map=...` for debug info
-only) — for example via {confval}`cmake.define` or `CFLAGS`.
+Coverage and debug tools fail when the temporary build directory and isolated
+source copy disappear after the build; the fix is a persistent `build-dir` with
+`--no-build-isolation`. See [debugging and IDE integration](debugging.md) for
+the workflow.
 
 ## IDE IntelliSense can't find headers (`compile_commands.json`)
 
-Editor tooling — the VSCode C/C++ extension, clangd, and similar — resolves
-headers like `pybind11/pybind11.h` from your include paths. Two defaults hide
-them:
-
-- **Build dependencies live in a temporary overlay.** With build isolation (the
-  default for `pip install .`, `python -m build`, `uv build`, and `uv sync`),
-  binding libraries such as pybind11 and nanobind are installed into a throwaway
-  environment that is deleted after the build. CMake reports a path such as
-  `.../Temp/pip-build-env-xxxx/overlay/Lib/site-packages/pybind11/include`,
-  which no longer exists when your editor looks for it.
-- **The build directory is temporary.** Without {confval}`build-dir` set,
-  scikit-build-core builds in a temporary directory, so the
-  `compile_commands.json` CMake generates is discarded too.
-
-The fix is to preinstall the build dependencies, disable build isolation, set a
-persistent `build-dir`, and have CMake export a compile database:
-
-````{tab} pip
-
-```bash
-pip install scikit-build-core pybind11
-pip install --no-build-isolation --check-build-dependencies -ve . \
-  -Cbuild-dir=build \
-  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
-```
-
-````
-
-````{tab} uv
-
-```bash
-uv pip install scikit-build-core pybind11
-uv pip install --no-build-isolation -ve . \
-  -Cbuild-dir=build \
-  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
-```
-
-In a uv-managed project, disable isolation for your package instead, so
-`uv sync` reuses the environment's build dependencies rather than a discarded
-overlay:
-
-```toml
-[tool.uv]
-no-build-isolation-package = ["mypackage"]
-```
-
-````
-
-This writes `build/compile_commands.json` with real, persistent paths. You can
-set the build directory in `pyproject.toml` instead of on the command line:
-
-```toml
-[tool.scikit-build]
-build-dir = "build"
-```
-
-Then point your editor at the file. For clangd, add
-`--compile-commands-dir=build` (or a `.clangd` with a
-`CompileFlags.CompilationDatabase: build` entry); for the VSCode C/C++
-extension, set
-`"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"`.
-See [editable installs](../configuration/index.md#editable-installs) for the
-related `--no-build-isolation` recommendations.
+Build isolation hides the binding libraries' include paths and the temporary
+build dir discards `compile_commands.json`; export a compile database from a
+persistent, non-isolated build and point your editor at it. See
+[debugging and IDE integration](#compile-commands) for the commands.
 
 (dependency-in-site-packages)=
 
@@ -225,7 +130,7 @@ Two rules keep this portable:
 - **Pin `*_OUTPUT_DIRECTORY` with an empty generator expression.** If you set
   `RUNTIME_OUTPUT_DIRECTORY` / `LIBRARY_OUTPUT_DIRECTORY` (for example to place
   a module for an
-  [inplace editable build](../configuration/index.md#editable-installs)), append
+  [inplace editable build](../configuration/editable.md#inplace-mode)), append
   `$<0:>` so multi-config generators don't add the config subdirectory back on.
   This saves setting every `*_OUTPUT_DIRECTORY_<CONFIG>` variant by hand.
 
@@ -243,91 +148,9 @@ selects Ninja by default on non-MSVC Windows.
 
 ## Shipping a library to load with `ctypes`
 
-If your package is a thin `ctypes` (or `cffi`) wrapper around a CMake-built
-shared library, rather than a compiled Python extension, the goal is to install
-the library alongside your Python code and then locate it at runtime without
-hard-coding a path. This has the nice property that a single wheel works on
-every Python version, since the library does not touch the Python ABI. The
-tradeoff is that you have to find and load the library yourself.
-
-### Install the library next to your Python code
-
-Point the install destination at your package directory so the library lands in
-`site-packages/mypackage/` next to `__init__.py`:
-
-```cmake
-install(TARGETS mylib DESTINATION mypackage)
-```
-
-The destination is relative to the platlib (`${SKBUILD_PLATLIB_DIR}`) by
-default; you can name any of the [install trees](#install-directories)
-explicitly if you need to. If you set `wheel.install-dir = "mypackage"`, then
-the destination is relative to that instead, and a bare `DESTINATION .` works.
-
-### Find it at runtime with `importlib.resources`
-
-Do **not** compute the path relative to `__file__` — that assumes the package
-lives on a real filesystem, which is not guaranteed (it could be in a zip, and
-in an editable install the Python source and the compiled library live in
-different directories). Use `importlib.resources` instead, which
-scikit-build-core's editable installs fully support:
-
-```python
-import ctypes
-import sys
-from importlib.resources import files
-
-# Pick the right suffix for the platform.
-_suffix = {"win32": ".dll", "darwin": ".dylib"}.get(sys.platform, ".so")
-_lib = files("mypackage") / f"libmylib{_suffix}"
-
-lib = ctypes.CDLL(str(_lib))
-```
-
-For the general (zip-safe) case, wrap the traversable in
-`importlib.resources.as_file`, which extracts the resource to a real path if
-necessary. Because `ctypes` needs the file to remain on disk for the lifetime of
-the process, keep the context manager open — for example with an
-`contextlib.ExitStack` closed at interpreter exit:
-
-```python
-import atexit, ctypes
-from contextlib import ExitStack
-from importlib.resources import files, as_file
-
-_files = ExitStack()
-atexit.register(_files.close)
-_lib = _files.enter_context(as_file(files("mypackage") / f"libmylib{_suffix}"))
-lib = ctypes.CDLL(str(_lib))
-```
-
-### Editable installs and rebuilds
-
-In redirect-mode editable installs (the default), `importlib.resources` finds
-the compiled library through the redirecting finder, so the code above works
-unchanged. Note that accessing a resource does **not** trigger a rebuild — plain
-libraries are not importable modules, so the automatic `editable.rebuild`
-on-import hook does not fire for them. To pick up C/C++ changes, either request
-a rebuild explicitly (this works whenever a persistent `build-dir` is set, with
-or without `editable.rebuild`)…
-
-```python
-import mypackage
-
-mypackage.__loader__.rebuild()
-```
-
-…or import a real extension module from the same project first, which does fire
-the on-import hook when `editable.rebuild` is enabled. See
-[](#triggering-a-rebuild-manually) for the details and the `build-dir`
-requirement.
-
-### Runtime search paths
-
-If your shipped library links against _other_ shared libraries, you still need
-to make those discoverable at load time (`RPATH` on Linux/macOS,
-`os.add_dll_directory` on Windows). See [](#dynamic-linking) for the full set of
-options, including wheel-repair tools.
+For a thin `ctypes`/`cffi` wrapper around a CMake-built shared library, install
+the library next to your Python code and load it via `importlib.resources`; the
+full walkthrough is in [shipping a library for ctypes](ctypes.md).
 
 ## Repairing wheels
 
@@ -343,11 +166,14 @@ recipes][]. There are a few things to keep in mind.
 
 You need to recreate your `build-system.requires` in the `host` table, with the
 conda versions of your dependencies. You also need to add `cmake` and either
-`make` or `ninja` to your `build:` table. Conda-build hard-codes
-`CMAKE_GENERATOR="Unix Makefiles"` on UNIX systems, so you have to set or unset
-this to use Ninja if you prefer Ninja. The `scikit-build-core` recipe cannot
-depend on `cmake`, `make`, or `ninja`, because that would add those to the wrong
-table (`host` instead of `build`). Here's an example:
+`make` or `ninja` to your `build:` table:
+
+```{note}
+The `scikit-build-core` recipe cannot depend on `cmake`, `make`, or `ninja`
+itself, because that would add those to the wrong table (`host` instead of
+`build`). Also, conda-build hard-codes `CMAKE_GENERATOR="Unix Makefiles"` on
+UNIX systems, so set or unset this if you prefer Ninja.
+```
 
 ```yaml
 build:
@@ -379,52 +205,9 @@ config files, Python cannot set it for you on the free-threaded variant.
 
 ## Building wheel variants (experimental)
 
-```{versionadded} 1.0
-
-```
-
-```{warning}
-This is an early preview of [PEP 817][] wheel variant support. The interface may
-change, and it must be opted into with `experimental = true`.
-```
-
-Scikit-build-core can attach variant metadata to a wheel, producing a
-variant-labeled filename (the label becomes the final field of the wheel name)
-and a `variant.json` file inside `*.dist-info`. This lets you ship several
-wheels for the same version that differ by hardware or library features (CPU
-ABI, CUDA version, BLAS implementation, etc.).
-
-Because each variant of a build needs different settings, the variant options
-are **only allowed in config-settings or `[[tool.scikit-build.overrides]]`** —
-they cannot be hard-coded at the top level of `pyproject.toml`. The relevant
-settings are:
-
-- `variant` / `variant-name`: variant properties in
-  `namespace :: feature :: value` form (repeatable).
-- `variant-label`: override the computed label used in the wheel filename.
-- `null-variant`: build the null variant (mutually exclusive with the above).
-
-When any of these are set, [`variantlib`][] is automatically injected as a build
-requirement, and the experimental flag must be enabled. For example, to build a
-CPU-ABI variant with `pip`:
-
-```bash
-pip wheel . \
-  -Cexperimental=true \
-  -Cvariant="cpu :: abi :: cp313" \
-  -Cvariant-label=cpu
-```
-
-Or to enable it for everyone via an override (still keeping the per-build values
-in config-settings), put the experimental flag in `pyproject.toml`:
-
-```toml
-[tool.scikit-build]
-experimental = true
-```
-
-Pass `-Cvariant=...` (and friends) at build time to select which variant to
-produce.
+Scikit-build-core has an early preview of [PEP 817][] wheel variant support —
+several wheels for the same version differing by hardware or library features.
+See [building wheel variants](../configuration/variants.md).
 
 [^1]:
     Due to a [bug in packaging](https://github.com/pypa/packaging/issues/160),
@@ -440,6 +223,5 @@ produce.
 
 [dozens of recipes]: https://github.com/search?type=code&q=org%3Aconda-forge+path%3Arecipe%2Fmeta.yaml+scikit-build-core
 [pep 817]: https://peps.python.org/pep-0817
-[`variantlib`]: https://github.com/wheelnext/variantlib
 
 <!-- prettier-ignore-end -->

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -69,20 +69,6 @@ This is now a subcommand of the unified `scikit-build` CLI (previously
 `python -m scikit_build_core.builder`).
 ```
 
-## Coverage and debugging (gcov / gcovr / GDB)
-
-Coverage and debug tools fail when the temporary build directory and isolated
-source copy disappear after the build; the fix is a persistent `build-dir` with
-`--no-build-isolation`. See [debugging and IDE integration](debugging.md) for
-the workflow.
-
-## IDE IntelliSense can't find headers (`compile_commands.json`)
-
-Build isolation hides the binding libraries' include paths and the temporary
-build dir discards `compile_commands.json`; export a compile database from a
-persistent, non-isolated build and point your editor at it. See
-[debugging and IDE integration](#compile-commands) for the commands.
-
 (dependency-in-site-packages)=
 
 ## A dependency's library ends up in `site-packages/bin` or `lib`
@@ -146,12 +132,6 @@ not set up the MSVC toolchain itself, so build from a Visual Studio Developer
 Command Prompt (or after running `vcvarsall.bat`). scikit-build-core already
 selects Ninja by default on non-MSVC Windows.
 
-## Shipping a library to load with `ctypes`
-
-For a thin `ctypes`/`cffi` wrapper around a CMake-built shared library, install
-the library next to your Python code and load it via `importlib.resources`; the
-full walkthrough is in [shipping a library for ctypes](ctypes.md).
-
 ## Repairing wheels
 
 Like most other backends[^1], scikit-build-core produces `linux` wheels, which
@@ -203,12 +183,6 @@ Windows currently requires a little extra care. You should set the C define
 `Py_GIL_DISABLED` on Windows; due to the way the two builds share the same
 config files, Python cannot set it for you on the free-threaded variant.
 
-## Building wheel variants (experimental)
-
-Scikit-build-core has an early preview of [PEP 817][] wheel variant support —
-several wheels for the same version differing by hardware or library features.
-See [building wheel variants](../configuration/variants.md).
-
 [^1]:
     Due to a [bug in packaging](https://github.com/pypa/packaging/issues/160),
     some backends may mistakenly produce the wrong tags (including
@@ -222,6 +196,5 @@ See [building wheel variants](../configuration/variants.md).
 <!-- prettier-ignore-start -->
 
 [dozens of recipes]: https://github.com/search?type=code&q=org%3Aconda-forge+path%3Arecipe%2Fmeta.yaml+scikit-build-core
-[pep 817]: https://peps.python.org/pep-0817
 
 <!-- prettier-ignore-end -->

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -3,22 +3,10 @@
 ## Starting a new project
 
 The quickest way is the built-in `init` command:
-`scikit-build init --backend pybind11 myproject` scaffolds a ready-to-build
-project (run without `--backend` to pick a binding interactively). See the
-[getting started guide](getting_started.md) for a walkthrough of what it
-generates.
-
-```{versionadded} 1.0
-The `scikit-build init` command.
-```
-
-For a fully-featured project layout, use the [Scientific Python cookie][], which
-makes a new project following the [Scientific Python Development Guidelines][].
-Scikit-build-core is one of the backends you can select. The project will have a
-lot of tooling prepared for you as well, including pre-commit checks and a
-noxfile; be sure to read the guidelines to see what is there and how it works.
-
-Another option is the [pybind11 example][].
+`scikit-build init --backend pybind11 myproject`. See the
+[quick start](getting_started.md#quick-start) for it and the other scaffolding
+options (Scientific Python cookie, uv, buildgen), and the rest of that guide for
+a walkthrough of what it generates.
 
 ## Multithreaded builds
 
@@ -39,21 +27,8 @@ to run in parallel with the number of cores on your machine.
 
 If your project has historically used a different environment variable (such as
 `MAX_JOBS`) to control this, you can forward it to `CMAKE_BUILD_PARALLEL_LEVEL`
-with the `[tool.scikit-build.env]` table:
-
-```toml
-[tool.scikit-build.env]
-CMAKE_BUILD_PARALLEL_LEVEL = { env = "MAX_JOBS" }
-```
-
-A directly-set `CMAKE_BUILD_PARALLEL_LEVEL` still wins, since `env` entries use
-`setdefault` semantics unless `force = true` is given. See
-[](../configuration/index.md#environment-variables-for-the-build) for the full
-`env` table reference, including selecting a compiler and setting search paths.
-
-```{versionadded} 1.0
-The `[tool.scikit-build.env]` table.
-```
+with the `[tool.scikit-build.env]` table; see
+[](../configuration/index.md#environment-variables-for-the-build).
 
 ## Dynamic setup.py options
 
@@ -66,14 +41,10 @@ you need, please open an issue and let us know.
 
 ## Finding Python
 
-When using `find_package(Python ...)`, you should only request the
-`Development.Module` component. If you request `Development`, you will also
-require the `Development.Embed` component, which will require the Python
-libraries to be found for linking. When building a module on Unix, you do not
-link to Python - the Python symbols are already loaded in the interpreter.
-What's more, the manylinux image (which is used to make redistributable Linux
-wheels) does not have the Python libraries, both to avoid this mistake, and to
-reduce size.
+When using `find_package(Python ...)`, only request the `Development.Module`
+component, not `Development`; see [Finding Python](cmakelists.md#finding-python)
+for the details (in short: `Development` also requires the embedding libraries,
+which manylinux images intentionally do not ship).
 
 ## Cross compiling
 
@@ -207,6 +178,8 @@ extension, set
 See [editable installs](../configuration/index.md#editable-installs) for the
 related `--no-build-isolation` recommendations.
 
+(dependency-in-site-packages)=
+
 ## A dependency's library ends up in `site-packages/bin` or `lib`
 
 If you build a shared dependency as part of your project (for example via
@@ -224,6 +197,8 @@ into your package directory and add the runtime hints yourself, or run a
 wheel-repair tool. See [](#dynamic-linking) for all of the options.
 
 [GNUInstallDirs]: inv:cmake:cmake:module#module:GNUInstallDirs
+
+(msvc-multi-config)=
 
 ## Target output paths differ on MSVC (multi-config generators)
 
@@ -463,9 +438,6 @@ produce.
 
 <!-- prettier-ignore-start -->
 
-[scientific python cookie]: https://github.com/scientific-python/cookie
-[scientific python development guidelines]: https://learn.scientific-python.org/development
-[pybind11 example]: https://github.com/pybind/scikit_build_example
 [dozens of recipes]: https://github.com/search?type=code&q=org%3Aconda-forge+path%3Arecipe%2Fmeta.yaml+scikit-build-core
 [pep 817]: https://peps.python.org/pep-0817
 [`variantlib`]: https://github.com/wheelnext/variantlib

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -36,21 +36,10 @@ There are several mechanisms to quickly get started with a package:
 The `scikit-build init` command.
 ```
 
-For the rest of this page, however, we will show you how to get set up from
-scratch.
-
 ## Writing an extension
-
-```{tip}
-The fastest way to lay these files out is `scikit-build init --backend pybind11`
-(or any backend below), which generates exactly the project shown here. Read on
-to understand each piece.
-```
 
 We will be writing these files:
 
-````{tab} pybind11
-
 ```
 example
 ├── pyproject.toml
@@ -58,116 +47,16 @@ example
 └── src
     └── example
         ├── __init__.py
-        └── _core.cpp
+        └── _core.*
 ```
 
-````
-
-````{tab} nanobind
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.cpp
-```
-
-````
-
-````{tab} SWIG
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        ├── _core.c
-        └── _core.i
-```
-
-````
-
-````{tab} Cython
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.pyx
-```
-
-````
-
-````{tab} C
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.c
-```
-
-````
-
-````{tab} ABI3
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.c
-```
-
-````
-
-````{tab} ABI3t
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.c
-```
-
-````
-
-````{tab} Fortran
-
-```
-example
-├── pyproject.toml
-├── CMakeLists.txt
-└── src
-    └── example
-        ├── __init__.py
-        └── _core.f
-```
-
-````
+The `_core.*` source suffix depends on the language you pick below (`.cpp`,
+`.c`, `.pyx`, or `.f`); SWIG additionally has a `_core.i` interface file.
 
 ### Source code
 
-For this tutorial, you can either write a C extension yourself, or you can use
-pybind11 and C++. Select your preferred version using the tabs - compare them!
 The compiled extension is built as `_core` and lives inside the `example`
-package at `src/example/_core.*`.
+package at `src/example/_core.*`. Select your binding tool using the tabs:
 
 ````{tab} pybind11
 
@@ -247,6 +136,8 @@ than reaching into `example._core`:
 :language: python
 ```
 
+(python-package-configuration)=
+
 ### Python package configuration
 
 To create your first compiled package, start with a pyproject.toml like this:
@@ -314,13 +205,8 @@ To create your first compiled package, start with a pyproject.toml like this:
 ```
 
 ```{warning}
-The module you build will require an equal or newer version of NumPy at runtime
-than the version it built with. The modern approach is to build against
-`numpy>=2.0`; NumPy 2.0 wheels are backward-compatible at the C ABI level, so a
-module built against NumPy 2.0 keeps working with older NumPy at runtime. Add a
-runtime floor (in `[project]` `dependencies`) only if your code needs newer NumPy
-features. Also it's hard to compile Fortran on Windows as it's not supported by
-MSVC and macOS as it's not supported by Clang.
+Fortran is hard to compile on Windows and macOS, as it is supported by neither
+MSVC nor Clang; you'll need a separate toolchain like gfortran.
 ```
 
 ````
@@ -339,22 +225,30 @@ a package, but this is enough to start for now. The
 page covers what keys are available. Another example is available at
 [the Scientific Python Library Development Guide](https://learn.scientific-python.org/development/guides).
 
+```{note}
+If your extension builds against NumPy, build against `numpy>=2.0`: NumPy 2.0
+wheels are backward-compatible at the C ABI level, so a module built against
+2.0 keeps working with older NumPy at runtime. Add a runtime floor in
+`[project]` `dependencies` only if your code needs newer NumPy features.
+```
+
+(cmake-file)=
+
 ### CMake file
 
-Now, you'll need a file called `CMakeLists.txt`. This one will do:
+Now, you'll need a file called `CMakeLists.txt`. A few things are common to
+every version below: scikit-build-core requires CMake 3.15, so there's no need
+to set `cmake_minimum_required` lower than that. The `project()` line can
+optionally use the `SKBUILD_PROJECT_NAME` and `SKBUILD_PROJECT_VERSION`
+variables to avoid repeating information from your `pyproject.toml`, and should
+specify exactly what language you use to keep CMake from searching for both `C`
+and `CXX` compilers (the default).
 
 ````{tab} pybind11
 
 ```{literalinclude} ../examples/generated/pybind11/CMakeLists.txt
 :language: cmake
 ```
-
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
 
 If you place find Python first, pybind11 will respect it instead of the older
 FindPythonInterp/FindPythonLibs mechanisms, which work, but are not as modern.
@@ -373,14 +267,6 @@ to `pybind11::module`, your choice.
 :language: cmake
 ```
 
-Scikit-build and nanobind require CMake 3.15, so there's no need to set it
-lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
-
 Nanobind places its config file such that CMake can find it from site-packages.
 ````
 
@@ -389,13 +275,6 @@ Nanobind places its config file such that CMake can find it from site-packages.
 ```{literalinclude} ../examples/generated/swig/CMakeLists.txt
 :language: cmake
 ```
-
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
 
 You'll need to handle the generation of files by SWIG directly.
 
@@ -406,13 +285,6 @@ You'll need to handle the generation of files by SWIG directly.
 ```{literalinclude} ../examples/generated/cython/CMakeLists.txt
 :language: cmake
 ```
-
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
 
 [cython-cmake][] provides the `cython_transpile` helper (via `include(UseCython)`)
 that turns your `.pyx` file into a C source you can pass to `python_add_library`.
@@ -425,13 +297,6 @@ Add it to your build requirements as shown in the pyproject.toml above.
 ```{literalinclude} ../examples/generated/c/CMakeLists.txt
 :language: cmake
 ```
-
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
 
 `find_package(Python ...)` should always include the `Development.Module`
 component instead of `Development`; the latter breaks if the embedding
@@ -450,13 +315,6 @@ without it).
 :language: cmake
 ```
 
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
-
 `find_package(Python ...)` needs `Development.SABIModule` for ABI3 extensions.
 
 You'll want `WITH_SOABI` when you make the module. You'll also need to set the `USE_SABI`
@@ -464,8 +322,8 @@ argument to the minimum version to build with. This will also add a proper
 PRIVATE define of `Py_LIMITED_API` for you.
 
 ```{note}
-This will not support pypy, so you'll want to provide an alternative if you
-support PyPy).
+This will not support PyPy, so you'll want to provide an alternative if you
+support PyPy.
 ```
 
 ````
@@ -504,13 +362,6 @@ classic single-phase `PyInit_` entry point cannot be used.
 :language: cmake
 ```
 
-Scikit-build requires CMake 3.15, so there's no need to set it lower than 3.15.
-
-The project line can optionally use `SKBUILD_PROJECT_NAME` and
-`SKBUILD_PROJECT_VERSION` variables to avoid repeating this information from
-your `pyproject.toml`. You should specify exactly what language you use to keep
-CMake from searching for both `C` and `CXX` compilers (the default).
-
 [f2py-cmake][] provides the `f2py_add_module` helper (via `include(UseF2Py)`)
 that generates the f2py wrappers, builds the `fortranobject` support code, and
 links it all into an importable module in a single call. Add it to your build
@@ -532,16 +383,14 @@ That's it! You can try building it:
 $ pipx run build
 ```
 
-[pipx](https://pipx.pypa.io) allows you to install and run Python applications
-in isolated environments.
-
 Or installing it (in a virtualenv, ideally):
 
 ```console
 $ pip install .
 ```
 
-That's it for a basic package!
+The [build guide](build.md) covers all the frontends and options for building,
+installing, and distributing your package.
 
 <!-- prettier-ignore-start -->
 [INTERSECT Training: Packaging]:     https://intersect-training.org/packaging

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -40,6 +40,8 @@ The `scikit-build init` command.
 
 We will be writing these files:
 
+````{tab} pybind11
+
 ```
 example
 ├── pyproject.toml
@@ -47,11 +49,109 @@ example
 └── src
     └── example
         ├── __init__.py
-        └── _core.*
+        └── _core.cpp
 ```
 
-The `_core.*` source suffix depends on the language you pick below (`.cpp`,
-`.c`, `.pyx`, or `.f`); SWIG additionally has a `_core.i` interface file.
+````
+
+````{tab} nanobind
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.cpp
+```
+
+````
+
+````{tab} SWIG
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        ├── _core.c
+        └── _core.i
+```
+
+````
+
+````{tab} Cython
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.pyx
+```
+
+````
+
+````{tab} C
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.c
+```
+
+````
+
+````{tab} ABI3
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.c
+```
+
+````
+
+````{tab} ABI3t
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.c
+```
+
+````
+
+````{tab} Fortran
+
+```
+example
+├── pyproject.toml
+├── CMakeLists.txt
+└── src
+    └── example
+        ├── __init__.py
+        └── _core.f
+```
+
+````
 
 ### Source code
 
@@ -224,13 +324,6 @@ a package, but this is enough to start for now. The
 [project metadata specification](https://packaging.python.org/en/latest/specifications/pyproject-toml)
 page covers what keys are available. Another example is available at
 [the Scientific Python Library Development Guide](https://learn.scientific-python.org/development/guides).
-
-```{note}
-If your extension builds against NumPy, build against `numpy>=2.0`: NumPy 2.0
-wheels are backward-compatible at the C ABI level, so a module built against
-2.0 keeps working with older NumPy at runtime. Add a runtime floor in
-`[project]` `dependencies` only if your code needs newer NumPy features.
-```
 
 (cmake-file)=
 

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -299,9 +299,8 @@ Add it to your build requirements as shown in the pyproject.toml above.
 ```
 
 `find_package(Python ...)` should always include the `Development.Module`
-component instead of `Development`; the latter breaks if the embedding
-components are missing, such as when you are building redistributable wheels on
-Linux.
+component instead of `Development`; see
+[Finding Python](cmakelists.md#finding-python).
 
 You'll want `WITH_SOABI` when you make the module to ensure the full extension
 is included on Unix systems (PyPy won't even be able to open the extension
@@ -377,20 +376,15 @@ would instead drop a single top-level extension into `site-packages`.
 
 ### Building and installing
 
-That's it! You can try building it:
-
-```console
-$ pipx run build
-```
-
-Or installing it (in a virtualenv, ideally):
+That's it! You can install your package with any standard frontend; for example,
+in a virtualenv:
 
 ```console
 $ pip install .
 ```
 
-The [build guide](build.md) covers all the frontends and options for building,
-installing, and distributing your package.
+The [build guide](build.md) covers all the frontends (pip, uv, `pipx run build`)
+and the options for building, installing, and distributing your package.
 
 <!-- prettier-ignore-start -->
 [INTERSECT Training: Packaging]:     https://intersect-training.org/packaging

--- a/docs/guide/going_further.md
+++ b/docs/guide/going_further.md
@@ -1,0 +1,17 @@
+# Going further
+
+Topic guides that build on the basics: shipping and linking shared libraries,
+cross-compiling, migrating from scikit-build classic, the build procedure in
+depth, monorepo layouts, and debugging your builds.
+
+```{toctree}
+:maxdepth: 1
+
+dynamic_link
+ctypes
+crosscompile
+migration_guide
+build
+workspaces
+debugging
+```

--- a/docs/guide/migration_guide.md
+++ b/docs/guide/migration_guide.md
@@ -7,8 +7,8 @@
 - Replace `scikit-build` with `scikit-build-core` in `build-system.requires`.
 - You should remove `cmake` and `ninja` from `build-system.requires`;
   scikit-build-core adds them only when necessary (see
-  [getting started](getting_started.md#python-package-configuration)). Instead,
-  set minimum required versions with `cmake.version` and `ninja.version` in the
+  [getting started](#python-package-configuration)). Instead, set minimum
+  required versions with `cmake.version` and `ninja.version` in the
   `[tool.scikit-build]` table.
 - You must fill out the `tool.scikit-build` table in pyproject.toml, see
   [getting started](getting_started.md) for more information.
@@ -56,12 +56,14 @@ python_add_library(${LIBRARY} MODULE WITH_SOABI ${FILENAME})
 
 - The UseCython CMake module distributed with scikit-build (classic) is replaced
   by the standalone [cython-cmake][] package; see the Cython tab in
-  [getting started](getting_started.md#cmake-file) for an example.
+  [getting started](#cmake-file) for an example.
 
 [cython-cmake]: https://github.com/scikit-build/cython-cmake
 
 - The `SKBUILD_CONFIGURE_OPTIONS` environment variable is now named
-  `SKBUILD_CMAKE_ARGS` for consistency.
+  `SKBUILD_CMAKE_ARGS` for consistency (the
+  [setuptools wrapper shim](../plugins/setuptools.md) is the one exception that
+  still honors the old name).
 - The `SKBUILD_BUILD_OPTIONS` environment variable is not supported. Some
   specific features are accessible using alternative variables. In particular,
   use `CMAKE_BUILD_PARALLEL_LEVEL` or `SKBUILD_BUILD_VERBOSE` to control build

--- a/docs/guide/migration_guide.md
+++ b/docs/guide/migration_guide.md
@@ -5,12 +5,11 @@
 - The `build-system.build-backend` key in pyproject.toml must be changed to
   `scikit_build_core.build`.
 - Replace `scikit-build` with `scikit-build-core` in `build-system.requires`.
-- You should remove `cmake` and `ninja` from `build-system.requires`.
-  `scikit-build-core` will add these if necessary, but will respect existing
-  installations of the tools by default, which allows compatibility with systems
-  where binaries are not available on PyPI but can be installed from elsewhere.
-  Instead, set the minimum required versions in the `[tool.scikit-build]` table:
-  `cmake.minimum-version` and `ninja.minimum-version`.
+- You should remove `cmake` and `ninja` from `build-system.requires`;
+  scikit-build-core adds them only when necessary (see
+  [getting started](getting_started.md#python-package-configuration)). Instead,
+  set minimum required versions with `cmake.version` and `ninja.version` in the
+  `[tool.scikit-build]` table.
 - You must fill out the `tool.scikit-build` table in pyproject.toml, see
   [getting started](getting_started.md) for more information.
 - If your project is primarily configured using setup.py or setup.cfg, you will
@@ -18,15 +17,19 @@
   [project metadata spec](https://packaging.python.org/en/latest/specifications/pyproject-toml)
   shows the information that can be placed directly in the project table. For
   additional metadata, see [our configuration guide](../configuration/index.md).
-  A useful trick for performing this migration is to change the `build-backend`
-  from `skbuild` to `setuptools`, install `hatch`, and run `hatch new --init`.
-  This should automatically migrate the configuration to pyproject.toml, after
-  which you can change the `build-backend` to `scikit-build-core`.
-- If you specify files to include in sdists via MANIFEST.in, with
-  `scikit-build-core` you should now instead use the `sdist.include` and
-  `sdist.exclude` fields in the `tool.scikit-build` table. Note that
-  scikit-build-core uses all non `.gitignore`'d files by default, so this is
+- If you specify files to include in sdists via MANIFEST.in, use the
+  `sdist.include` and `sdist.exclude` settings instead (see
+  [source file inclusion](../configuration/index.md#configuring-source-file-inclusion)).
+  Scikit-build-core uses all non `.gitignore`'d files by default, so this is
   often minimal or not needed.
+
+```{tip}
+A useful trick for migrating setup.py/setup.cfg configuration is to change the
+`build-backend` from `skbuild` to `setuptools`, install `hatch`, and run
+`hatch new --init`. This automatically migrates the configuration to
+pyproject.toml, after which you can change the `build-backend` to
+`scikit_build_core.build`.
+```
 
 ## CMake changes
 
@@ -52,8 +55,8 @@ python_add_library(${LIBRARY} MODULE WITH_SOABI ${FILENAME})
 ```
 
 - The UseCython CMake module distributed with scikit-build (classic) is replaced
-  by the standalone [cython-cmake][] package (`include(UseCython)`). See
-  [our getting started guide](getting_started.md) for an example.
+  by the standalone [cython-cmake][] package; see the Cython tab in
+  [getting started](getting_started.md#cmake-file) for an example.
 
 [cython-cmake]: https://github.com/scikit-build/cython-cmake
 

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -8,9 +8,9 @@ into the shared environment through the standard PEP 517/660 build hooks.
 
 Scikit-build-core needs no special support for this: a workspace member that
 builds with scikit-build-core is simply an editable install, so everything on
-the [editable installs](../configuration/index.md#editable-installs) page
-applies unchanged. This page collects the few things worth knowing when several
-such members live side by side.
+the [editable installs](../configuration/editable.md) page applies unchanged.
+This page collects the few things worth knowing when several such members live
+side by side.
 
 ## Rebuilding after C++/CMake edits (uv)
 
@@ -40,12 +40,12 @@ list. uv now reruns the build whenever any matched file changes.
 
 ### Option 2: let scikit-build-core rebuild on import
 
-Enable [`editable.rebuild`](../configuration/index.md#editable-installs) with a
-persistent `build-dir`. The member is then rebuilt on import, which makes the
-frontend's caching moot — you never rely on uv noticing a source change. The
-rebuild shim shells out to `cmake` directly and does **not** import
-scikit-build-core, so it works even though uv builds members with isolation; it
-only needs `cmake` on `PATH` at import time.
+Enable [`editable.rebuild`](../configuration/editable.md) with a persistent
+`build-dir`. The member is then rebuilt on import, which makes the frontend's
+caching moot — you never rely on uv noticing a source change. The rebuild shim
+shells out to `cmake` directly and does **not** import scikit-build-core, so it
+works even though uv builds members with isolation; it only needs `cmake` on
+`PATH` at import time.
 
 You can set this per member in `pyproject.toml`:
 
@@ -55,9 +55,9 @@ build-dir = "build/{wheel_tag}"
 editable.rebuild = true
 ```
 
-See [editable installs](../configuration/index.md#editable-installs) for the
-full set of options (verbosity, manual `__loader__.rebuild()`, inplace mode, and
-the newer `editable.rebuild-dir`).
+See [editable installs](../configuration/editable.md) for the full set of
+options (verbosity, manual `__loader__.rebuild()`, inplace mode, and the newer
+`editable.rebuild-dir`).
 
 ## Per-member configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,18 +38,11 @@ guide/faqs
 ```
 
 ```{toctree}
-:maxdepth: 1
+:maxdepth: 2
 :titlesonly:
 :caption: Configuration
 
 configuration/index
-configuration/editable
-configuration/overrides
-configuration/dynamic
-configuration/formatted
-configuration/search_paths
-configuration/entrypoint_config
-configuration/variants
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,10 +28,12 @@ time). Some of our past meeting minutes are
 guide/getting_started
 guide/cmakelists
 guide/dynamic_link
+guide/ctypes
 guide/crosscompile
 guide/migration_guide
 guide/build
 guide/workspaces
+guide/debugging
 guide/faqs
 ```
 
@@ -41,11 +43,13 @@ guide/faqs
 :caption: Configuration
 
 configuration/index
+configuration/editable
 configuration/overrides
 configuration/dynamic
 configuration/formatted
 configuration/search_paths
 configuration/entrypoint_config
+configuration/variants
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,16 @@
 # Scikit-build-core
 
-[Scikit-build-core][] is a complete ground-up rewrite of scikit-build on top of
-modern packaging APIs. It provides a bridge between CMake and the Python build
-system, allowing you to make Python modules with CMake.
+[Scikit-build-core][] is the build backend for making Python modules with CMake.
 
-:::{admonition} Scikit-build community meeting
+```{admonition} Scikit-build community meeting
+:class: note
 
 We have a public Scikit-build community meeting every month!
 [Join us on Google Meet](https://meet.google.com/tgz-umhu-onf) on the third
 Friday of every month at [12:00 PM ET][] (<span id="meeting-time"></span> your
 time). Some of our past meeting minutes are
 [available here](https://github.com/orgs/scikit-build/discussions/categories/community-meeting-notes).
-
-:::
+```
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,13 +27,7 @@ time). Some of our past meeting minutes are
 
 guide/getting_started
 guide/cmakelists
-guide/dynamic_link
-guide/ctypes
-guide/crosscompile
-guide/migration_guide
 guide/build
-guide/workspaces
-guide/debugging
 guide/faqs
 ```
 
@@ -43,6 +37,10 @@ guide/faqs
 :caption: Configuration
 
 configuration/index
+configuration/editable
+configuration/overrides
+configuration/dynamic
+configuration/advanced
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ time). Some of our past meeting minutes are
 
 guide/getting_started
 guide/cmakelists
-guide/build
+guide/going_further
 guide/faqs
 ```
 

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -17,9 +17,9 @@ separate package in the future.
 :::{versionchanged} 1.0
 
 The plugin is no longer experimental (the `experimental = true` toggle is not
-required), [editable installs](../configuration/index.md#editable-installs) are
-supported, and the `[hatchling]` extra is the recommended way to depend on it
-(warning shown if missing).
+required), [editable installs](../configuration/editable.md) are supported, and
+the `[hatchling]` extra is the recommended way to depend on it (warning shown if
+missing).
 
 :::
 

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -17,8 +17,9 @@ separate package in the future.
 :::{versionchanged} 1.0
 
 The plugin is no longer experimental (the `experimental = true` toggle is not
-required), editable installs are supported, and the `[hatchling]` extra is the
-recommended way to depend on it (warning shown if missing).
+required), [editable installs](../configuration/index.md#editable-installs) are
+supported, and the `[hatchling]` extra is the recommended way to depend on it
+(warning shown if missing).
 
 :::
 

--- a/docs/plugins/hatchling.md
+++ b/docs/plugins/hatchling.md
@@ -16,9 +16,9 @@ separate package in the future.
 
 :::{versionchanged} 1.0
 
-The plugin is no longer experimental (the `experimental = true` toggle is no
-longer required), editable installs are supported, and the `[hatchling]` extra
-is the recommended way to depend on it (warning shown if missing).
+The plugin is no longer experimental (the `experimental = true` toggle is not
+required), editable installs are supported, and the `[hatchling]` extra is the
+recommended way to depend on it (warning shown if missing).
 
 :::
 
@@ -30,7 +30,7 @@ get `cmake` and `ninja` auto-added if needed, and 1.24 if you want to write out
 custom scripts, metadata, or shared data.
 
 You need a `tool.hatch.build.targets.wheel.hooks.scikit-build` section to
-activate the plugin. It was added in 0.9.
+activate the plugin.
 
 ```toml
 [build-system]

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -83,9 +83,7 @@ possible.
 
 All other configuration is available as normal `tool.scikit-build` in
 `pyproject.toml` or environment variables as applicable. Config-settings is
-_not_ supported, as setuptools has very poor support for config-settings. The
-build hook might pre-process options in the future, but it's tricky to pass them
-through, so it will likely require use cases to be presented.
+_not_ supported, as setuptools has very poor support for config-settings.
 
 For classic scikit-build compatibility, two environment variables are honored,
 but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -122,8 +122,9 @@ editable.mode = "inplace"
 The setuptools plugin follows setuptools' editable-wheel mechanism, so editable
 builds place CMake-installed extension modules into the source layout that
 setuptools exposes via its `.pth` file. This is effectively the setuptools
-equivalent of scikit-build-core's `inplace` editable mode, so redirect mode is
-not supported here.
+equivalent of scikit-build-core's
+[`inplace` editable mode](../configuration/index.md#editable-installs), so
+redirect mode is not supported here.
 
 Because of that, `editable.rebuild` is not supported in setuptools mode.
 

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -123,7 +123,7 @@ The setuptools plugin follows setuptools' editable-wheel mechanism, so editable
 builds place CMake-installed extension modules into the source layout that
 setuptools exposes via its `.pth` file. This is effectively the setuptools
 equivalent of scikit-build-core's
-[`inplace` editable mode](../configuration/index.md#editable-installs), so
+[`inplace` editable mode](../configuration/editable.md#inplace-mode), so
 redirect mode is not supported here.
 
 Because of that, `editable.rebuild` is not supported in setuptools mode.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A three-part cleanup of the docs (net −305 lines while adding four pages), from a full review pass:

- **In-place dedup and polish**: repeated prose consolidated (getting-started CMake boilerplate was in 6 of 8 tabs, dynamic.md explained the legacy metadata table five times, build.md had twin SDist/Wheel hook lists), platform sections and more settings converted to tabs/`conf-tabs`, condition and `py-api` walls of prose converted to tables, asides moved into admonitions. Also fixes outdated `cmake.minimum-version` advice in the migration guide.
- **Page ownership**: topics that were told in full on 2–3 pages (wheel repair, Finding Python, `SKBUILD_*_DIR` trees, parallel builds) now have one owning page; other mentions shrink to a sentence + crosslink, with reciprocal see-also links added.
- **Structural moves**: new pages `guide/ctypes.md`, `guide/debugging.md` (coverage + IDE IntelliSense merged around their shared root cause), `configuration/editable.md`, and `configuration/variants.md` — the FAQ shrinks to true Q&A stubs and the configuration guide no longer links into the FAQ for feature docs.

Old external deep links to moved sections are not redirected (discussed; intentional). Docs build warning-free from a clean tree.