### PR TITLE
feat: harden downstream A/B harness for real-world projects

### DIFF
--- a/.agents/skills/test-downstream/SKILL.md
+++ b/.agents/skills/test-downstream/SKILL.md
@@ -71,11 +71,15 @@ Each entry has:
 pypi = "iminuit"            # what the user is likely to say
 github = "scikit-hep/iminuit"   # -> https://github.com/scikit-hep/iminuit
 path = "awkward-cpp/pyproject.toml"   # optional -> --subdir awkward-cpp
+requires = ["hatch-fancy-pypi-readme"]  # optional -> --requires (repeatable)
+prepare = "nox -s prepare"    # optional -> --prepare (repo-local prep command)
 ```
 
 - The `project` argument to nox is a git URL: `https://github.com/<github>`.
 - If `path` is present, pass `--subdir <dirname of path>` (strip the trailing
   `/pyproject.toml`).
+- If `requires` is present, forward each as `--requires <pkg>`.
+- If `prepare` is present, forward it as `--prepare "<command>"`.
 
 If the user gives a full URL or local path, use it directly. If a named project
 isn't in the list, use the obvious GitHub URL and mention it wasn't in the
@@ -99,6 +103,16 @@ Useful options (all forwarded to `nox -s downstream`):
 - `--subdir DIR` — build a subdirectory (from `path` in projects.toml).
 - `-C key=val` — a config-setting, repeatable (e.g. `-C cmake.verbose=true`).
 - `-c "import foo; foo.test()"` — import/smoke check, editable mode only.
+- `--requires PKG` — extra package to install into the build env, repeatable.
+  Use for a scikit-build-core dynamic-metadata provider a project needs but
+  doesn't list in `build-system.requires` (e.g. ninja needs
+  `--requires hatch-fancy-pypi-readme`, or editable mode fails to find the
+  provider). See the safety rule below before using it for system packages.
+- `--prepare "CMD"` — a repo-local prep command run once in the clone root
+  before configure (and before any `--subdir` chdir). Use for generated sources,
+  e.g. awkward-cpp (built from the `awkward-cpp/` subdir) needs the parent
+  repo's `--prepare "nox -s prepare"` to produce kernel headers, or CMake fails
+  early. **Not for mutating the host** — see below.
 - `--mode build` or `--mode editable` — run just one mode instead of both.
 - `extra` positional args are forwarded to `git clone` (e.g. `--branch v2`).
 - `--keep` — keep the baseline worktree for inspection; `--out DIR` — choose the
@@ -167,6 +181,19 @@ parallel runs don't clobber one another.
 `--editable` switches to `pip install -e`; `-c CODE` runs a Python snippet after
 an editable install (it errors in build mode). Built wheels land under
 `.nox/downstream/tmp/<slug>/[subdir]/dist/`.
+
+## Safety: `--prepare` must not mutate the host
+
+`--prepare` is for **repo-local** prep only — generating sources, running a
+project's own `nox -s prepare`, and similar steps scoped to the clone. In normal
+use it must never mutate the host system.
+
+**Do NOT run host-mutating commands (`brew install`, `apt-get install`, `sudo`,
+etc.) via `--prepare` unless this skill is running inside a container.** Some
+projects need system libraries (e.g. spherely needs `s2`); installing those is
+only acceptable in a disposable containerized run, never on a developer's
+machine. If a project needs a system package and you are not in a container, say
+so and stop — do not install it.
 
 ## Things that bite
 

--- a/.agents/skills/test-downstream/scripts/downstream_ab.py
+++ b/.agents/skills/test-downstream/scripts/downstream_ab.py
@@ -119,6 +119,8 @@ def nox_downstream(
     subdir: str | None,
     config_settings: list[str],
     code: str | None,
+    requires: list[str],
+    prepare: str | None,
     extra: list[str],
     logpath: Path,
 ) -> int:
@@ -132,6 +134,10 @@ def nox_downstream(
             posargs += ["-c", code]
     for c in config_settings:
         posargs += ["-C", c]
+    for r in requires:
+        posargs += ["--requires", r]
+    if prepare:
+        posargs += ["--prepare", prepare]
     posargs += extra
     cmd = ["nox", "-s", "downstream", "--", *posargs]
 
@@ -188,6 +194,18 @@ def main() -> int:
     p.add_argument("-C", dest="config_settings", action="append", default=[])
     p.add_argument("-c", dest="code", help="import check code (editable mode only)")
     p.add_argument(
+        "--requires",
+        action="append",
+        default=[],
+        help="extra package(s) to install into the build env (repeatable), "
+        "e.g. a dynamic-metadata provider like hatch-fancy-pypi-readme",
+    )
+    p.add_argument(
+        "--prepare",
+        help="repo-local prep command run in the clone root before the build "
+        "(e.g. 'nox -s prepare'); see SKILL.md for the container safety rule",
+    )
+    p.add_argument(
         "--repo", type=Path, help="scikit-build-core repo (default: git root of cwd)"
     )
     p.add_argument(
@@ -234,6 +252,8 @@ def main() -> int:
                     subdir=args.subdir,
                     config_settings=args.config_settings,
                     code=args.code,
+                    requires=args.requires,
+                    prepare=args.prepare,
                     extra=args.extra,
                     logpath=out / f"{label}-{mode}.log",
                 )

--- a/docs/data/projects.toml
+++ b/docs/data/projects.toml
@@ -18,6 +18,8 @@ github = "Freed-Wu/astyle-wheel"
 pypi = "awkward-cpp"
 github = "scikit-hep/awkward"
 path = "awkward-cpp/pyproject.toml"
+# Built from a subdir; the parent repo generates kernel headers first.
+prepare = "nox -s prepare"
 
 [[project]]
 pypi = "boost-histogram"
@@ -148,6 +150,8 @@ github = "mctools/ncrystal"
 [[project]]
 pypi = "ninja"
 github = "scikit-build/ninja-python-distributions"
+# Uses a scikit-build-core dynamic-metadata provider not in build-system.requires.
+requires = ["hatch-fancy-pypi-readme"]
 
 [[project]]
 pypi = "nodejs-wheel"

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import shlex
 import shutil
 import sys
 import urllib.request
@@ -263,6 +265,23 @@ def test_doc_examples(session: nox.Session, example: str) -> None:
     session.run("pytest")
 
 
+def downstream_dir_name(project: str) -> str:
+    """
+    Deterministic, filesystem-safe clone-dir name for a project spec.
+
+    Handles URLs (``https://github.com/org/repo``), scp-style git remotes
+    (``git@github.com:org/repo.git``), and local paths. Runs of characters
+    outside ``[A-Za-z0-9._-]`` collapse to a single ``_`` and a trailing
+    ``.git`` is dropped, so re-runs of the same project map to the same dir
+    (the session does ``git pull`` when it already exists). Crucially the
+    result contains no ``:`` -- an embedded colon confuses ``pyproject_hooks``
+    when it splits a project's ``backend-path``.
+    """
+    name = re.sub(r"\.git$", "", project)
+    name = re.sub(r"[^A-Za-z0-9._-]+", "_", name)
+    return name.strip("_")
+
+
 @nox.session(default=False)
 def downstream(session: nox.Session) -> None:
     """
@@ -281,10 +300,20 @@ def downstream(session: nox.Session) -> None:
     )
     parser.add_argument("-c", dest="code", help="Run some Python code")
     parser.add_argument("-C", help="config-settings", action="append", default=[])
+    parser.add_argument(
+        "--requires",
+        action="append",
+        default=[],
+        help="Extra package(s) to install into the no-isolation env (repeatable)",
+    )
+    parser.add_argument(
+        "--prepare",
+        help="Shell command to run in the repo root before the build (e.g. 'nox -s prepare')",
+    )
     args, remaining = parser.parse_known_args(session.posargs)
 
     tmp_dir = Path(session.create_tmp())
-    proj_dir = tmp_dir / "_".join(args.project.split("/"))
+    proj_dir = tmp_dir / downstream_dir_name(args.project)
 
     session.install("build", "hatch-vcs", "hatchling")
     session.install(".", "--no-build-isolation")
@@ -304,7 +333,16 @@ def downstream(session: nox.Session) -> None:
         )
         session.chdir(proj_dir)
 
-    # Read and strip requirements
+    # Repo-local prep (e.g. generating headers) runs at the clone root, before
+    # any --subdir chdir, since it often lives in the parent repo.
+    if args.prepare:
+        session.run(*shlex.split(args.prepare), external=True)
+
+    # Read and strip requirements from the build pyproject.toml. For subdir
+    # projects that lives in the subdir, so chdir there first.
+    if args.subdir:
+        session.chdir(args.subdir)
+
     pyproject = nox.project.load_toml("pyproject.toml")
     requires = [
         x
@@ -317,9 +355,8 @@ def downstream(session: nox.Session) -> None:
         requires.append("cmake")
     if requires:
         session.install(*requires)
-
-    if args.subdir:
-        session.chdir(args.subdir)
+    if args.requires:
+        session.install(*args.requires)
 
     if args.editable:
         session.install("-e.", "--no-build-isolation")

--- a/tests/test_noxfile_downstream.py
+++ b/tests/test_noxfile_downstream.py
@@ -72,7 +72,7 @@ def test_downstream_dir_name(project: str, expected: str) -> None:
 
 
 def test_downstream_dir_name_has_no_colon() -> None:
-    # Regression: an embedded ':' made pyproject_hooks mis-split backend-path.
+    # Regression: an embedded ':' confused pyproject_hooks splitting backend-path.
     url = "https://github.com/scikit-build/ninja-python-distributions"
     result = noxfile.downstream_dir_name(url)
     assert ":" not in result

--- a/tests/test_noxfile_downstream.py
+++ b/tests/test_noxfile_downstream.py
@@ -1,0 +1,84 @@
+"""Unit tests for helpers in the repo-root noxfile.py.
+
+``nox`` is not a test dependency, so the module (which imports nox and defines
+sessions at import time) is loaded with a minimal stub injected into
+``sys.modules``. That keeps the pure ``downstream_dir_name`` helper testable
+without pulling nox into the test env.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+NOXFILE = ROOT / "noxfile.py"
+
+
+def _load_noxfile() -> types.ModuleType:
+    nox_stub = types.ModuleType("nox")
+
+    def session(*_args: object, **_kwargs: object):
+        def decorator(func: object) -> object:
+            return func
+
+        return decorator
+
+    def parametrize(*_args: object, **_kwargs: object):
+        def decorator(func: object) -> object:
+            return func
+
+        return decorator
+
+    nox_stub.session = session  # type: ignore[attr-defined]
+    nox_stub.parametrize = parametrize  # type: ignore[attr-defined]
+    nox_stub.needs_version = ""  # type: ignore[attr-defined]
+    nox_stub.options = types.SimpleNamespace()  # type: ignore[attr-defined]
+    nox_stub.project = types.SimpleNamespace()  # type: ignore[attr-defined]
+
+    saved = sys.modules.get("nox")
+    sys.modules["nox"] = nox_stub
+    try:
+        spec = importlib.util.spec_from_file_location("_skbc_noxfile", NOXFILE)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        if saved is None:
+            del sys.modules["nox"]
+        else:
+            sys.modules["nox"] = saved
+    return module
+
+
+noxfile = _load_noxfile()
+
+
+@pytest.mark.parametrize(
+    ("project", "expected"),
+    [
+        ("https://github.com/org/repo", "https_github.com_org_repo"),
+        ("git@github.com:org/repo.git", "git_github.com_org_repo"),
+        ("/home/user/projects/repo", "home_user_projects_repo"),
+    ],
+)
+def test_downstream_dir_name(project: str, expected: str) -> None:
+    assert noxfile.downstream_dir_name(project) == expected
+
+
+def test_downstream_dir_name_has_no_colon() -> None:
+    # Regression: an embedded ':' made pyproject_hooks mis-split backend-path.
+    url = "https://github.com/scikit-build/ninja-python-distributions"
+    result = noxfile.downstream_dir_name(url)
+    assert ":" not in result
+    assert "/" not in result
+
+
+def test_downstream_dir_name_stable_across_runs() -> None:
+    url = "https://github.com/scikit-build/ninja-python-distributions.git"
+    assert noxfile.downstream_dir_name(url) == noxfile.downstream_dir_name(url)


### PR DESCRIPTION
Followup to #1439.

:robot: _AI text below_ :robot:

Running the downstream A/B skill across many projects surfaced three harness limitations (not backend bugs) that stopped projects from ever reaching scikit-build-core. This fixes them and adds two inputs.

**Clone-dir sanitization.** The clone dir was `"_".join(project.split("/"))`, which for a URL leaves the `://` colon in the path (`https:__github.com_...`). That embedded colon made `pyproject_hooks` mis-split a project's `backend-path`, so e.g. ninja died with `Cannot find module 'backend'` before the backend ran. Extracted a `downstream_dir_name` helper that maps runs of non-`[A-Za-z0-9._-]` to `_` and drops a trailing `.git`, so the name is colon-free and stable across re-runs. Unit-tested (regression: no colon for the ninja-style URL).

**Subdir pyproject read.** The session ran `load_toml("pyproject.toml")` at the clone root but only chdir'd into `--subdir` afterward, so every subdir project (lightgbm, awkward-cpp, ompl, kiss-icp, pyarrow) failed to read its build pyproject on both baseline and current. Reordered so `--prepare` runs at the root, then the subdir chdir happens, then the pyproject read + requires strip/install run in the subdir.

**New inputs.**
- `--requires` (repeatable): extra packages installed into the no-isolation env after the project's own requires — for a dynamic-metadata provider a project needs but doesn't declare (ninja needs `hatch-fancy-pypi-readme`).
- `--prepare`: a repo-local prep command run once at the clone root before configure (awkward-cpp needs the parent repo's `nox -s prepare` to generate kernel headers).

Both are threaded through `downstream_ab.py` into the nox posargs (not the git-clone passthrough) and documented in SKILL.md, including the rule that `--prepare` must not mutate the host — system-package installs are container-only.

Also wired the two known cases into `docs/data/projects.toml` (`requires` for ninja, `prepare` for awkward-cpp); the docs cog only reads `pypi`/`github`/`path`, so the extra keys are ignored by generation.