### PR TITLE
docs: prepare changelog for 1.0.1

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 1.0.1
+
+This patch release fixes two bugs: shared namespace packages were being
+truncated in redirect editable installs, and the wheel timestamp clamp could
+overflow on 32-bit `time_t` platforms.
+
+Fixes:
+
+- Don't truncate shared namespaces in redirect mode by @henryiii in #1483
+- Wheel timestamp clamp overflows on 32-bit `time_t` platforms by @henryiii in
+  #1484
+
+Internal:
+
+- Update pre-commit hooks in #1480
+
 ## Version 1.0.0
 
 We've worked through over 100 issues and ran extensive review sweeps, fixing


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `1.0.1` section to the changelog covering the two fixes since `v1.0.0` (#1483, #1484) plus the pre-commit hook update (#1480).