### PR TITLE
fix(editable): don't truncate shared namespaces in redirect mode

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -433,6 +433,26 @@ def collect_search_locations(
                     ancestor_dir = str(Path(ancestor_dir).parent)
                     directories.setdefault(ancestor, set()).add(ancestor_dir)
 
+    # Second pass: extend already-registered ancestors with each loose file's
+    # matching parent directories. An install tree holding only leaf files
+    # under a namespace (e.g. ``myns/mypkg/_ext.so``, no install-tree
+    # ``__init__``) otherwise leaves the namespace ancestor (``myns``) without
+    # the install-tree path, and the finder truncates the shared namespace to
+    # the source tree, hiding sibling distributions in site-packages (#1482).
+    # Only ancestors registered above are extended, so an untracked containing
+    # directory (a ``wheel.install-dir`` prefix) is still not synthesized.
+    registered = frozenset(directories)
+    for module, directory, is_init in entries:
+        if is_init:
+            continue
+        ancestor = module.rpartition(".")[0]
+        ancestor_dir = directory
+        while "." in ancestor:
+            ancestor = ancestor.rpartition(".")[0]
+            ancestor_dir = str(Path(ancestor_dir).parent)
+            if ancestor in registered:
+                directories[ancestor].add(ancestor_dir)
+
     return (
         {pkg: sorted(dirs) for pkg, dirs in directories.items()},
         sorted(packages),

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -504,6 +504,18 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         # A tracked package directory without an importable __init__ is a
         # namespace package.
         if submodule_search_locations is not None:
+            # A PEP 420 namespace can be shared with other distributions, so
+            # merge in the portions native resolution would find on sys.path
+            # (e.g. a sibling distribution installed normally into
+            # site-packages); synthesizing from the tracked directories alone
+            # would truncate the namespace (#1482).
+            from importlib.machinery import PathFinder
+
+            native = PathFinder.find_spec(fullname, path)  # type: ignore[arg-type]
+            if native is not None and native.loader is None:
+                for location in native.submodule_search_locations or []:
+                    if location not in submodule_search_locations:
+                        submodule_search_locations.append(location)
             loader = _ScikitBuildNamespaceLoader(submodule_search_locations, self)
             spec = importlib.util.spec_from_loader(
                 fullname,

--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -1,19 +1,15 @@
 from __future__ import annotations
 
-__lazy_modules__ = {"importlib.util", "subprocess"}
+__lazy_modules__ = {"importlib.machinery", "importlib.util", "subprocess"}
 
 import importlib.abc
+import importlib.machinery
 import importlib.util
 import os
 import subprocess
 import sys
 
-# Importing as little as possible is important, since every usage of Python
-# imports this file. That's why we use this trick for TYPE_CHECKING
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from importlib.machinery import ModuleSpec
-
+# Import as little as possible, since every usage of Python imports this file.
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 MARKER = "SKBUILD_EDITABLE_SKIP"
@@ -478,7 +474,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         fullname: str,
         path: object = None,
         target: object = None,
-    ) -> ModuleSpec | None:
+    ) -> importlib.machinery.ModuleSpec | None:
         # If no known submodule_search_locations is found, it means it is a root
         # module.
         if fullname in self.submodule_search_locations:
@@ -506,12 +502,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         if submodule_search_locations is not None:
             # A PEP 420 namespace can be shared with other distributions, so
             # merge in the portions native resolution would find on sys.path
-            # (e.g. a sibling distribution installed normally into
-            # site-packages); synthesizing from the tracked directories alone
-            # would truncate the namespace (#1482).
-            from importlib.machinery import PathFinder
-
-            native = PathFinder.find_spec(fullname, path)  # type: ignore[arg-type]
+            native = importlib.machinery.PathFinder.find_spec(fullname, path)  # type: ignore[arg-type]
             if native is not None and native.loader is None:
                 for location in native.submodule_search_locations or []:
                     if location not in submodule_search_locations:
@@ -532,7 +523,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         fullname: str,
         origin: str,
         submodule_search_locations: list[str] | None,
-    ) -> ModuleSpec | None:
+    ) -> importlib.machinery.ModuleSpec | None:
         is_pkg = origin.endswith(("__init__.py", "__init__.pyc"))
         spec = importlib.util.spec_from_file_location(
             fullname,
@@ -614,7 +605,7 @@ class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
         fullname: str,
         path: object = None,
         target: object = None,
-    ) -> ModuleSpec | None:
+    ) -> importlib.machinery.ModuleSpec | None:
         if fullname.partition(".")[0] not in self.known_packages:
             return None
 
@@ -624,12 +615,10 @@ class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
             self.rebuilt = True
             self.rebuild()
 
-        from importlib.machinery import PathFinder
-
         # ``path`` is the parent package's __path__ for submodules, None for a
         # top-level import; fall back to our recorded search locations.
         search = self.search_paths if path is None else path
-        spec = PathFinder.find_spec(fullname, search)  # type: ignore[arg-type]
+        spec = importlib.machinery.PathFinder.find_spec(fullname, search)  # type: ignore[arg-type]
         # Namespace packages have no concrete loader to wrap; leaving them to
         # native resolution also avoids truncating a namespace whose parts span
         # locations beyond our search paths.

--- a/tests/packages/namespace_sibling_package/pyproject.toml
+++ b/tests/packages/namespace_sibling_package/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "myns.otherpkg"
+version = "0.0.1"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/myns"]

--- a/tests/packages/namespace_sibling_package/src/myns/otherpkg/__init__.py
+++ b/tests/packages/namespace_sibling_package/src/myns/otherpkg/__init__.py
@@ -1,0 +1,1 @@
+value = "sibling"

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -68,6 +68,41 @@ def test_editable_redirect():
     assert finder.pkgs == frozenset(["pkg", "pkg.subpkg"])
 
 
+def test_synthesized_namespace_merges_native_portions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A synthesized namespace spec must also carry the portions native
+    # resolution would find on sys.path (e.g. a sibling distribution sharing
+    # the namespace), not just the tracked directories (#1482).
+    src_ns = tmp_path / "src" / "myns"
+    src_ns.mkdir(parents=True)
+    other_site = tmp_path / "othersite"
+    sibling = other_site / "myns" / "otherpkg"
+    sibling.mkdir(parents=True)
+    sibling.joinpath("__init__.py").touch()
+    monkeypatch.syspath_prepend(str(other_site))
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={},
+        known_wheel_files={},
+        known_directories={"myns": [str(src_ns)]},
+        known_packages=[],
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path / "sitepackages"),
+        install_dir="",
+    )
+
+    spec = finder.find_spec("myns")
+    assert spec is not None
+    locations = list(spec.submodule_search_locations or [])
+    assert str(src_ns) in locations
+    assert str(other_site / "myns") in locations
+
+
 @pytest.fixture
 def _restore_meta_path():
     saved = sys.meta_path[:]

--- a/tests/test_editable_unit.py
+++ b/tests/test_editable_unit.py
@@ -381,6 +381,55 @@ def test_navigate_editable_namespace_package(
     assert out == "False"
 
 
+def test_navigate_editable_namespace_sibling_distribution(
+    tmp_path: Path, virtualenv: VEnv, monkeypatch: pytest.MonkeyPatch
+):
+    # Regression test for #1482: the shared (PEP 420) namespace myns is split
+    # across this editable install (myns.mypkg) and a sibling distribution
+    # installed normally into site-packages (myns.otherpkg). The redirect
+    # finder synthesizes myns, and must not truncate its __path__ to the
+    # editable's own directories -- the sibling must stay importable.
+    site_packages = virtualenv.purelib
+
+    source_dir = tmp_path / "source"
+    leaf = source_dir / "src" / "myns" / "mypkg"
+    leaf.mkdir(parents=True)
+    monkeypatch.chdir(source_dir)
+    leaf.joinpath("__init__.py").write_text("value = 'ns'\n")
+
+    packages = {"myns/mypkg": str(Path("src") / "myns" / "mypkg")}
+    mapping = packages_to_file_mapping(
+        packages=packages,
+        platlib_dir=site_packages,
+        include=[],
+        src_exclude=[],
+        target_exclude=[],
+        build_dir="",
+        mode="classic",
+    )
+    files = editable_redirect_files(
+        libdir=site_packages,
+        mapping=mapping,
+        name="myns_mypkg",
+        packages=package_search_dirs(packages),
+        reload_dir=None,
+        settings=ScikitBuildSettings(),
+        use_start=False,
+    )
+    for fname, content in files.items():
+        site_packages.joinpath(fname).write_bytes(content)
+
+    # The sibling distribution, installed normally (after the editable, so its
+    # files are not mistaken for the editable's install tree).
+    sibling = site_packages / "myns" / "otherpkg"
+    sibling.mkdir(parents=True)
+    sibling.joinpath("__init__.py").write_text("value = 'sibling'\n")
+
+    assert virtualenv.execute("import myns.mypkg; print(myns.mypkg.value)") == "ns"
+    out = virtualenv.execute("import myns.otherpkg; print(myns.otherpkg.value)")
+    assert out == "sibling"
+
+
 def test_packages_to_file_mapping_module(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1158,6 +1207,32 @@ def test_collect_search_locations_namespace_ancestor(tmp_path: Path):
     # The namespace ancestor is registered, pointing at the parent directory.
     assert "myns" in directories
     assert str(src / "myns") in directories["myns"]
+
+
+def test_collect_search_locations_install_tree_leaf_namespace_ancestor(
+    tmp_path: Path,
+):
+    # The install (CMake) tree holds only a leaf module under the namespace
+    # (myns/mypkg/_ext.py) -- no install-tree __init__ anywhere. The namespace
+    # ancestor (myns) must still get the install-tree parent directory, not
+    # just the source tree; otherwise the redirect finder truncates the shared
+    # namespace and hides a sibling distribution in site-packages (#1482).
+    libdir = tmp_path / "site"
+    mod_dir = libdir / "myns" / "mypkg"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "_ext.py").touch()
+    src = tmp_path / "src"
+    mapping = {
+        str(src / "myns" / "mypkg" / "__init__.py"): str(
+            libdir / "myns" / "mypkg" / "__init__.py"
+        )
+    }
+
+    directories, packages = collect_search_locations(mapping, libdir)
+
+    assert packages == ["myns.mypkg"]
+    assert str(src / "myns") in directories["myns"]
+    assert str(Path("myns")) in directories["myns"]
 
 
 def test_collect_search_locations_install_dir_prefix_not_namespace(tmp_path: Path):

--- a/tests/test_pyproject_namespace.py
+++ b/tests/test_pyproject_namespace.py
@@ -24,3 +24,35 @@ def test_pep517_wheel_namespace_package(virtualenv, tmp_path: Path):
         "import myns.mypkg; print(myns.mypkg.__version__)",
     )
     assert version.strip() == "1.2.3"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("editable_mode", ["redirect", "inplace"])
+@pytest.mark.parametrize(
+    "multiple_packages",
+    [["namespace_purelib_package", "namespace_sibling_package"]],
+    indirect=True,
+)
+def test_editable_namespace_sibling_distribution(
+    multiple_packages, isolated, editable_mode
+):
+    # An editable install must not hide sibling distributions sharing the same
+    # PEP 420 namespace (issue #1482): 'myns.otherpkg' (hatchling, installed
+    # normally) must stay importable next to editable 'myns.mypkg'
+    # (scikit-build-core). Neither package compiles anything.
+    editable_pkg, sibling_pkg = multiple_packages
+
+    isolated.install(str(sibling_pkg.workdir), installer="pip")
+    isolated.install(
+        "-v",
+        f"--config-settings=editable.mode={editable_mode}",
+        "-e",
+        str(editable_pkg.workdir),
+        installer="pip",
+    )
+
+    output = isolated.execute(
+        "import myns.mypkg, myns.otherpkg;"
+        " print(myns.mypkg.__version__, myns.otherpkg.value)"
+    )
+    assert output.strip() == "1.2.3 sibling"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1482.

The redirecting finder synthesized shared (PEP 420) namespace packages with a `__path__` built only from the tracked directories, truncating the namespace: portions from sibling distributions (e.g. mqt-core installed normally next to an editable mqt-ddsim) disappeared, so `import mqt.core` failed. qmap only survived by accident — a stray `__init__.pyi` under `mqt/qmap/na/` triggered the ancestor walk.

Two layers, both fixed:

- **Generation** (`collect_search_locations`): the namespace-ancestor walk (#1417) only ran for `__init__` entries, so an install tree holding just a leaf module (`mqt/ddsim/pyddsim.abi3.so`) never gave the ancestor (`mqt`) the install-tree path. A second pass now lets loose files extend *already-registered* ancestors; unregistered containing directories (a `wheel.install-dir` prefix) still are not synthesized, preserving #1427.
- **Runtime** (redirect finder): a synthesized namespace spec now merges the portions native `PathFinder` resolution finds on `sys.path` (only when native resolution also sees a namespace), so siblings on any path entry stay importable — matching the pre-1.0 plain-`.pth` behavior. This also covers siblings outside the editable's own site-packages (user-site, other `.pth` entries).

Regression tests were written first and reproduced the report, including an end-to-end venv test where a normally-installed sibling shares the namespace with the editable install and failed with the reported `ModuleNotFoundError`.