### PR TITLE
feat: PEP 808 (METADATA 2.6) support via pyproject-metadata 0.12.1

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -311,7 +311,8 @@ And several optional ones (`build_state`, `dynamic_wheel`, and
 `get_requires_for_dynamic_metadata`). You can optionally use a class, as well.
 Fields a plugin reports via `dynamic_wheel` as possibly changing between the
 SDist and a wheel built from it are marked `Dynamic` in the SDist's `PKG-INFO`
-(METADATA 2.2); `version` may never change in this sense.
+(METADATA 2.2, or 2.6 when the field also has a static value in `[project]`, per
+[PEP 808][]); `version` may never change in this sense.
 
 A plugin distributed as a package is referenced by the name it registers in the
 `dynamic_metadata.provider` entry-point group. A plugin that lives inside your

--- a/src/scikit_build_core/_vendor/pyproject_metadata/__init__.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/__init__.py
@@ -77,7 +77,7 @@ if sys.version_info < (3, 12, 4):
     RE_EOL_BYTES = re.compile(rb"[\r\n]+")
 
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "ConfigurationError",
@@ -462,7 +462,10 @@ class StandardMetadata:
         for field in dynamic:
             # ``dynamic`` is validated separately with error collection, so the
             # raw list may still contain values outside the Dynamic literal
-            # (e.g. the invalid "name"); treat it as a plain string here.
+            # (e.g. the invalid "name" or a non-string entry); skip anything
+            # that is not a string and let that validation report it.
+            if not isinstance(field, str):
+                continue
             field_str: str = field
             if field_str in data["project"]:
                 if field_str in constants.PROJECT_DYNAMIC_STATIC:

--- a/src/scikit_build_core/_vendor/pyproject_metadata/__init__.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/__init__.py
@@ -18,12 +18,12 @@ Example usage:
    with open("METADATA", "wb") as f:
        f.write(pkg_info.as_bytes())
 
-   ep = self.metadata.entrypoints.copy()
-   ep["console_scripts"] = self.metadata.scripts
-   ep["gui_scripts"] = self.metadata.gui_scripts
-   for group, entries in ep.items():
-       if entries:
-           with open("entry_points.txt", "w", encoding="utf-8") as f:
+   ep = metadata.entrypoints.copy()
+   ep["console_scripts"] = metadata.scripts
+   ep["gui_scripts"] = metadata.gui_scripts
+   with open("entry_points.txt", "w", encoding="utf-8") as f:
+       for group, entries in ep.items():
+           if entries:
                print(f"[{group}]", file=f)
                for name, target in entries.items():
                    print(f"{name} = {target}", file=f)
@@ -33,16 +33,17 @@ Example usage:
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import dataclasses
 import email.message
 import email.policy
-import email.utils
 import itertools
 import keyword
 import os
 import os.path
 import pathlib
+import re
 import sys
 import typing
 import warnings
@@ -64,9 +65,7 @@ if typing.TYPE_CHECKING:
     else:
         from typing import Self
 
-    from .project_table import Dynamic
-
-import contextlib
+    from .project_table import Dynamic, ProjectTable
 
 import packaging.markers
 import packaging.specifiers
@@ -74,13 +73,11 @@ import packaging.utils
 import packaging.version
 
 if sys.version_info < (3, 12, 4):
-    import re
-
     RE_EOL_STR = re.compile(r"[\r\n]+")
     RE_EOL_BYTES = re.compile(rb"[\r\n]+")
 
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 __all__ = [
     "ConfigurationError",
@@ -212,7 +209,7 @@ class RFC822Policy(email.policy.EmailPolicy):
         ) -> str:  # pragma: no cover
             if hasattr(value, "name"):
                 return value.fold(policy=self)  # type: ignore[no-any-return]
-            maxlen = self.max_line_length if self.max_line_length else sys.maxsize
+            maxlen = self.max_line_length or sys.maxsize
 
             # this is from the library version, and it improperly breaks on chars like 0x0c, treating
             # them as 'form feed' etc.
@@ -249,8 +246,8 @@ def _validate_import_names(
     for fullname in names:
         if not isinstance(fullname, str):
             continue
-        name, simicolon, private = fullname.partition(";")
-        if simicolon and private.lstrip() != "private":
+        name, semicolon, private = fullname.partition(";")
+        if semicolon and private.strip() != "private":
             msg = "{key} contains an ending tag other than '; private', got {value!r}"
             errors.config_error(msg, key=key, value=fullname)
         name = name.rstrip()
@@ -278,7 +275,6 @@ def _validate_dotted_names(names: set[str], *, errors: ErrorCollector) -> None:
             if parent not in names:
                 msg = "{key} is missing {value!r}, but submodules are present elsewhere"
                 errors.config_error(msg, key="project.import-namespaces", value=parent)
-                continue
 
 
 class RFC822Message(email.message.EmailMessage):
@@ -336,9 +332,16 @@ class StandardMetadata:
     import_namespaces: list[str] | None = None
     dynamic: list[Dynamic] = dataclasses.field(default_factory=list)
     """
-    This field is used to track dynamic fields. You can't set a field not in this list.
+    This field contains the list of fields declared dynamic in ``project.dynamic``.
+    A field that is both declared dynamic and explicitly set causes a parsing error.
     """
 
+    dual_dynamic: set[str] = dataclasses.field(default_factory=set, repr=False)
+    """
+    Fields that are both declared in ``project.dynamic`` and given a static value
+    in ``[project]`` (PEP 808). Emitting these as dynamic metadata requires
+    metadata_version 2.6+.
+    """
     dynamic_metadata: list[str] = dataclasses.field(default_factory=list)
     """
     This is a list of METADATA fields that can change in between SDist and wheel. Requires metadata_version 2.2+.
@@ -359,6 +362,22 @@ class StandardMetadata:
         self.validate()
 
     @property
+    def _dual_dynamic_metadata(self) -> set[str]:
+        """
+        Dual-dynamic fields (PEP 808) whose METADATA field is also marked in
+        ``dynamic_metadata``. Only these require metadata_version 2.6; fields
+        with no METADATA representation (scripts, gui-scripts, entry-points)
+        never do, nor do dual fields unrelated to the marked Dynamic headers.
+        """
+        dynamic_metadata = {field.lower() for field in self.dynamic_metadata}
+        return {
+            field
+            for field in self.dual_dynamic
+            if {header.lower() for header in constants.PROJECT_TO_METADATA[field]}
+            & dynamic_metadata
+        }
+
+    @property
     def auto_metadata_version(self) -> str:
         """
         This computes the metadata version based on the fields set in the object
@@ -367,6 +386,8 @@ class StandardMetadata:
         if self.metadata_version is not None:
             return self.metadata_version
 
+        if self._dual_dynamic_metadata:
+            return "2.6"
         if self.import_names is not None or self.import_namespaces is not None:
             return "2.5"
         if isinstance(self.license, str) or self.license_files is not None:
@@ -411,8 +432,16 @@ class StandardMetadata:
         with error_collector.collect():
             to_project_table(dict(data), collect_errors=all_errors)
 
-        assert "project" in data
         project = data["project"]
+        if not isinstance(project, dict):
+            # In non-collecting mode, to_project_table already raised; this path
+            # is only reachable with all_errors=True, where the type error was
+            # collected and finalize is guaranteed to raise.
+            error_collector.finalize("Failed to parse pyproject.toml")
+            msg = "Unreachable code"  # pragma: no cover
+            raise AssertionError(msg)  # noqa: TRY004  # pragma: no cover
+        project = typing.cast("ProjectTable", project)
+
         project_dir = pathlib.Path(project_dir)
 
         if not allow_extra_keys:
@@ -429,10 +458,18 @@ class StandardMetadata:
 
         dynamic = project.get("dynamic", [])
 
+        dual_dynamic: set[str] = set()
         for field in dynamic:
-            if field in data["project"] and field != "name":
-                msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
-                error_collector.config_error(msg, key=f"project.{field}")
+            # ``dynamic`` is validated separately with error collection, so the
+            # raw list may still contain values outside the Dynamic literal
+            # (e.g. the invalid "name"); treat it as a plain string here.
+            field_str: str = field
+            if field_str in data["project"]:
+                if field_str in constants.PROJECT_DYNAMIC_STATIC:
+                    dual_dynamic.add(field_str)
+                elif field_str != "name":
+                    msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
+                    error_collector.config_error(msg, key=f"project.{field_str}")
 
         name = pyproject.ensure_str(project.get("name")) or "UNKNOWN"
 
@@ -447,7 +484,14 @@ class StandardMetadata:
                         if version_string
                         else None
                     )
-        elif "version" not in dynamic:
+        elif "version" in dynamic:
+            # A dynamic version that has not been assigned yet is None; the
+            # build backend is expected to set ``metadata.version`` before
+            # writing the metadata. The 0.0.0 placeholder is only kept for the
+            # error-collection paths (version present but invalid) so parsing
+            # can continue under ``all_errors=True``.
+            version = None
+        else:
             msg = (
                 "Field {key} missing and 'version' not specified in \"project.dynamic\""
             )
@@ -507,6 +551,7 @@ class StandardMetadata:
                 import_names=project.get("import-names", None),
                 import_namespaces=project.get("import-namespaces", None),
                 dynamic=dynamic,
+                dual_dynamic=dual_dynamic,
                 dynamic_metadata=dynamic_metadata or [],
                 metadata_version=metadata_version,
                 all_errors=all_errors,
@@ -547,6 +592,7 @@ class StandardMetadata:
         - ``license_files`` can't be used with classic ``license``
         - License classifiers can't be used with SPDX license
         - ``description`` is a single line (warning)
+        - Extra names in "project.optional-dependencies" should be valid (warning)
         - ``license`` is not an SPDX license expression if metadata_version >= 2.4 (warning)
         - License classifiers deprecated for metadata_version >= 2.4 (warning)
         - ``license`` is an SPDX license expression if metadata_version >= 2.4
@@ -555,6 +601,7 @@ class StandardMetadata:
         - ``import-name(paces)s`` is only supported on metadata_version >= 2.5
         - ``import-name(space)s`` must be valid names, optionally with ``; private``
         - ``import-names`` and ``import-namespaces`` cannot overlap.
+        - A field that is both static and dynamic metadata requires metadata_version >= 2.6
         """
         errors = ErrorCollector(collect_errors=self.all_errors)
 
@@ -598,6 +645,17 @@ class StandardMetadata:
                 elif any(c.startswith("License ::") for c in self.classifiers):
                     warnings.warn(
                         "'License ::' classifiers are deprecated for metadata >= 2.4, use a SPDX license expression for \"project.license\" instead",
+                        ConfigurationWarning,
+                        stacklevel=2,
+                    )
+            for extra in self.optional_dependencies:
+                try:
+                    packaging.utils.canonicalize_name(extra, validate=True)
+                except packaging.utils.InvalidName:  # noqa: PERF203
+                    warnings.warn(
+                        f'Invalid extra name {extra!r} in "project.optional-dependencies". '
+                        "A valid name consists only of ASCII letters and numbers, period, "
+                        "underscore and hyphen. It must start and end with a letter or number",
                         ConfigurationWarning,
                         stacklevel=2,
                     )
@@ -652,6 +710,15 @@ class StandardMetadata:
 
         _validate_dotted_names(import_names | import_namespaces, errors=errors)
 
+        dual_dynamic_metadata = self._dual_dynamic_metadata
+        if (
+            dual_dynamic_metadata
+            and self.auto_metadata_version in constants.PRE_2_6_METADATA_VERSIONS
+        ):
+            fields = ", ".join(sorted(dual_dynamic_metadata))
+            msg = "Fields {fields} are declared as both static and dynamic, which requires metadata_version >= 2.6"
+            errors.config_error(msg, key="project.dynamic", fields=fields)
+
         errors.finalize("Metadata validation failed")
 
     def _write_metadata(  # noqa: C901
@@ -689,13 +756,13 @@ class StandardMetadata:
 
         if self.license_files is not None:
             for license_file in sorted(set(self.license_files)):
-                smart_message["License-File"] = os.fspath(license_file.as_posix())
+                smart_message["License-File"] = license_file.as_posix()
         elif (
             self.auto_metadata_version not in constants.PRE_SPDX_METADATA_VERSIONS
             and isinstance(self.license, License)
             and self.license.file
         ):
-            smart_message["License-File"] = os.fspath(self.license.file.as_posix())
+            smart_message["License-File"] = self.license.file.as_posix()
 
         for classifier in self.classifiers:
             smart_message["Classifier"] = classifier
@@ -730,11 +797,11 @@ class StandardMetadata:
         if self.auto_metadata_version != "2.1":
             for field in self.dynamic_metadata:
                 if field.lower() in {"name", "version", "dynamic"}:
-                    msg = f"Metadata field {field!r} cannot be declared dynamic"
-                    errors.config_error(msg)
+                    msg = "Metadata field {field!r} cannot be declared dynamic"
+                    errors.config_error(msg, field=field)
                 if field.lower() not in constants.KNOWN_METADATA_FIELDS:
-                    msg = f"Unknown metadata field {field!r} cannot be declared dynamic"
-                    errors.config_error(msg)
+                    msg = "Unknown metadata field {field!r} cannot be declared dynamic"
+                    errors.config_error(msg, field=field)
                 smart_message["Dynamic"] = field
 
         errors.finalize("Failed to write metadata")
@@ -747,14 +814,23 @@ def _name_list(people: list[tuple[str, str | None]]) -> str | None:
     return ", ".join(name for name, email_ in people if not email_) or None
 
 
+_DISPLAY_NAME_NEEDS_QUOTING = re.compile(r'[][\\()<>@,:;".]')
+_QUOTED_STRING_ESCAPE = re.compile(r'([\\"])')
+
+
+def _format_address(name: str, addr: str) -> str:
+    if _DISPLAY_NAME_NEEDS_QUOTING.search(name):
+        quoted = _QUOTED_STRING_ESCAPE.sub(r"\\\1", name)
+        return f'"{quoted}" <{addr}>'
+    return f"{name} <{addr}>"
+
+
 def _email_list(people: list[tuple[str, str | None]]) -> str | None:
     """
     Build a comma-separated list of emails.
     """
     return (
-        ", ".join(
-            email.utils.formataddr((name, _email)) for name, _email in people if _email
-        )
+        ", ".join(_format_address(name, _email) for name, _email in people if _email)
         or None
     )
 

--- a/src/scikit_build_core/_vendor/pyproject_metadata/_dispatch.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/_dispatch.py
@@ -41,7 +41,7 @@ T = typing.TypeVar("T")
 class KeyDispatcher(Generic[P, R]):
     def __init__(self, func: Callable[Concatenate[str, P], R]) -> None:
         self.default: Callable[Concatenate[str, P], R] = func
-        self.registry: dict[str, Callable[Concatenate[str, P], R]] = {}
+        self.registry: dict[re.Pattern[str], Callable[Concatenate[str, P], R]] = {}
         functools.update_wrapper(self, func)
 
     def register(
@@ -52,16 +52,17 @@ class KeyDispatcher(Generic[P, R]):
         def decorator(
             func: Callable[Concatenate[str, P], R],
         ) -> Callable[Concatenate[str, P], R]:
-            self.registry[value] = func
+            self.registry[re.compile(value, re.ASCII)] = func
             return func
 
         return decorator
 
     def dispatch(self, value: str) -> Callable[Concatenate[str, P], R]:
         """Return the registered implementation or the default."""
-        results = [key for key in self.registry if re.fullmatch(key, value, re.ASCII)]
-        result = results[0] if results else ""
-        return self.registry.get(result, self.default)
+        for pattern, func in self.registry.items():
+            if pattern.fullmatch(value):
+                return func
+        return self.default
 
     def __call__(self, value: str, *args: P.args, **kwargs: P.kwargs) -> R:
         impl = self.dispatch(value)

--- a/src/scikit_build_core/_vendor/pyproject_metadata/constants.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/constants.py
@@ -11,11 +11,12 @@ __all__ = [
     "KNOWN_BUILD_SYSTEM_FIELDS",
     "KNOWN_METADATA_FIELDS",
     "KNOWN_METADATA_VERSIONS",
-    "KNOWN_METADATA_VERSIONS",
     "KNOWN_MULTIUSE",
     "KNOWN_PROJECT_FIELDS",
     "KNOWN_TOPLEVEL_FIELDS",
+    "PRE_2_6_METADATA_VERSIONS",
     "PRE_SPDX_METADATA_VERSIONS",
+    "PROJECT_DYNAMIC_STATIC",
     "PROJECT_TO_METADATA",
 ]
 
@@ -24,9 +25,10 @@ def __dir__() -> list[str]:
     return __all__
 
 
-KNOWN_METADATA_VERSIONS = {"2.1", "2.2", "2.3", "2.4", "2.5"}
+KNOWN_METADATA_VERSIONS = {"2.1", "2.2", "2.3", "2.4", "2.5", "2.6"}
 PRE_SPDX_METADATA_VERSIONS = {"2.1", "2.2", "2.3"}
 PRE_2_5_METADATA_VERSIONS = {"2.1", "2.2", "2.3", "2.4"}
+PRE_2_6_METADATA_VERSIONS = {"2.1", "2.2", "2.3", "2.4", "2.5"}
 
 PROJECT_TO_METADATA = {
     "authors": frozenset(["Author", "Author-Email"]),
@@ -36,6 +38,8 @@ PROJECT_TO_METADATA = {
     "dynamic": frozenset(),
     "entry-points": frozenset(),
     "gui-scripts": frozenset(),
+    "import-names": frozenset(["Import-Name"]),
+    "import-namespaces": frozenset(["Import-Namespace"]),
     "keywords": frozenset(["Keywords"]),
     "license": frozenset(["License", "License-Expression"]),
     "license-files": frozenset(["License-File"]),
@@ -47,8 +51,25 @@ PROJECT_TO_METADATA = {
     "scripts": frozenset(),
     "urls": frozenset(["Project-URL"]),
     "version": frozenset(["Version"]),
-    "import-names": frozenset(["Import-Name"]),
-    "import-namespaces": frozenset(["Import-Namespaces"]),
+}
+
+# Fields PEP 808 allows to be both statically defined and listed in
+# project.dynamic. These are the arrays and tables with arbitrary entries; a
+# backend may extend them but not remove or modify existing entries.
+PROJECT_DYNAMIC_STATIC = {
+    "authors",
+    "classifiers",
+    "dependencies",
+    "entry-points",
+    "gui-scripts",
+    "import-names",
+    "import-namespaces",
+    "keywords",
+    "license-files",
+    "maintainers",
+    "optional-dependencies",
+    "scripts",
+    "urls",
 }
 
 KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}
@@ -64,6 +85,8 @@ KNOWN_METADATA_FIELDS = {
     "download-url",  # Not specified via pyproject standards, deprecated by PEP 753
     "dynamic",  # Can't be in dynamic
     "home-page",  # Not specified via pyproject standards, deprecated by PEP 753
+    "import-name",
+    "import-namespace",
     "keywords",
     "license",
     "license-expression",
@@ -86,8 +109,6 @@ KNOWN_METADATA_FIELDS = {
     "summary",
     "supported-platform",  # Not specified via pyproject standards
     "version",  # Can't be in dynamic
-    "import-name",
-    "import-namespace",
 }
 
 KNOWN_MULTIUSE = {

--- a/src/scikit_build_core/_vendor/pyproject_metadata/errors.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/errors.py
@@ -130,7 +130,7 @@ class SimpleErrorCollector:
             raise error
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class ErrorCollector(SimpleErrorCollector):
     """
     Collect errors and raise them as a group at the end (if collect_errors is True),

--- a/src/scikit_build_core/_vendor/pyproject_metadata/project_table.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/project_table.py
@@ -10,6 +10,7 @@ Documentation notice: the fields with hyphens are not shown due to a sphinx-auto
 
 from __future__ import annotations
 
+import functools
 import re
 import sys
 import typing
@@ -292,6 +293,12 @@ def _(prefix: str, data: object, error_collector: SimpleErrorCollector) -> None:
         error_collector.error(ConfigurationError(msg, key=prefix))
 
 
+@functools.lru_cache(maxsize=None)
+def _get_type_hints(cls: type[object]) -> dict[str, Any]:
+    """Cache ``typing.get_type_hints`` results per class."""
+    return typing.get_type_hints(cls)
+
+
 def _cast_typed_dict(
     cls: type[Any], data: object, prefix: str, error_collector: SimpleErrorCollector
 ) -> None:
@@ -302,7 +309,7 @@ def _cast_typed_dict(
         msg = f'Field "{prefix}" has an invalid type, expecting {get_name(cls)} (got {get_name(type(data))})'
         raise ConfigurationTypeError(msg, key=prefix)
 
-    hints = typing.get_type_hints(cls)
+    hints = _get_type_hints(cls)  # type: ignore[arg-type]
     for key, typ in hints.items():
         if key in data:
             with error_collector.collect(ConfigurationError):

--- a/src/scikit_build_core/_vendor/pyproject_metadata/pyproject.py
+++ b/src/scikit_build_core/_vendor/pyproject_metadata/pyproject.py
@@ -12,13 +12,13 @@ record errors.
 from __future__ import annotations
 
 import dataclasses
+import pathlib
 import typing
 from typing import Any
 
 import packaging.requirements
 
 if typing.TYPE_CHECKING:
-    import pathlib
     from collections.abc import Generator, Iterable
 
     from packaging.requirements import Requirement
@@ -133,8 +133,10 @@ def get_license(
     if filename:
         file = project_dir.joinpath(filename)
         if not file.is_file():
-            msg = f"License file not found ({filename!r})"
-            error_collector.config_error(msg, key="project.license.file")
+            msg = "License file not found ({filename!r})"
+            error_collector.config_error(
+                msg, key="project.license.file", filename=filename
+            )
             return None
         text = file.read_text(encoding="utf-8")
 
@@ -143,7 +145,7 @@ def get_license(
 
 
 def get_license_files(
-    project: dict[str, Any], project_dir: pathlib.Path, error_collector: ErrorCollector
+    project: ProjectTable, project_dir: pathlib.Path, error_collector: ErrorCollector
 ) -> list[pathlib.Path] | None:
     """Get the license-files list of files from the project table.
 
@@ -160,7 +162,7 @@ def get_license_files(
 
 
 def get_readme(  # noqa: C901
-    project: dict[str, Any], project_dir: pathlib.Path, error_collector: ErrorCollector
+    project: ProjectTable, project_dir: pathlib.Path, error_collector: ErrorCollector
 ) -> Readme | None:
     """Get the text of the readme from the project table.
 
@@ -231,7 +233,7 @@ def get_readme(  # noqa: C901
     return Readme(text, file, content_type)
 
 
-def get_dependencies(project: dict[str, Any]) -> list[Requirement]:
+def get_dependencies(project: ProjectTable) -> list[Requirement]:
     """Get the dependencies from the project table."""
     requirement_strings: list[str] | None = None
     requirement_strings_raw = project.get("dependencies")
@@ -251,7 +253,7 @@ def get_dependencies(project: dict[str, Any]) -> list[Requirement]:
 
 
 def get_optional_dependencies(
-    project: dict[str, Any],
+    project: ProjectTable,
 ) -> dict[str, list[Requirement]]:
     """Get the optional dependencies from the project table."""
     val = project.get("optional-dependencies")
@@ -261,7 +263,7 @@ def get_optional_dependencies(
     requirements_dict: dict[str, list[Requirement]] = {}
     if not isinstance(val, dict):
         return {}
-    for extra, requirements in val.copy().items():
+    for extra, requirements in val.items():
         assert isinstance(extra, str)
         if not isinstance(requirements, list):
             return {}
@@ -273,10 +275,10 @@ def get_optional_dependencies(
                 requirements_dict[extra].append(packaging.requirements.Requirement(req))
             except packaging.requirements.InvalidRequirement:
                 return {}
-    return dict(requirements_dict)
+    return requirements_dict
 
 
-def get_entrypoints(project: dict[str, Any]) -> dict[str, dict[str, str]]:
+def get_entrypoints(project: ProjectTable) -> dict[str, dict[str, str]]:
     """Get the entrypoints from the project table."""
     val = project.get("entry-points")
     if val is None:
@@ -305,14 +307,22 @@ def _get_files_from_globs(
 ) -> Generator[pathlib.Path, None, None]:
     """Given a list of globs, get files that match."""
     for glob in globs:
-        if glob.startswith(("..", "/")):
+        # Reject any glob that escapes the project directory: absolute paths
+        # (POSIX or Windows) or any pattern containing a ".." path segment.
+        pure_path = pathlib.PurePosixPath(glob)
+        if (
+            pure_path.is_absolute()
+            or pathlib.PureWindowsPath(glob).is_absolute()
+            or ".." in pure_path.parts
+            or ".." in pathlib.PureWindowsPath(glob).parts
+        ):
             msg = "{glob!r} is an invalid {key} glob: the pattern must match files within the project directory"
             error_collector.config_error(msg, key="project.license-files", glob=glob)
-            break
+            continue
         files = [f for f in project_dir.glob(glob) if f.is_file()]
         if not files:
             msg = "Every pattern in {key} must match at least one file: {glob!r} did not match any"
             error_collector.config_error(msg, key="project.license-files", glob=glob)
-            break
+            continue
         for f in files:
             yield f.relative_to(project_dir)

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -22,7 +22,10 @@ from .._vendor.pyproject_metadata import (
     extras_build_system,
     extras_top_level,
 )
-from .._vendor.pyproject_metadata.constants import PROJECT_TO_METADATA
+from .._vendor.pyproject_metadata.constants import (
+    PROJECT_DYNAMIC_STATIC,
+    PROJECT_TO_METADATA,
+)
 from ..builder._load_provider import (
     dynamic_wheel_fields,
     process_dynamic_metadata,
@@ -57,6 +60,16 @@ def get_standard_metadata(
 ) -> StandardMetadata:
     new_pyproject_dict = copy.deepcopy(dict(pyproject_dict))
     project = new_pyproject_dict["project"]
+
+    # PEP 808: fields the author gives a static value in [project] *and* lists in
+    # dynamic. Captured before providers resolve them, as process_*dynamic_metadata
+    # drops resolved fields from dynamic. Only those also marked Dynamic in the
+    # SDist (via dynamic_wheel, below) need metadata_version 2.6.
+    dual_dynamic = {
+        field
+        for field in project.get("dynamic", [])
+        if field in project and field in PROJECT_DYNAMIC_STATIC
+    }
 
     # Handle the legacy tool.scikit-build.metadata table, then the standard
     # top-level [[tool.dynamic-metadata]] entries (dynamic-metadata 0.3). Both
@@ -107,6 +120,11 @@ def get_standard_metadata(
         all_errors=True,
         allow_extra_keys=allow_extra_keys,
     )
+
+    # Restore the PEP 808 dual-dynamic set that from_pyproject can no longer see
+    # (the fields were dropped from dynamic during resolution). Combined with the
+    # Dynamic metadata headers above, this bumps auto_metadata_version to 2.6.
+    metadata.dual_dynamic = dual_dynamic
 
     # For scikit-build-core < 0.5, we keep the normalized name for back-compat
     if settings.minimum_version is not None and settings.minimum_version < Version(

--- a/src/scikit_build_core/build/metadata.py
+++ b/src/scikit_build_core/build/metadata.py
@@ -68,7 +68,9 @@ def get_standard_metadata(
     dual_dynamic = {
         field
         for field in project.get("dynamic", [])
-        if field in project and field in PROJECT_DYNAMIC_STATIC
+        if isinstance(field, str)
+        and field in project
+        and field in PROJECT_DYNAMIC_STATIC
     }
 
     # Handle the legacy tool.scikit-build.metadata table, then the standard

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -582,6 +582,111 @@ def test_dynamic_wheel_marks_sdist_fields_dynamic(
     assert b"Dynamic:" not in bytes(metadata.as_rfc822())
 
 
+def test_dynamic_wheel_static_field_is_metadata_2_6(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A field static in [project] *and* dynamic_wheel-marked is PEP 808 (2.6)."""
+    monkeypatch.chdir(tmp_path)
+    _write_dynamic_wheel_plugin(
+        "wheel_plugin_dual",
+        """\
+        def dynamic_metadata(settings, project):
+            return {"dependencies": ["scipy>=1"]}
+
+        def dynamic_wheel(settings):
+            return {"dependencies": True}
+        """,
+    )
+    Path("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "test-dual-dynamic"
+            version = "0.1.0"
+            dependencies = ["numpy"]
+            dynamic = ["dependencies"]
+
+            [[tool.dynamic-metadata]]
+            provider = {path = "plugins_wheel_plugin_dual", module = "wheel_plugin_dual"}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with Path("pyproject.toml").open("rb") as ft:
+        pyproject = tomllib.load(ft)
+    settings = SettingsReader(pyproject, {}, state="sdist").settings
+
+    metadata = get_standard_metadata(pyproject, settings, build_state="sdist")
+    assert metadata.dynamic_metadata == ["Requires-Dist"]
+    # The static [project] value coexists with Dynamic: Requires-Dist -> 2.6
+    assert metadata.auto_metadata_version == "2.6"
+    pkg_info = bytes(metadata.as_rfc822())
+    assert b"Metadata-Version: 2.6" in pkg_info
+    assert b"Requires-Dist: numpy" in pkg_info
+    assert b"Requires-Dist: scipy>=1" in pkg_info
+    assert b"Dynamic: Requires-Dist" in pkg_info
+
+    # The wheel resolves the field fully; no Dynamic, so no 2.6 bump.
+    metadata = get_standard_metadata(pyproject, settings, build_state="wheel")
+    assert not metadata.dynamic_metadata
+    assert metadata.auto_metadata_version != "2.6"
+    assert b"Dynamic:" not in bytes(metadata.as_rfc822())
+
+
+def test_static_field_extended_without_dynamic_wheel_is_not_2_6(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dual field a provider extends but does not report via dynamic_wheel is
+    fully resolved into the SDist (not Dynamic, not 2.6)."""
+    monkeypatch.chdir(tmp_path)
+    _write_dynamic_wheel_plugin(
+        "wheel_plugin_no_wheel",
+        """\
+        def dynamic_metadata(settings, project):
+            return {"dependencies": ["scipy>=1"]}
+
+        def dynamic_wheel(settings):
+            return {"dependencies": False}
+        """,
+    )
+    Path("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["scikit-build-core"]
+            build-backend = "scikit_build_core.build"
+
+            [project]
+            name = "test-dual-static"
+            version = "0.1.0"
+            dependencies = ["numpy"]
+            dynamic = ["dependencies"]
+
+            [[tool.dynamic-metadata]]
+            provider = {path = "plugins_wheel_plugin_no_wheel", module = "wheel_plugin_no_wheel"}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with Path("pyproject.toml").open("rb") as ft:
+        pyproject = tomllib.load(ft)
+    settings = SettingsReader(pyproject, {}, state="sdist").settings
+
+    metadata = get_standard_metadata(pyproject, settings, build_state="sdist")
+    assert not metadata.dynamic_metadata
+    assert metadata.auto_metadata_version != "2.6"
+    pkg_info = bytes(metadata.as_rfc822())
+    assert b"Requires-Dist: numpy" in pkg_info
+    assert b"Requires-Dist: scipy>=1" in pkg_info
+    assert b"Dynamic:" not in pkg_info
+
+
 @pytest.mark.parametrize(
     ("returns", "match"),
     [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the vendored `pyproject-metadata` to the released **0.12.0**, which adds PEP 808 (partially-dynamic project metadata / METADATA 2.6), and wires scikit-build-core to emit 2.6 when appropriate.

### Vendor bump
0.12.0 brings PEP 808, the PEP 685 invalid-extra-name warning, and assorted fixes. It also includes the upstream typing fixes from pypa/pyproject-metadata#329, so the vendored copy type-checks cleanly under our strict mypy with no override needed.

### METADATA 2.6 emission
When a field has a static value in `[project]` **and** is listed in `project.dynamic` (PEP 808), and a `[[tool.dynamic-metadata]]` provider reports it via the `dynamic_wheel` hook, the SDist now emits `Metadata-Version: 2.6` with the static value alongside `Dynamic:`, instead of 2.2.

- A dual field a provider merely extends (no `dynamic_wheel`) is fully resolved into the SDist and stays pre-2.6.
- A purely-dynamic field (no static `[project]` value) is unchanged and stays 2.2.
- Wheels resolve the field fully, so they carry no `Dynamic` header and are not bumped.

`process_dynamic_metadata` drops resolved fields from `dynamic` before `from_pyproject` runs, so the library can no longer detect the dual case on its own; the dual set is captured beforehand and re-attached to the metadata object.