### PR TITLE
fix: wheel timestamp clamp overflows on 32-bit time_t platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,34 @@ jobs:
           verbose: true
           token: 6d9cc0e0-158a-41ee-b8f4-0318d3595ac2
 
+  checks-32bit:
+    name: 🐍 3.13 • 32-bit Linux (i686)
+    needs: changes
+    if: fromJSON(needs.changes.outputs.run-tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # actions/setup-python has no 32-bit Linux builds, and `container:` can't
+      # run i386 images (the runner injects a 64-bit node), so use docker
+      # directly. i386 runs natively on the amd64 host. No numpy: no i686
+      # wheels; numpy-dependent tests skip. linux32 makes uname report i686.
+      - name: Test package
+        run: |
+          docker run -i --rm --platform linux/386 -v "$PWD:/io" -w /io \
+            i386/python:3.13-slim linux32 bash -euxs <<'EOF'
+          apt-get update
+          apt-get install -y --no-install-recommends cmake make ninja-build g++ git
+          git config --global --add safe.directory /io
+          pip install -U pip
+          pip install -e ".[wheel-free-setuptools]" --group test-parallel \
+            --group test-meta --group test-pybind11 --group test-schema
+          pytest -ra --showlocals -n auto --durations=20
+          EOF
+
   min:
     name: Min 🐍 ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     needs: changes

--- a/src/scikit_build_core/build/_wheelfile.py
+++ b/src/scikit_build_core/build/_wheelfile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __lazy_modules__ = {
     "base64",
     "csv",
+    "datetime",
     "email",
     "email.message",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._reproducible",
@@ -17,6 +18,7 @@ __lazy_modules__ = {
 import base64
 import csv
 import dataclasses
+import datetime
 import hashlib
 import io
 import os
@@ -143,7 +145,11 @@ class WheelWriter:
         # The ZIP file format only supports timestamps from 1980-01-01 to
         # 2107-12-31 23:59:59 (inclusive); clamp rather than let zipfile crash.
         timestamp = min(max(timestamp, MIN_TIMESTAMP), MAX_TIMESTAMP)
-        return time.gmtime(timestamp)[0:6]
+        # Not time.gmtime: it overflows past 2038 where time_t is 32 bits.
+        dt = datetime.datetime(
+            1970, 1, 1, tzinfo=datetime.timezone.utc
+        ) + datetime.timedelta(seconds=timestamp)
+        return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
     def dist_info_contents(self) -> dict[str, bytes]:
         entry_points = io.StringIO()

--- a/tests/test_wheelfile_utils.py
+++ b/tests/test_wheelfile_utils.py
@@ -50,17 +50,19 @@ def test_wheel_timestamp_clamps_epoch_beyond_zip_range(
 ):
     # A SOURCE_DATE_EPOCH beyond 2107-12-31 23:59:59 UTC (e.g. a milliseconds-epoch
     # mistake) cannot be represented in the ZIP date format and must be clamped
-    # rather than crash deep inside zipfile with a struct.error.
+    # rather than crash deep inside zipfile with a struct.error. The expected
+    # value is hardcoded because time.gmtime(MAX_TIMESTAMP) overflows on 32-bit
+    # time_t platforms (which is also why timestamp() must not use time.gmtime).
     monkeypatch.setenv("SOURCE_DATE_EPOCH", str(MAX_TIMESTAMP + 1))
     wheel = _make_writer(tmp_path, reproducible=reproducible)
-    assert wheel.timestamp() == time.gmtime(MAX_TIMESTAMP)[0:6]
+    assert wheel.timestamp() == (2107, 12, 31, 23, 59, 59)
 
     # The resulting date must actually be writable to a real ZIP archive (the DOS
     # date format only stores even seconds, so the last field may round down).
     with wheel:
         wheel.writestr("data.txt", b"hello")
     with zipfile.ZipFile(wheel.wheelpath) as zf:
-        assert zf.getinfo("data.txt").date_time[:5] == time.gmtime(MAX_TIMESTAMP)[0:5]
+        assert zf.getinfo("data.txt").date_time[:5] == (2107, 12, 31, 23, 59)
 
 
 def test_reproducible_epoch_non_integer_errors(monkeypatch, capsys):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1481.

`WheelWriter.timestamp()` clamps out-of-range `SOURCE_DATE_EPOCH` values to the ZIP format's limits, but the upper bound (2107-12-31) is past what a 32-bit `time_t` can represent, so `time.gmtime` raised `OverflowError` on 32-bit platforms — in the production code path, not just the test. The conversion now uses pure `datetime` arithmetic, and the test's expected values are hardcoded (they previously called `time.gmtime(MAX_TIMESTAMP)` too).

Also adds a 32-bit i686 Linux CI job. `actions/setup-python` has no 32-bit Linux builds and GHA `container:` can't run i386 images (the runner injects a 64-bit node binary), so the job runs the suite via `docker run --platform linux/386` with apt-provided cmake/ninja/g++ and no numpy (no i686 wheels; those tests skip). Both the failure and the fix were verified in a local `i386/python:3.13-slim` container.