### PR TITLE
chore: regenerate cog sections for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ strict-config = true
 experimental = false
 
 # If set, this will provide a method for backward compatibility.
-minimum-version = "0.12"  # current version
+minimum-version = "1.0"  # current version
 
 # The CMake build directory. Defaults to a unique temporary directory.
 build-dir = ""

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -122,7 +122,7 @@ print(mk_skbuild_docs())
 .. confval:: minimum-version
 
   :Type: ``Version``
-  :Default: "0.12"  # current version
+  :Default: "1.0"  # current version
   :Config-settings: ``minimum-version`` or ``skbuild.minimum-version``
   :Environment variable: ``SKBUILD_MINIMUM_VERSION``
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Ran `nox -t gen` now that 1.0 is released. The only change is the `# current version` comment on the `minimum-version` default, which updates from 0.12 to 1.0 in `README.md` and `docs/reference/configs.md`.