### PR TITLE
docs: add a Windows debug builds note

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -112,7 +112,8 @@ A `cmake.build-type=Debug` extension links against the debug CPython
 (`python_d.exe`) — importing it under a normal `python.exe` crashes with
 `0x80000003`. This is CPython behavior, not scikit-build-core's: run the build
 itself under `python_d.exe` so the `_d` suffix and import library line up (and
-the `t` ABI flag is added for free-threaded debug builds, e.g. `pythonXYt_d.dll`).
+the `t` ABI flag is added for free-threaded debug builds, e.g.
+`pythonXYt_d.dll`).
 
 To keep debug info while still loading under a normal Python, don't do a debug
 build — instead undefine `_DEBUG` around the CPython headers so they don't

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -104,3 +104,27 @@ VSCode C/C++ extension, set
 `"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"`.
 See [editable installs](../configuration/editable.md) for the related
 `--no-build-isolation` recommendations.
+
+## Debug builds on Windows
+
+A `cmake.build-type=Debug` extension links against the debug CPython
+(`pythonXY_d.dll`, `_d.pyd` suffix), so it only loads under a debug interpreter
+(`python_d.exe`) — importing it under a normal `python.exe` crashes with
+`0x80000003`. This is CPython behavior, not scikit-build-core's: run the build
+itself under `python_d.exe` so the `_d` suffix and import library line up (and
+the `t` ABI flag is added for free-threaded debug builds, e.g. `pythonXYt_d.dll`).
+
+To keep debug info while still loading under a normal Python, don't do a debug
+build — instead undefine `_DEBUG` around the CPython headers so they don't
+auto-link `pythonXY_d.lib`, and add debug flags yourself:
+
+```c
+#ifdef _DEBUG
+#  define SKB_RESTORE_DEBUG
+#  undef _DEBUG
+#endif
+#include <Python.h>
+#ifdef SKB_RESTORE_DEBUG
+#  define _DEBUG
+#endif
+```


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a short "Debug builds on Windows" section to the debugging guide, prompted by #670. It explains why a `Debug` extension only loads under `python_d.exe` (the `pythonXY_d.dll` / `_d.pyd` link and the `0x80000003` crash under a normal `python.exe`), notes the free-threaded `t`-flag variant, and gives the `#undef _DEBUG` recipe for keeping debug info while staying loadable under a release Python.

Docs only; the build machinery already handles the debug interpreter correctly (`builder/sysconfig.py` detects `Py_DEBUG` and the bundled FindPython appends `_d`).

Closes #670.
