### PR TITLE
docs: use -C instead of --config-settings in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,9 @@ step by step. More examples are in the
 
 ## Configuration
 
-All configuration options can be placed in `pyproject.toml`, passed via
-`-C`/`--config-setting` in build or `-C`/`--config-settings` in `pip` , or set
-as environment variables. `tool.scikit-build` is used in toml, `skbuild.` for
-`-C` options, or `SKBUILD_*` for environment variables.
+All configuration options can be placed in `pyproject.toml`, passed via `-C` in
+pip, uv, and build, or set as environment variables. `tool.scikit-build` is used
+in toml, `skbuild.` for `-C` options, or `SKBUILD_*` for environment variables.
 
 For a full reference and explanation of the variables see the [online
 documentation][conf-ref]

--- a/docs/configuration/editable.md
+++ b/docs/configuration/editable.md
@@ -16,7 +16,7 @@ Python versions. On Python 3.8, use the `importlib_resources` backport, since
 
 ```console
 # Very experimental rebuild on initial import feature
-$ pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=build -ve.
+$ pip install --no-build-isolation -Ceditable.rebuild=true -Cbuild-dir=build -ve.
 ```
 
 The automatic rebuild-on-import feature (`editable.rebuild`) is still

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -36,7 +36,7 @@ logging.level = "INFO"
 ````{tab} pip
 
 ```console
-$ pip install . -v --config-settings=build.verbose=true --config-settings=logging.level=INFO
+$ pip install . -v -Cbuild.verbose=true -Clogging.level=INFO
 ```
 
 ````
@@ -634,7 +634,7 @@ FOOD_GROUPS = ["Apple", "Lemon;Lime", "Banana"]
 ````{tab} pip
 
 ```console
-$ pip install . --config-settings=cmake.define.SOME_DEFINE=ON
+$ pip install . -Ccmake.define.SOME_DEFINE=ON
 ```
 
 ````

--- a/docs/ext/conftabs.py
+++ b/docs/ext/conftabs.py
@@ -41,7 +41,7 @@ class ConfTabs(SphinxDirective):
         ````{{tab}} pip
 
         ```console
-        $ pip install . --config-settings={name}={joined_result}
+        $ pip install . -C{name}={joined_result}
         ```
 
         ````

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -17,7 +17,7 @@ build.verbose = true
 ````{tab} pip
 
 ```console
-$ pip install . --config-settings=build.verbose=true
+$ pip install . -Cbuild.verbose=true
 ```
 
 ````


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Since `-C` is now well supported by pip, uv, and build, use it consistently across the documentation examples instead of the longer `--config-settings`/`--config-setting` forms.

This updates the `conftabs` pip-tab generator, the config/editable/reference example commands, and the README prose. The uv-specific `--config-settings`/`--config-settings-package` references in the workspaces guide are left as-is, since those name uv options directly.