### PR TITLE
feat: package-declared config-settings

### DIFF
--- a/docs/api/scikit_build_core.settings.rst
+++ b/docs/api/scikit_build_core.settings.rst
@@ -25,6 +25,14 @@ scikit\_build\_core.settings.auto\_requires module
    :show-inheritance:
    :undoc-members:
 
+scikit\_build\_core.settings.config\_settings module
+----------------------------------------------------
+
+.. automodule:: scikit_build_core.settings.config_settings
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 scikit\_build\_core.settings.documentation module
 -------------------------------------------------
 

--- a/docs/configuration/config_settings.md
+++ b/docs/configuration/config_settings.md
@@ -21,7 +21,6 @@ config-settings:
 [tool.scikit-build.config-setting."zmq.prefix"]
 help = "Prefix to search for libzmq"
 env = "ZMQ_PREFIX"
-cmake = "ZMQ_PREFIX"
 
 [tool.scikit-build.config-setting."zmq.libzmq"]
 help = "Where libzmq comes from"
@@ -40,7 +39,6 @@ The supported keys are:
 - `env`: An environment variable that is also read for this setting.
 - `choices`: A list of allowed string values (`str` type only); other values
   produce an error.
-- `cmake`: A CMake cache variable that is set to the resolved value (see below).
 
 Users can then configure the build with either interface:
 
@@ -58,27 +56,17 @@ Declaring config-settings requires `minimum-version = "1.1"` (or unset).
 
 ## Passing values to CMake
 
-There are two equivalent ways to forward a setting to CMake. The `cmake` key in
-the declaration is the most compact:
-
-```toml
-[tool.scikit-build.config-setting."zmq.prefix"]
-env = "ZMQ_PREFIX"
-cmake = "ZMQ_PREFIX"
-```
-
-Alternatively, a `cmake.define` entry can reference the setting, similar to the
-`{env = ...}` form:
+A `cmake.define` entry can reference a setting, similar to the `{env = ...}`
+form:
 
 ```toml
 [tool.scikit-build.cmake.define]
 ZMQ_PREFIX = { config-setting = "zmq.prefix" }
 ```
 
-In both forms, the define is left unset when the setting resolves to no value,
-so `if(DEFINED ZMQ_PREFIX)` works in CMake, and an explicit define (in the
-static table, an override, `-C cmake.define.NAME=...`, or
-`SKBUILD_CMAKE_DEFINE`) wins over the declaration's `cmake` alias.
+The define is left unset when the setting resolves to no value, so
+`if(DEFINED ZMQ_PREFIX)` works in CMake, and `-C cmake.define.NAME=...` or
+`SKBUILD_CMAKE_DEFINE` still win over the referenced value.
 
 ## Use in overrides
 

--- a/docs/configuration/config_settings.md
+++ b/docs/configuration/config_settings.md
@@ -81,15 +81,6 @@ messages.after-success = "{green}Using bundled libzmq"
 String conditions are regexes; boolean conditions match the truthiness of the
 value (unset matches `false`).
 
-:::{note}
-
-Since scikit-build-core versions before 1.1 reject unknown `if` conditions, a
-package that must remain buildable with older versions can guard the override
-with `if.scikit-build-version = ">=1.1"` (though declaring the settings table
-itself already requires 1.1 via `build-system.requires`).
-
-:::
-
 :::{warning}
 
 Some build frontends (like pip) pass the same `-C` settings to every package

--- a/docs/configuration/config_settings.md
+++ b/docs/configuration/config_settings.md
@@ -24,7 +24,6 @@ env = "ZMQ_PREFIX"
 
 [tool.scikit-build.config-setting."zmq.libzmq"]
 help = "Where libzmq comes from"
-choices = ["bundled", "system"]
 default = "system"
 ```
 
@@ -37,8 +36,6 @@ The supported keys are:
 - `default`: The value used when the setting is not passed; must match the type.
   If not set, the setting is "unset" when not passed.
 - `env`: An environment variable that is also read for this setting.
-- `choices`: A list of allowed string values (`str` type only); other values
-  produce an error.
 
 Users can then configure the build with either interface:
 

--- a/docs/configuration/config_settings.md
+++ b/docs/configuration/config_settings.md
@@ -1,0 +1,115 @@
+# Package config-settings
+
+Packages can declare their own config-settings, giving users a documented,
+package-level interface for configuring the build, with no need to expose raw
+CMake defines like `-C cmake.define.ZMQ_PREFIX=...`. Declared settings can be
+passed as PEP 517 config-settings (`-C name=value`), bound to an environment
+variable, and forwarded to CMake.
+
+:::{versionadded} 1.1
+
+:::
+
+## Declaring settings
+
+Each setting is declared in the `tool.scikit-build.config-setting` table. Names
+must have at least two dot-separated segments; using your import package name as
+the first segment is recommended to avoid clashes with other tools'
+config-settings:
+
+```toml
+[tool.scikit-build.config-setting."zmq.prefix"]
+help = "Prefix to search for libzmq"
+env = "ZMQ_PREFIX"
+cmake = "ZMQ_PREFIX"
+
+[tool.scikit-build.config-setting."zmq.libzmq"]
+help = "Where libzmq comes from"
+choices = ["bundled", "system"]
+default = "system"
+```
+
+The supported keys are:
+
+- `help`: A description of the setting, for documentation purposes.
+- `type`: Either `"str"` (default) or `"bool"`. Boolean values are parsed like
+  environment variables in overrides (case insensitive `true`, `on`, `yes`, `y`,
+  `t`, or a positive number are truthy).
+- `default`: The value used when the setting is not passed; must match the type.
+  If not set, the setting is "unset" when not passed.
+- `env`: An environment variable that is also read for this setting.
+- `choices`: A list of allowed string values (`str` type only); other values
+  produce an error.
+- `cmake`: A CMake cache variable that is set to the resolved value (see below).
+
+Users can then configure the build with either interface:
+
+```console
+$ pip install . -Czmq.libzmq=bundled
+$ ZMQ_PREFIX=/opt/zmq pip install .
+```
+
+The environment variable takes precedence over the config-setting, which takes
+precedence over the default (the same ordering used for scikit-build-core's own
+settings). Declared names are matched verbatim, are exempt from `strict-config`
+validation, and get "did you mean" suggestions when mistyped.
+
+Declaring config-settings requires `minimum-version = "1.1"` (or unset).
+
+## Passing values to CMake
+
+There are two equivalent ways to forward a setting to CMake. The `cmake` key in
+the declaration is the most compact:
+
+```toml
+[tool.scikit-build.config-setting."zmq.prefix"]
+env = "ZMQ_PREFIX"
+cmake = "ZMQ_PREFIX"
+```
+
+Alternatively, a `cmake.define` entry can reference the setting, similar to the
+`{env = ...}` form:
+
+```toml
+[tool.scikit-build.cmake.define]
+ZMQ_PREFIX = { config-setting = "zmq.prefix" }
+```
+
+In both forms, the define is left unset when the setting resolves to no value,
+so `if(DEFINED ZMQ_PREFIX)` works in CMake, and an explicit define (in the
+static table, an override, `-C cmake.define.NAME=...`, or
+`SKBUILD_CMAKE_DEFINE`) wins over the declaration's `cmake` alias.
+
+## Use in overrides
+
+Declared settings can drive [overrides](./overrides.md) with the
+`if.config-setting` condition, which matches the resolved value (so `-C` and the
+bound environment variable behave identically):
+
+```toml
+[[tool.scikit-build.overrides]]
+if.config-setting."zmq.libzmq" = "bundled"
+cmake.define.ZMQ_LIBZMQ = "ON"
+messages.after-success = "{green}Using bundled libzmq"
+```
+
+String conditions are regexes; boolean conditions match the truthiness of the
+value (unset matches `false`).
+
+:::{note}
+
+Since scikit-build-core versions before 1.1 reject unknown `if` conditions, a
+package that must remain buildable with older versions can guard the override
+with `if.scikit-build-version = ">=1.1"` (though declaring the settings table
+itself already requires 1.1 via `build-system.requires`).
+
+:::
+
+:::{warning}
+
+Some build frontends (like pip) pass the same `-C` settings to every package
+built in a single command, so a setting intended for one package may reach
+another, where it is unrecognized and rejected under `strict-config`. Prefer
+installing such packages in separate commands when passing config-settings.
+
+:::

--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -131,6 +131,27 @@ This is often combined with `if.any`.
 
 :::
 
+### `config-setting.*` (string or bool)
+
+A table of [package-declared config-settings](./config_settings.md) mapped to
+either string regexes, or booleans. The condition matches the _resolved_ value
+(from the bound environment variable, the `-C` config-setting, or the default),
+so both user interfaces behave identically. An unset setting never matches a
+string condition and matches a `false` boolean condition. The setting must be
+declared in `tool.scikit-build.config-setting`.
+
+Example:
+
+```toml
+[[tool.scikit-build.overrides]]
+if.config-setting."zmq.libzmq" = "bundled"
+cmake.define.ZMQ_LIBZMQ = "ON"
+```
+
+:::{versionadded} 1.1
+
+:::
+
 ### `state` (string)
 
 The state of the build, one of `sdist`, `wheel`, `editable`, `metadata_wheel`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ guide/faqs
 configuration/index
 configuration/editable
 configuration/overrides
+configuration/config_settings
 configuration/dynamic
 configuration/advanced
 ```

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -626,6 +626,7 @@
           "properties": {
             "help": {
               "type": "string",
+              "default": "",
               "description": "A description of the setting."
             },
             "type": {
@@ -649,8 +650,8 @@
             },
             "env": {
               "type": "string",
-              "minLength": 1,
-              "description": "An environment variable also read for this setting; it takes precedence over `-C`."
+              "description": "An environment variable also read for this setting; it takes precedence over `-C`.",
+              "minLength": 1
             }
           }
         }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -651,13 +651,6 @@
               "type": "string",
               "minLength": 1,
               "description": "An environment variable also read for this setting; it takes precedence over `-C`."
-            },
-            "choices": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "The allowed values (str type only)."
             }
           }
         }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -658,11 +658,6 @@
                 "type": "string"
               },
               "description": "The allowed values (str type only)."
-            },
-            "cmake": {
-              "type": "string",
-              "minLength": 1,
-              "description": "A CMake cache variable set to the resolved value; explicit defines win over it."
             }
           }
         }

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -70,6 +70,20 @@
                       ]
                     }
                   }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "config-setting"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "config-setting": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "The declared config-setting name whose resolved value this define takes; the define is dropped when unset."
+                    }
+                  }
                 }
               ]
             }
@@ -601,6 +615,59 @@
       "default": "",
       "description": "The CMake build directory. Defaults to a unique temporary directory."
     },
+    "config-setting": {
+      "type": "object",
+      "description": "Declare package-specific config-settings, settable via `-C name=value` or a bound environment variable.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "help": {
+              "type": "string",
+              "description": "A description of the setting."
+            },
+            "type": {
+              "enum": [
+                "str",
+                "bool"
+              ],
+              "default": "str",
+              "description": "The type of the setting."
+            },
+            "default": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "The value used when the setting is not passed; must match the type."
+            },
+            "env": {
+              "type": "string",
+              "minLength": 1,
+              "description": "An environment variable also read for this setting; it takes precedence over `-C`."
+            },
+            "choices": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The allowed values (str type only)."
+            },
+            "cmake": {
+              "type": "string",
+              "minLength": 1,
+              "description": "A CMake cache variable set to the resolved value; explicit defines win over it."
+            }
+          }
+        }
+      }
+    },
     "overrides": {
       "type": "array",
       "description": "A list of overrides to apply to the settings, based on the `if` selector.",
@@ -953,6 +1020,24 @@
           "additionalProperties": false,
           "minProperties": 1,
           "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0."
+        },
+        "config-setting": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "A table of declared config-settings (tool.scikit-build.config-setting) mapped to either string regexs, or booleans. Matches the resolved value (env var, `-C`, or default)."
         }
       }
     },

--- a/src/scikit_build_core/settings/config_settings.py
+++ b/src/scikit_build_core/settings/config_settings.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    f"{__spec__.parent}.skbuild_model",
+    f"{__spec__.parent}.skbuild_overrides",
+    "typing",
+}
+
+import dataclasses
+import re
+from typing import Any, Literal
+
+from .._logging import rich_error
+from .skbuild_model import ScikitBuildSettings
+from .skbuild_overrides import strtobool
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = [
+    "ConfigSettingDeclaration",
+    "apply_cmake_aliases",
+    "load_declarations",
+    "resolve_config_settings",
+    "resolve_define_references",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+# At least two dotted segments; matched verbatim (no dash/underscore
+# normalization), like env-table keys.
+_NAME_REGEX = re.compile(r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$")
+
+_DECLARATION_KEYS = frozenset({"help", "type", "default", "env", "choices", "cmake"})
+
+
+@dataclasses.dataclass(frozen=True)
+class ConfigSettingDeclaration:
+    """
+    A single entry in the ``tool.scikit-build.config-setting`` table.
+
+    Declares a package-specific config-setting key that users may pass via PEP
+    517 config-settings (``-C name=value``) or, if ``env`` is set, an
+    environment variable.
+    """
+
+    help: str = ""
+    type: Literal["str", "bool"] = "str"
+    default: str | bool | None = None
+    env: str | None = None
+    choices: list[str] | None = None
+    cmake: str | None = None
+
+
+def _error_context(name: str) -> str:
+    return f"tool.scikit-build.config-setting.{name!r}"
+
+
+def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
+    """
+    Validate and load the raw ``tool.scikit-build.config-setting`` table.
+    """
+    if not isinstance(raw, dict):
+        rich_error("tool.scikit-build.config-setting must be a table")
+
+    reserved = {
+        field.name.replace("_", "-")
+        for field in dataclasses.fields(ScikitBuildSettings)
+    } | {"overrides", "config-setting", "skbuild"}
+
+    decls: dict[str, ConfigSettingDeclaration] = {}
+    for name, entry in raw.items():
+        if not _NAME_REGEX.match(name):
+            rich_error(
+                f"{_error_context(name)} must be two or more dotted segments of"
+                " letters, digits, '-', and '_'"
+            )
+        first_segment = name.split(".", 1)[0]
+        if first_segment in reserved:
+            rich_error(
+                f"{_error_context(name)} may not start with the reserved segment"
+                f" {first_segment!r}"
+            )
+        if not isinstance(entry, dict):
+            rich_error(f"{_error_context(name)} must be a table")
+        unknown = set(entry) - _DECLARATION_KEYS
+        if unknown:
+            rich_error(
+                f"{_error_context(name)} has unrecognized keys:"
+                f" {', '.join(sorted(unknown))}"
+            )
+
+        help_text = entry.get("help", "")
+        if not isinstance(help_text, str):
+            rich_error(f"{_error_context(name)} 'help' must be a string")
+        type_ = entry.get("type", "str")
+        if type_ not in {"str", "bool"}:
+            rich_error(f"{_error_context(name)} 'type' must be 'str' or 'bool'")
+        env = entry.get("env")
+        if env is not None and (not isinstance(env, str) or not env):
+            rich_error(f"{_error_context(name)} 'env' must be a non-empty string")
+        cmake = entry.get("cmake")
+        if cmake is not None and (not isinstance(cmake, str) or not cmake):
+            rich_error(f"{_error_context(name)} 'cmake' must be a non-empty string")
+        choices = entry.get("choices")
+        if choices is not None:
+            if type_ == "bool":
+                rich_error(
+                    f"{_error_context(name)} 'choices' is not allowed with"
+                    " type = 'bool'"
+                )
+            if not isinstance(choices, list) or not all(
+                isinstance(c, str) for c in choices
+            ):
+                rich_error(
+                    f"{_error_context(name)} 'choices' must be a list of strings"
+                )
+        default = entry.get("default")
+        if default is not None:
+            # bool is checked first since bool is an int subclass.
+            if type_ == "bool" and not isinstance(default, bool):
+                rich_error(
+                    f"{_error_context(name)} 'default' must be a boolean for"
+                    " type = 'bool'"
+                )
+            if type_ == "str" and not isinstance(default, str):
+                rich_error(
+                    f"{_error_context(name)} 'default' must be a string for"
+                    " type = 'str'"
+                )
+            if choices is not None and default not in choices:
+                rich_error(
+                    f"{_error_context(name)} 'default' must be one of the choices"
+                )
+
+        decls[name] = ConfigSettingDeclaration(
+            help=help_text,
+            type=type_,
+            default=default,
+            env=env,
+            choices=choices,
+            cmake=cmake,
+        )
+    return decls
+
+
+def resolve_config_settings(
+    decls: Mapping[str, ConfigSettingDeclaration],
+    config_settings: Mapping[str, str | list[str] | bool],
+    env: Mapping[str, str],
+) -> dict[str, str | bool | None]:
+    """
+    Resolve declared config-settings; precedence env var > config-setting >
+    default, with ``None`` meaning "unset".
+    """
+    values: dict[str, str | bool | None] = {}
+    for name, decl in decls.items():
+        raw: str | bool | None
+        if decl.env is not None and decl.env in env:
+            raw = env[decl.env]
+        elif name in config_settings:
+            item = config_settings[name]
+            if isinstance(item, list):
+                if len(item) != 1:
+                    rich_error(f"config-setting {name!r} was passed more than once")
+                item = item[0]
+            raw = item
+        else:
+            # Defaults are validated against the declared type at load time.
+            values[name] = decl.default
+            continue
+
+        if decl.type == "bool":
+            values[name] = raw if isinstance(raw, bool) else strtobool(raw)
+            continue
+        if isinstance(raw, bool):
+            rich_error(f"config-setting {name!r} expected a string, got a boolean")
+        if decl.choices is not None and raw not in decl.choices:
+            rich_error(
+                f"config-setting {name!r} got {raw!r}; valid choices:"
+                f" {', '.join(decl.choices)}"
+            )
+        values[name] = raw
+    return values
+
+
+def resolve_define_references(
+    tool_skb: dict[str, Any], values: Mapping[str, str | bool | None]
+) -> None:
+    """
+    Replace ``{config-setting = "..."}`` values in the raw ``cmake.define``
+    table with the resolved values, in place. Unset settings drop the define
+    (mirroring the ``{env = ...}`` form). Malformed non-table values are left
+    for the normal settings conversion to report.
+    """
+    cmake_table = tool_skb.get("cmake", {})
+    if not isinstance(cmake_table, dict):
+        return
+    define = cmake_table.get("define", {})
+    if not isinstance(define, dict):
+        return
+    for key, entry in list(define.items()):
+        if not isinstance(entry, dict) or "config-setting" not in entry:
+            continue
+        unknown = set(entry) - {"config-setting"}
+        if unknown:
+            rich_error(
+                f"cmake.define.{key} config-setting reference has unrecognized"
+                f" keys: {', '.join(sorted(unknown))} (put defaults in the"
+                " declaration instead)"
+            )
+        name = entry["config-setting"]
+        if not isinstance(name, str) or name not in values:
+            rich_error(
+                f"cmake.define.{key} references undeclared config-setting {name!r}"
+            )
+        value = values[name]
+        if value is None:
+            del define[key]
+        else:
+            define[key] = value
+
+
+def apply_cmake_aliases(
+    tool_skb: dict[str, Any],
+    decls: Mapping[str, ConfigSettingDeclaration],
+    values: Mapping[str, str | bool | None],
+) -> None:
+    """
+    Insert resolved values for declarations with a ``cmake`` alias into the raw
+    ``cmake.define`` table. Explicit defines (TOML, overrides, config-settings,
+    env vars) win over the alias. Malformed non-table values are left for the
+    normal settings conversion to report.
+    """
+    for name, decl in decls.items():
+        if decl.cmake is None:
+            continue
+        value = values[name]
+        if value is None:
+            continue
+        cmake_table = tool_skb.setdefault("cmake", {})
+        if not isinstance(cmake_table, dict):
+            return
+        define = cmake_table.setdefault("define", {})
+        if not isinstance(define, dict):
+            return
+        define.setdefault(decl.cmake, value)

--- a/src/scikit_build_core/settings/config_settings.py
+++ b/src/scikit_build_core/settings/config_settings.py
@@ -10,7 +10,7 @@ __lazy_modules__ = {
 
 import dataclasses
 import re
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from .._logging import rich_error
 from .skbuild_model import ScikitBuildSettings
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 
-def __dir__() -> List[str]:
+def __dir__() -> list[str]:
     return __all__
 
 
@@ -76,7 +76,7 @@ def _error_context(name: str) -> str:
     return f"tool.scikit-build.config-setting.{name!r}"
 
 
-def load_declarations(raw: Any) -> Dict[str, ConfigSettingDeclaration]:
+def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
     """
     Validate and load the raw ``tool.scikit-build.config-setting`` table.
     """
@@ -90,7 +90,7 @@ def load_declarations(raw: Any) -> Dict[str, ConfigSettingDeclaration]:
         for field in dataclasses.fields(ScikitBuildSettings)
     } | {"overrides", "config-setting", "skbuild"}
 
-    decls: Dict[str, ConfigSettingDeclaration] = {}
+    decls: dict[str, ConfigSettingDeclaration] = {}
     for name, entry in raw.items():
         if not _NAME_REGEX.match(name):
             rich_error(
@@ -146,14 +146,14 @@ def load_declarations(raw: Any) -> Dict[str, ConfigSettingDeclaration]:
 
 def resolve_config_settings(
     decls: "Mapping[str, ConfigSettingDeclaration]",
-    config_settings: "Mapping[str, Union[str, List[str], bool]]",
+    config_settings: "Mapping[str, Union[str, list[str], bool]]",
     env: "Mapping[str, str]",
-) -> Dict[str, Optional[Union[str, bool]]]:
+) -> dict[str, Optional[Union[str, bool]]]:
     """
     Resolve declared config-settings; precedence env var > config-setting >
     default, with ``None`` meaning "unset".
     """
-    values: Dict[str, Optional[Union[str, bool]]] = {}
+    values: dict[str, Optional[Union[str, bool]]] = {}
     for name, decl in decls.items():
         raw: Optional[Union[str, bool]]
         if decl.env is not None and decl.env in env:
@@ -180,7 +180,7 @@ def resolve_config_settings(
 
 
 def resolve_define_references(
-    tool_skb: Dict[str, Any], values: "Mapping[str, Optional[Union[str, bool]]]"
+    tool_skb: dict[str, Any], values: "Mapping[str, Optional[Union[str, bool]]]"
 ) -> None:
     """
     Replace ``{config-setting = "..."}`` values in the raw ``cmake.define``

--- a/src/scikit_build_core/settings/config_settings.py
+++ b/src/scikit_build_core/settings/config_settings.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ConfigSettingDeclaration",
-    "apply_cmake_aliases",
     "load_declarations",
     "resolve_config_settings",
     "resolve_define_references",
@@ -36,7 +35,7 @@ def __dir__() -> list[str]:
 # normalization), like env-table keys.
 _NAME_REGEX = re.compile(r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$")
 
-_DECLARATION_KEYS = frozenset({"help", "type", "default", "env", "choices", "cmake"})
+_DECLARATION_KEYS = frozenset({"help", "type", "default", "env", "choices"})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -54,7 +53,6 @@ class ConfigSettingDeclaration:
     default: str | bool | None = None
     env: str | None = None
     choices: list[str] | None = None
-    cmake: str | None = None
 
 
 def _error_context(name: str) -> str:
@@ -104,9 +102,6 @@ def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
         env = entry.get("env")
         if env is not None and (not isinstance(env, str) or not env):
             rich_error(f"{_error_context(name)} 'env' must be a non-empty string")
-        cmake = entry.get("cmake")
-        if cmake is not None and (not isinstance(cmake, str) or not cmake):
-            rich_error(f"{_error_context(name)} 'cmake' must be a non-empty string")
         choices = entry.get("choices")
         if choices is not None:
             if type_ == "bool":
@@ -144,7 +139,6 @@ def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
             default=default,
             env=env,
             choices=choices,
-            cmake=cmake,
         )
     return decls
 
@@ -224,29 +218,3 @@ def resolve_define_references(
             del define[key]
         else:
             define[key] = value
-
-
-def apply_cmake_aliases(
-    tool_skb: dict[str, Any],
-    decls: Mapping[str, ConfigSettingDeclaration],
-    values: Mapping[str, str | bool | None],
-) -> None:
-    """
-    Insert resolved values for declarations with a ``cmake`` alias into the raw
-    ``cmake.define`` table. Explicit defines (TOML, overrides, config-settings,
-    env vars) win over the alias. Malformed non-table values are left for the
-    normal settings conversion to report.
-    """
-    for name, decl in decls.items():
-        if decl.cmake is None:
-            continue
-        value = values[name]
-        if value is None:
-            continue
-        cmake_table = tool_skb.setdefault("cmake", {})
-        if not isinstance(cmake_table, dict):
-            return
-        define = cmake_table.setdefault("define", {})
-        if not isinstance(define, dict):
-            return
-        define.setdefault(decl.cmake, value)

--- a/src/scikit_build_core/settings/config_settings.py
+++ b/src/scikit_build_core/settings/config_settings.py
@@ -1,4 +1,5 @@
-from __future__ import annotations
+# No `from __future__ import annotations` here: `to_json_schema` reads real
+# runtime types from the dataclass fields, like `skbuild_model.py`.
 
 __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
@@ -9,7 +10,7 @@ __lazy_modules__ = {
 
 import dataclasses
 import re
-from typing import Any, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from .._logging import rich_error
 from .skbuild_model import ScikitBuildSettings
@@ -27,7 +28,7 @@ __all__ = [
 ]
 
 
-def __dir__() -> list[str]:
+def __dir__() -> List[str]:
     return __all__
 
 
@@ -36,10 +37,7 @@ def __dir__() -> list[str]:
 _NAME_REGEX = re.compile(r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$")
 
 # A "choices" key (allowed values, str type only) was cut from the initial
-# release to keep the surface minimal. To re-add: a `choices: list[str] | None`
-# field here, load-time validation (list of strings, not with type = 'bool',
-# default must be a member), a resolved-value check in resolve_config_settings,
-# and the entry-schema property in skbuild_schema.py.
+# release to keep the surface minimal; see git history to re-add.
 _DECLARATION_KEYS = frozenset({"help", "type", "default", "env"})
 
 
@@ -54,28 +52,45 @@ class ConfigSettingDeclaration:
     """
 
     help: str = ""
+    """
+    A description of the setting.
+    """
+
     type: Literal["str", "bool"] = "str"
-    default: str | bool | None = None
-    env: str | None = None
+    """
+    The type of the setting.
+    """
+
+    default: Optional[Union[str, bool]] = None
+    """
+    The value used when the setting is not passed; must match the type.
+    """
+
+    env: Optional[str] = None
+    """
+    An environment variable also read for this setting; it takes precedence over `-C`.
+    """
 
 
 def _error_context(name: str) -> str:
     return f"tool.scikit-build.config-setting.{name!r}"
 
 
-def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
+def load_declarations(raw: Any) -> Dict[str, ConfigSettingDeclaration]:
     """
     Validate and load the raw ``tool.scikit-build.config-setting`` table.
     """
     if not isinstance(raw, dict):
         rich_error("tool.scikit-build.config-setting must be a table")
+    if not raw:
+        return {}
 
     reserved = {
         field.name.replace("_", "-")
         for field in dataclasses.fields(ScikitBuildSettings)
     } | {"overrides", "config-setting", "skbuild"}
 
-    decls: dict[str, ConfigSettingDeclaration] = {}
+    decls: Dict[str, ConfigSettingDeclaration] = {}
     for name, entry in raw.items():
         if not _NAME_REGEX.match(name):
             rich_error(
@@ -130,17 +145,17 @@ def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
 
 
 def resolve_config_settings(
-    decls: Mapping[str, ConfigSettingDeclaration],
-    config_settings: Mapping[str, str | list[str] | bool],
-    env: Mapping[str, str],
-) -> dict[str, str | bool | None]:
+    decls: "Mapping[str, ConfigSettingDeclaration]",
+    config_settings: "Mapping[str, Union[str, List[str], bool]]",
+    env: "Mapping[str, str]",
+) -> Dict[str, Optional[Union[str, bool]]]:
     """
     Resolve declared config-settings; precedence env var > config-setting >
     default, with ``None`` meaning "unset".
     """
-    values: dict[str, str | bool | None] = {}
+    values: Dict[str, Optional[Union[str, bool]]] = {}
     for name, decl in decls.items():
-        raw: str | bool | None
+        raw: Optional[Union[str, bool]]
         if decl.env is not None and decl.env in env:
             raw = env[decl.env]
         elif name in config_settings:
@@ -165,7 +180,7 @@ def resolve_config_settings(
 
 
 def resolve_define_references(
-    tool_skb: dict[str, Any], values: Mapping[str, str | bool | None]
+    tool_skb: Dict[str, Any], values: "Mapping[str, Optional[Union[str, bool]]]"
 ) -> None:
     """
     Replace ``{config-setting = "..."}`` values in the raw ``cmake.define``

--- a/src/scikit_build_core/settings/config_settings.py
+++ b/src/scikit_build_core/settings/config_settings.py
@@ -35,7 +35,12 @@ def __dir__() -> list[str]:
 # normalization), like env-table keys.
 _NAME_REGEX = re.compile(r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$")
 
-_DECLARATION_KEYS = frozenset({"help", "type", "default", "env", "choices"})
+# A "choices" key (allowed values, str type only) was cut from the initial
+# release to keep the surface minimal. To re-add: a `choices: list[str] | None`
+# field here, load-time validation (list of strings, not with type = 'bool',
+# default must be a member), a resolved-value check in resolve_config_settings,
+# and the entry-schema property in skbuild_schema.py.
+_DECLARATION_KEYS = frozenset({"help", "type", "default", "env"})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -52,7 +57,6 @@ class ConfigSettingDeclaration:
     type: Literal["str", "bool"] = "str"
     default: str | bool | None = None
     env: str | None = None
-    choices: list[str] | None = None
 
 
 def _error_context(name: str) -> str:
@@ -102,19 +106,6 @@ def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
         env = entry.get("env")
         if env is not None and (not isinstance(env, str) or not env):
             rich_error(f"{_error_context(name)} 'env' must be a non-empty string")
-        choices = entry.get("choices")
-        if choices is not None:
-            if type_ == "bool":
-                rich_error(
-                    f"{_error_context(name)} 'choices' is not allowed with"
-                    " type = 'bool'"
-                )
-            if not isinstance(choices, list) or not all(
-                isinstance(c, str) for c in choices
-            ):
-                rich_error(
-                    f"{_error_context(name)} 'choices' must be a list of strings"
-                )
         default = entry.get("default")
         if default is not None:
             # bool is checked first since bool is an int subclass.
@@ -128,17 +119,12 @@ def load_declarations(raw: Any) -> dict[str, ConfigSettingDeclaration]:
                     f"{_error_context(name)} 'default' must be a string for"
                     " type = 'str'"
                 )
-            if choices is not None and default not in choices:
-                rich_error(
-                    f"{_error_context(name)} 'default' must be one of the choices"
-                )
 
         decls[name] = ConfigSettingDeclaration(
             help=help_text,
             type=type_,
             default=default,
             env=env,
-            choices=choices,
         )
     return decls
 
@@ -174,11 +160,6 @@ def resolve_config_settings(
             continue
         if isinstance(raw, bool):
             rich_error(f"config-setting {name!r} expected a string, got a boolean")
-        if decl.choices is not None and raw not in decl.choices:
-            rich_error(
-                f"config-setting {name!r} got {raw!r}; valid choices:"
-                f" {', '.join(decl.choices)}"
-            )
         values[name] = raw
     return values
 

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -115,6 +115,7 @@ def override_match(
     ],
     has_dist_info: bool,
     retry: bool,
+    current_config_settings: Mapping[str, str | bool | None] | None = None,
     python_version: str | None = None,
     implementation_name: str | None = None,
     implementation_version: str | None = None,
@@ -122,6 +123,7 @@ def override_match(
     platform_machine: str | None = None,
     platform_node: str | None = None,
     env: dict[str, str] | None = None,
+    config_setting: dict[str, str | bool] | None = None,
     state: str | None = None,
     from_sdist: bool | None = None,
     failed: bool | None = None,
@@ -283,6 +285,43 @@ def override_match(
                 else:
                     failed_set.add(f"env.{key}")
 
+    if config_setting:
+        for cs_key, cs_match in config_setting.items():
+            if current_config_settings is None or cs_key not in current_config_settings:
+                msg = (
+                    f"if.config-setting {cs_key!r} is not declared in"
+                    " tool.scikit-build.config-setting"
+                )
+                raise TypeError(msg)
+            cs_value = current_config_settings[cs_key]
+            if isinstance(cs_match, bool):
+                cs_bool = (
+                    cs_value
+                    if isinstance(cs_value, bool)
+                    else strtobool(cs_value or "")
+                )
+                if cs_bool == cs_match:
+                    passed_dict[f"config-setting.{cs_key}"] = (
+                        f"config-setting {cs_key} is {cs_match}"
+                    )
+                else:
+                    failed_set.add(f"config-setting.{cs_key}")
+            elif cs_value is None:
+                failed_set.add(f"config-setting.{cs_key}")
+            else:
+                cs_str = (
+                    ("true" if cs_value else "false")
+                    if isinstance(cs_value, bool)
+                    else cs_value
+                )
+                match_msg = regex_match(cs_str, cs_match)
+                if match_msg:
+                    passed_dict[f"config-setting.{cs_key}"] = (
+                        f"config-setting {cs_key}: {match_msg}"
+                    )
+                else:
+                    failed_set.add(f"config-setting.{cs_key}")
+
     if len(passed_dict) + len(failed_set) + len(unknown) < 1:
         msg = "At least one override must be provided"
         raise ValueError(msg)
@@ -364,6 +403,7 @@ def process_overrides(
     state: Literal["sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"],
     retry: bool,
     env: Mapping[str, str] | None = None,
+    config_settings: Mapping[str, str | bool | None] | None = None,
 ) -> tuple[set[str], dict[str, OverrideRecord]]:
     """
     Process overrides into the main dictionary if they match. Modifies the input
@@ -400,6 +440,7 @@ def process_overrides(
                 current_state=state,
                 has_dist_info=has_dist_info,
                 retry=retry,
+                current_config_settings=config_settings,
                 **select,
             )
             unknown |= set(unknown_any)
@@ -430,6 +471,7 @@ def process_overrides(
                 current_state=state,
                 has_dist_info=has_dist_info,
                 retry=retry,
+                current_config_settings=config_settings,
                 **select,
             )
             unknown |= set(unknown_all)

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -296,26 +296,33 @@ class SettingsReader:
             self.config_setting_decls, config_settings, environ
         )
 
+        def process_table(
+            skb: dict[str, Any], declaration_error: str
+        ) -> tuple[set[str], dict[str, OverrideRecord]]:
+            """
+            Apply overrides to one settings table, reject stray config-setting
+            declarations (the static table was popped from pyproject.toml above,
+            so any survivor is misplaced), and resolve define references.
+            """
+            matched, overridden = process_overrides(
+                skb,
+                state=state,
+                env=env,
+                retry=retry,
+                config_settings=self.custom_config_settings,
+            )
+            if "config-setting" in skb:
+                rich_error(declaration_error)
+            resolve_define_references(skb, self.custom_config_settings)
+            return matched, overridden
+
         # Handle overrides
-        self.overrides, self.overridden_items = process_overrides(
-            tool_skb,
-            state=state,
-            env=env,
-            retry=retry,
-            config_settings=self.custom_config_settings,
+        self.overrides, self.overridden_items = process_table(
+            tool_skb, "config-setting declarations may not be set by overrides"
         )
-        # The static table was popped above, so any survivor came from an
-        # override body.
-        if "config-setting" in tool_skb:
-            rich_error("config-setting declarations may not be set by overrides")
-        resolve_define_references(tool_skb, self.custom_config_settings)
 
         # Support for minimum-version='build-system.requires'
-        tmp_min_v = (
-            pyproject.get("tool", {})
-            .get("scikit-build", {})
-            .get("minimum-version", None)
-        )
+        tmp_min_v = tool_skb.get("minimum-version")
         if tmp_min_v == "build-system.requires":
             reqlist = pyproject["build-system"]["requires"]
             min_v = get_min_requires("scikit-build-core", reqlist)
@@ -324,7 +331,7 @@ class SettingsReader:
                     "scikit-build-core needs a min version in "
                     "build-system.requires to use minimum-version='build-system.requires'"
                 )
-            pyproject["tool"]["scikit-build"]["minimum-version"] = str(min_v)
+            tool_skb["minimum-version"] = str(min_v)
         toml_srcs = [TOMLSource("tool", "scikit-build", settings=pyproject)]
         # Human-readable names parallel to ``toml_srcs`` (used by suggestions).
         toml_src_names = ["pyproject.toml"]
@@ -346,18 +353,10 @@ class SettingsReader:
 
         if extra_settings is not None:
             extra_skb = copy.deepcopy(dict(extra_settings))
-            extra_matched, extra_overridden = process_overrides(
+            extra_matched, extra_overridden = process_table(
                 extra_skb,
-                state=state,
-                env=env,
-                retry=retry,
-                config_settings=self.custom_config_settings,
+                "config-setting declarations are only allowed in pyproject.toml",
             )
-            if "config-setting" in extra_skb:
-                rich_error(
-                    "config-setting declarations are only allowed in pyproject.toml"
-                )
-            resolve_define_references(extra_skb, self.custom_config_settings)
             self.overrides |= extra_matched
             self.overridden_items.update(extra_overridden)
             toml_srcs.insert(0, TOMLSource(settings=extra_skb))
@@ -390,18 +389,10 @@ class SettingsReader:
                 # which merges dicts but takes lists wholesale from the
                 # highest-precedence source. A future refactor could process
                 # overrides on the merged view instead.
-                ep_matched, ep_overridden = process_overrides(
+                ep_matched, ep_overridden = process_table(
                     ep_skb,
-                    state=state,
-                    env=env,
-                    retry=retry,
-                    config_settings=self.custom_config_settings,
+                    "config-setting declarations are only allowed in pyproject.toml",
                 )
-                if "config-setting" in ep_skb:
-                    rich_error(
-                        "config-setting declarations are only allowed in pyproject.toml"
-                    )
-                resolve_define_references(ep_skb, self.custom_config_settings)
                 self.overrides |= ep_matched
                 ep_source = TOMLSource(settings=ep_skb)
                 ep_srcs.append(ep_source)

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -13,6 +13,7 @@ __lazy_modules__ = {
     f"{__spec__.parent}._load_entrypoint_config",
     f"{__spec__.parent}.auto_cmake_version",
     f"{__spec__.parent}.auto_requires",
+    f"{__spec__.parent}.config_settings",
     f"{__spec__.parent}.skbuild_model",
     f"{__spec__.parent}.sources",
     "packaging",
@@ -42,6 +43,12 @@ from ..utils.typing import get_target_raw_type
 from ._load_entrypoint_config import load_config_providers
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
+from .config_settings import (
+    apply_cmake_aliases,
+    load_declarations,
+    resolve_config_settings,
+    resolve_define_references,
+)
 from .skbuild_model import (
     CMakeSettings,
     NinjaSettings,
@@ -264,7 +271,7 @@ class SettingsReader:
     def __init__(
         self,
         pyproject: dict[str, Any],
-        config_settings: Mapping[str, str | list[str]],
+        config_settings: Mapping[str, str | list[str] | bool],
         *,
         state: Literal[
             "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
@@ -277,13 +284,34 @@ class SettingsReader:
         self.state = state
         environ = os.environ if env is None else env
 
-        # Handle overrides
         pyproject = copy.deepcopy(pyproject)
+        tool_skb = pyproject.get("tool", {}).get("scikit-build", {})
+
+        # Project-declared config-settings: pop the declaration table (like
+        # ``overrides``, it is not a settings field) and resolve values before
+        # overrides so ``if.config-setting`` can match them.
+        self.config_setting_decls = load_declarations(
+            tool_skb.pop("config-setting", {})
+        )
+        self.custom_config_settings = resolve_config_settings(
+            self.config_setting_decls, config_settings, environ
+        )
+
+        # Handle overrides
         self.overrides, self.overridden_items = process_overrides(
-            pyproject.get("tool", {}).get("scikit-build", {}),
+            tool_skb,
             state=state,
             env=env,
             retry=retry,
+            config_settings=self.custom_config_settings,
+        )
+        # The static table was popped above, so any survivor came from an
+        # override body.
+        if "config-setting" in tool_skb:
+            rich_error("config-setting declarations may not be set by overrides")
+        resolve_define_references(tool_skb, self.custom_config_settings)
+        apply_cmake_aliases(
+            tool_skb, self.config_setting_decls, self.custom_config_settings
         )
 
         # Support for minimum-version='build-system.requires'
@@ -311,20 +339,29 @@ class SettingsReader:
 
         # Support for cmake.version='CMakeLists.txt'
         # We will save the value for now since we need the CMakeLists location
+        # A malformed non-table cmake value is left for conversion to report.
+        cmake_table = tool_skb.get("cmake", {})
         force_auto_cmake = (
-            pyproject.get("tool", {})
-            .get("scikit-build", {})
-            .get("cmake", {})
-            .get("version", None)
-        ) == "CMakeLists.txt"
+            isinstance(cmake_table, dict)
+            and cmake_table.get("version", None) == "CMakeLists.txt"
+        )
         if force_auto_cmake:
-            del pyproject["tool"]["scikit-build"]["cmake"]["version"]
+            del cmake_table["version"]
 
         if extra_settings is not None:
             extra_skb = copy.deepcopy(dict(extra_settings))
             extra_matched, extra_overridden = process_overrides(
-                extra_skb, state=state, env=env, retry=retry
+                extra_skb,
+                state=state,
+                env=env,
+                retry=retry,
+                config_settings=self.custom_config_settings,
             )
+            if "config-setting" in extra_skb:
+                rich_error(
+                    "config-setting declarations are only allowed in pyproject.toml"
+                )
+            resolve_define_references(extra_skb, self.custom_config_settings)
             self.overrides |= extra_matched
             self.overridden_items.update(extra_overridden)
             toml_srcs.insert(0, TOMLSource(settings=extra_skb))
@@ -358,8 +395,17 @@ class SettingsReader:
                 # highest-precedence source. A future refactor could process
                 # overrides on the merged view instead.
                 ep_matched, ep_overridden = process_overrides(
-                    ep_skb, state=state, env=env, retry=retry
+                    ep_skb,
+                    state=state,
+                    env=env,
+                    retry=retry,
+                    config_settings=self.custom_config_settings,
                 )
+                if "config-setting" in ep_skb:
+                    rich_error(
+                        "config-setting declarations are only allowed in pyproject.toml"
+                    )
+                resolve_define_references(ep_skb, self.custom_config_settings)
                 self.overrides |= ep_matched
                 ep_source = TOMLSource(settings=ep_skb)
                 ep_srcs.append(ep_source)
@@ -386,7 +432,11 @@ class SettingsReader:
         dynamic_srcs: list[Source] = [
             EnvSource("SKBUILD", env=env),
             ConfSource("skbuild", settings=prefixed, verify=verify_conf),
-            ConfSource(settings=remaining, verify=verify_conf),
+            ConfSource(
+                settings=remaining,
+                verify=verify_conf,
+                extra_keys=frozenset(self.config_setting_decls),
+            ),
         ]
         # env vars + config-settings; these lead ``self.sources`` (see below),
         # so ``print_suggestions`` relies on their count.
@@ -539,6 +589,15 @@ class SettingsReader:
             and static_settings.build.targets == self.settings.build.targets,
         )
 
+        if (
+            self.config_setting_decls
+            and self.settings.minimum_version is not None
+            and self.settings.minimum_version < Version("1.1")
+        ):
+            rich_error(
+                "minimum-version must be at least 1.1 to use tool.scikit-build.config-setting"
+            )
+
         if self.settings.sdist.inclusion_mode is not None:
             if (
                 self.settings.minimum_version is not None
@@ -669,7 +728,7 @@ class SettingsReader:
     def from_file(
         cls,
         pyproject_path: os.PathLike[str] | str,
-        config_settings: Mapping[str, str | list[str]] | None = None,
+        config_settings: Mapping[str, str | list[str] | bool] | None = None,
         *,
         state: Literal[
             "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -44,7 +44,6 @@ from ._load_entrypoint_config import load_config_providers
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .config_settings import (
-    apply_cmake_aliases,
     load_declarations,
     resolve_config_settings,
     resolve_define_references,
@@ -310,9 +309,6 @@ class SettingsReader:
         if "config-setting" in tool_skb:
             rich_error("config-setting declarations may not be set by overrides")
         resolve_define_references(tool_skb, self.custom_config_settings)
-        apply_cmake_aliases(
-            tool_skb, self.config_setting_decls, self.custom_config_settings
-        )
 
         # Support for minimum-version='build-system.requires'
         tmp_min_v = (

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -258,11 +258,6 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
                         "items": {"type": "string"},
                         "description": "The allowed values (str type only).",
                     },
-                    "cmake": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "A CMake cache variable set to the resolved value; explicit defines win over it.",
-                    },
                 },
             }
         },

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -42,6 +42,7 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
     "Generate the complete schema for scikit-build settings."
     assert tool_name == "scikit-build", "Only scikit-build is supported."
 
+    from .config_settings import _NAME_REGEX, ConfigSettingDeclaration
     from .json_schema import to_json_schema
     from .skbuild_model import ScikitBuildSettings
 
@@ -226,36 +227,13 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
     )
 
     # Added after ``props`` is collected so overrides cannot target it.
+    declaration_entry = to_json_schema(ConfigSettingDeclaration, normalize_keys=True)
+    declaration_entry["properties"]["env"]["minLength"] = 1
     schema["properties"]["config-setting"] = {
         "type": "object",
         "description": "Declare package-specific config-settings, settable via `-C name=value` or a bound environment variable.",
         "additionalProperties": False,
-        "patternProperties": {
-            r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$": {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    "help": {
-                        "type": "string",
-                        "description": "A description of the setting.",
-                    },
-                    "type": {
-                        "enum": ["str", "bool"],
-                        "default": "str",
-                        "description": "The type of the setting.",
-                    },
-                    "default": {
-                        "oneOf": [{"type": "string"}, {"type": "boolean"}],
-                        "description": "The value used when the setting is not passed; must match the type.",
-                    },
-                    "env": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "An environment variable also read for this setting; it takes precedence over `-C`.",
-                    },
-                },
-            }
-        },
+        "patternProperties": {_NAME_REGEX.pattern: declaration_entry},
     }
 
     schema["properties"]["overrides"] = {

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -169,6 +169,15 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
                 "minProperties": 1,
                 "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0.",
             },
+            "config-setting": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {"oneOf": [{"type": "string"}, {"type": "boolean"}]}
+                },
+                "additionalProperties": False,
+                "minProperties": 1,
+                "description": "A table of declared config-settings (tool.scikit-build.config-setting) mapped to either string regexs, or booleans. Matches the resolved value (env var, `-C`, or default).",
+            },
         },
     }
     schema["$defs"]["inherit"] = {
@@ -195,6 +204,68 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
         k: {"type": "object", "additionalProperties": False, "properties": v}
         for k, v in inherit_props.items()
         if v
+    }
+
+    # The define-table {config-setting = "..."} reference form.
+    define_values = schema["properties"]["cmake"]["properties"]["define"][
+        "patternProperties"
+    ][".+"]
+    define_values["oneOf"].append(
+        {
+            "type": "object",
+            "required": ["config-setting"],
+            "additionalProperties": False,
+            "properties": {
+                "config-setting": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The declared config-setting name whose resolved value this define takes; the define is dropped when unset.",
+                }
+            },
+        }
+    )
+
+    # Added after ``props`` is collected so overrides cannot target it.
+    schema["properties"]["config-setting"] = {
+        "type": "object",
+        "description": "Declare package-specific config-settings, settable via `-C name=value` or a bound environment variable.",
+        "additionalProperties": False,
+        "patternProperties": {
+            r"^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "help": {
+                        "type": "string",
+                        "description": "A description of the setting.",
+                    },
+                    "type": {
+                        "enum": ["str", "bool"],
+                        "default": "str",
+                        "description": "The type of the setting.",
+                    },
+                    "default": {
+                        "oneOf": [{"type": "string"}, {"type": "boolean"}],
+                        "description": "The value used when the setting is not passed; must match the type.",
+                    },
+                    "env": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "An environment variable also read for this setting; it takes precedence over `-C`.",
+                    },
+                    "choices": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "The allowed values (str type only).",
+                    },
+                    "cmake": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A CMake cache variable set to the resolved value; explicit defines win over it.",
+                    },
+                },
+            }
+        },
     }
 
     schema["properties"]["overrides"] = {

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -253,11 +253,6 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
                         "minLength": 1,
                         "description": "An environment variable also read for this setting; it takes precedence over `-C`.",
                     },
-                    "choices": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "The allowed values (str type only).",
-                    },
                 },
             }
         },

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -271,6 +271,12 @@ def _dict_with_envvar(target: Any, /) -> Any:
     """
     if not isinstance(target, dict):
         return target
+    if "config-setting" in target:
+        # These are resolved from the raw pyproject dict by SettingsReader
+        # before source conversion; reaching here means a direct SourceChain
+        # user passed one through.
+        msg = "{config-setting = ...} values are only supported via SettingsReader"
+        raise TypeError(msg)
     env = target["env"]
     default = target.get("default", None)
     value = os.environ.get(env, default)
@@ -510,15 +516,23 @@ class ConfSource(Source):
     unrelated config keys.
     """
 
+    extra_keys: frozenset[str]
+    """
+    Raw keys accepted verbatim even though they are not model fields (the
+    project-declared ``tool.scikit-build.config-setting`` names).
+    """
+
     def __init__(
         self,
         *prefixes: str,
         settings: Mapping[str, str | list[str] | bool],
         verify: bool = True,
+        extra_keys: frozenset[str] = frozenset(),
     ) -> None:
         self.prefixes = prefixes
         self.settings = settings
         self.verify = verify
+        self.extra_keys = extra_keys
 
     def _get_name(self, *fields: str) -> list[str]:
         names = [field.replace("_", "-") for field in fields]
@@ -633,7 +647,10 @@ class ConfSource(Source):
     def unrecognized_options(self, options: object) -> Generator[str, None, None]:
         if not self.verify:
             return
+        extra_namespaces = {k.split(".", 1)[0] for k in self.extra_keys}
         for keystr in self.settings:
+            if keystr in self.extra_keys:
+                continue
             keys = keystr.replace("-", "_").split(".")[len(self.prefixes) :]
             try:
                 outer_option = _dig_fields(options, *keys[:-1])
@@ -643,6 +660,11 @@ class ConfSource(Source):
                 # non-dataclass), so anything nested under it is free-form and
                 # cannot be a dataclass field.
                 if _under_dict_field(options, keys[:-1]):
+                    continue
+                if keystr.split(".", 1)[0] in extra_namespaces:
+                    # Shares a namespace with a declared extra key: report the
+                    # full key so suggestions can offer the declared names.
+                    yield keystr
                     continue
                 yield ".".join(keystr.split(".")[:-1])
                 continue
@@ -668,6 +690,7 @@ class ConfSource(Source):
         for names in _nested_dataclass_to_names(target):
             dash_names = [name.replace("_", "-") for name in names]
             yield ".".join((*self.prefixes, *dash_names))
+        yield from self.extra_keys
 
 
 class TOMLSource(Source):

--- a/tests/packages/config_settings/CMakeLists.txt
+++ b/tests/packages/config_settings/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15...4.3)
+project(config_settings LANGUAGES NONE)
+
+set(ZMQ_PREFIX
+    ""
+    CACHE STRING "")
+set(ZMQ_LIBZMQ
+    ""
+    CACHE STRING "")
+
+set(out_file "${CMAKE_CURRENT_BINARY_DIR}/log.txt")
+file(WRITE "${out_file}" "ZMQ_PREFIX = ${ZMQ_PREFIX}\n")
+file(APPEND "${out_file}" "ZMQ_LIBZMQ = ${ZMQ_LIBZMQ}\n")

--- a/tests/packages/config_settings/pyproject.toml
+++ b/tests/packages/config_settings/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.scikit-build]
+cmake.version = ">=3.15"
+
+[tool.scikit-build.config-setting."zmq.prefix"]
+help = "Prefix to search for libzmq"
+env = "ZMQ_PREFIX"
+cmake = "ZMQ_PREFIX"
+
+[tool.scikit-build.config-setting."zmq.libzmq"]
+help = "Where libzmq comes from"
+choices = ["bundled", "system"]
+default = "system"
+
+[tool.scikit-build.cmake.define]
+ZMQ_LIBZMQ = {config-setting = "zmq.libzmq"}

--- a/tests/packages/config_settings/pyproject.toml
+++ b/tests/packages/config_settings/pyproject.toml
@@ -7,7 +7,6 @@ env = "ZMQ_PREFIX"
 
 [tool.scikit-build.config-setting."zmq.libzmq"]
 help = "Where libzmq comes from"
-choices = ["bundled", "system"]
 default = "system"
 
 [tool.scikit-build.cmake.define]

--- a/tests/packages/config_settings/pyproject.toml
+++ b/tests/packages/config_settings/pyproject.toml
@@ -4,7 +4,6 @@ cmake.version = ">=3.15"
 [tool.scikit-build.config-setting."zmq.prefix"]
 help = "Prefix to search for libzmq"
 env = "ZMQ_PREFIX"
-cmake = "ZMQ_PREFIX"
 
 [tool.scikit-build.config-setting."zmq.libzmq"]
 help = "Where libzmq comes from"
@@ -12,4 +11,5 @@ choices = ["bundled", "system"]
 default = "system"
 
 [tool.scikit-build.cmake.define]
+ZMQ_PREFIX = {config-setting = "zmq.prefix"}
 ZMQ_LIBZMQ = {config-setting = "zmq.libzmq"}

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -48,6 +48,7 @@ def test_declaration_minimal(tmp_path: Path):
     "entry",
     [
         pytest.param('"zmq.prefix" = {unknown = "x"}', id="unknown-key"),
+        pytest.param('"zmq.prefix" = {cmake = "ZMQ_PREFIX"}', id="no-cmake-alias"),
         pytest.param('"zmq.prefix" = {type = "int"}', id="bad-type"),
         pytest.param('prefix = {help = "no dot"}', id="dotless-name"),
         pytest.param('"cmake.prefix" = {help = "reserved"}', id="reserved-segment"),
@@ -300,66 +301,13 @@ def test_define_conf_beats_toml_reference(tmp_path: Path):
     assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/explicit"
 
 
-ALIAS_DECLARATION = dedent(
+PREFIX_DECLARATION = dedent(
     """\
     [tool.scikit-build.config-setting."zmq.prefix"]
     help = "Prefix to search for libzmq"
     env = "ZMQ_PREFIX"
-    cmake = "ZMQ_PREFIX"
     """
 )
-
-
-def test_cmake_alias(tmp_path: Path):
-    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
-    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
-    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/foo"
-
-
-def test_cmake_alias_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("ZMQ_PREFIX", "/from-env")
-    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
-    settings_reader = SettingsReader.from_file(pyproject_toml)
-    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/from-env"
-
-
-def test_cmake_alias_unset_absent(tmp_path: Path):
-    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
-    settings_reader = SettingsReader.from_file(pyproject_toml)
-    assert "ZMQ_PREFIX" not in settings_reader.settings.cmake.define
-
-
-def test_cmake_alias_explicit_define_wins(tmp_path: Path):
-    pyproject_toml = write_pyproject(
-        tmp_path,
-        ALIAS_DECLARATION
-        + dedent(
-            """\
-            [tool.scikit-build.cmake.define]
-            ZMQ_PREFIX = "/explicit"
-            """
-        ),
-    )
-    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
-    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/explicit"
-
-
-def test_cmake_alias_override_define_wins(tmp_path: Path):
-    pyproject_toml = write_pyproject(
-        tmp_path,
-        ALIAS_DECLARATION
-        + dedent(
-            """\
-            [[tool.scikit-build.overrides]]
-            if.state = "wheel"
-            cmake.define.ZMQ_PREFIX = "/override"
-            """
-        ),
-    )
-    settings_reader = SettingsReader.from_file(
-        pyproject_toml, {"zmq.prefix": "/foo"}, state="wheel"
-    )
-    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/override"
 
 
 @pytest.mark.parametrize("with_decl", [True, False])
@@ -375,7 +323,7 @@ def test_malformed_cmake_table(tmp_path: Path, malformed: str, with_decl: bool):
     internal AttributeError in the config-setting resolution helpers."""
     content = f"[tool.scikit-build]\n{malformed}\n"
     if with_decl:
-        content += ALIAS_DECLARATION
+        content += PREFIX_DECLARATION
     pyproject_toml = write_pyproject(tmp_path, content)
     with pytest.raises(Exception, match="Failed converting") as exc:
         SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scikit_build_core.settings.skbuild_read_settings import SettingsReader
+
+DIR = Path(__file__).parent.resolve()
+
+DECLARATION = dedent(
+    """\
+    [tool.scikit-build.config-setting."zmq.prefix"]
+    help = "Prefix to search for libzmq"
+
+    [tool.scikit-build.config-setting."zmq.libzmq"]
+    help = "Where libzmq comes from"
+    choices = ["bundled", "system"]
+    default = "system"
+    """
+)
+
+
+def write_pyproject(tmp_path: Path, text: str) -> Path:
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(text, encoding="utf-8")
+    return pyproject_toml
+
+
+# ---------------------------------------------------------------------------
+# Declaration parsing
+# ---------------------------------------------------------------------------
+
+
+def test_declaration_minimal(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    settings_reader.validate_may_exit()
+    decls = settings_reader.config_setting_decls
+    assert set(decls) == {"zmq.prefix", "zmq.libzmq"}
+    assert decls["zmq.prefix"].help == "Prefix to search for libzmq"
+    assert decls["zmq.libzmq"].choices == ["bundled", "system"]
+    assert decls["zmq.libzmq"].default == "system"
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pytest.param('"zmq.prefix" = {unknown = "x"}', id="unknown-key"),
+        pytest.param('"zmq.prefix" = {type = "int"}', id="bad-type"),
+        pytest.param('prefix = {help = "no dot"}', id="dotless-name"),
+        pytest.param('"cmake.prefix" = {help = "reserved"}', id="reserved-segment"),
+        pytest.param('"skbuild.x" = {help = "reserved"}', id="skbuild-segment"),
+        pytest.param(
+            '"zmq.bundled" = {type = "bool", choices = ["a"]}', id="choices-on-bool"
+        ),
+        pytest.param(
+            '"zmq.bundled" = {type = "bool", default = "yes"}', id="bad-default-bool"
+        ),
+        pytest.param('"zmq.prefix" = {default = true}', id="bad-default-str"),
+        pytest.param('"zmq.pre fix" = {help = "bad segment"}', id="bad-charset"),
+        pytest.param('"zmq.prefix" = "just a string"', id="not-a-table"),
+    ],
+)
+def test_declaration_invalid(tmp_path: Path, entry: str):
+    pyproject_toml = write_pyproject(
+        tmp_path, f"[tool.scikit-build.config-setting]\n{entry}\n"
+    )
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml)
+    assert exc.value.code == 7
+
+
+# ---------------------------------------------------------------------------
+# Strict-config acceptance of declared keys
+# ---------------------------------------------------------------------------
+
+
+def test_declared_key_accepted(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml, {"zmq.libzmq": "bundled"}
+    )
+    settings_reader.validate_may_exit()
+    assert settings_reader.custom_config_settings["zmq.libzmq"] == "bundled"
+
+
+def test_undeclared_key_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    pyproject_toml = write_pyproject(tmp_path, "[tool.scikit-build]\n")
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml, {"zmq.libzmq": "bundled"}
+    )
+    with pytest.raises(SystemExit) as exc:
+        settings_reader.validate_may_exit()
+    assert exc.value.code == 7
+    out, _ = capsys.readouterr()
+    assert "zmq" in out
+
+
+def test_typo_gets_suggestion(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.libzq": "x"})
+    with pytest.raises(SystemExit) as exc:
+        settings_reader.validate_may_exit()
+    assert exc.value.code == 7
+    out, _ = capsys.readouterr()
+    assert "zmq.libzmq" in out
+
+
+def test_skbuild_prefixed_custom_key_rejected(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml, {"skbuild.zmq.libzmq": "bundled"}
+    )
+    with pytest.raises(SystemExit) as exc:
+        settings_reader.validate_may_exit()
+    assert exc.value.code == 7
+
+
+# ---------------------------------------------------------------------------
+# Resolution: env > config-settings > default
+# ---------------------------------------------------------------------------
+
+ENV_DECLARATION = dedent(
+    """\
+    [tool.scikit-build.config-setting."zmq.prefix"]
+    help = "Prefix to search for libzmq"
+    env = "ZMQ_PREFIX"
+    """
+)
+
+
+def test_resolve_from_config_settings(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, ENV_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert settings_reader.custom_config_settings["zmq.prefix"] == "/foo"
+
+
+def test_resolve_repeated_config_setting_errors(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, ENV_DECLARATION)
+    with pytest.raises(SystemExit):
+        SettingsReader.from_file(pyproject_toml, {"zmq.prefix": ["/foo", "/bar"]})
+
+
+def test_resolve_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ZMQ_PREFIX", "/from-env")
+    pyproject_toml = write_pyproject(tmp_path, ENV_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert settings_reader.custom_config_settings["zmq.prefix"] == "/from-env"
+
+
+def test_env_beats_config_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ZMQ_PREFIX", "/from-env")
+    pyproject_toml = write_pyproject(tmp_path, ENV_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert settings_reader.custom_config_settings["zmq.prefix"] == "/from-env"
+
+
+def test_default_and_unset(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert settings_reader.custom_config_settings["zmq.libzmq"] == "system"
+    assert settings_reader.custom_config_settings["zmq.prefix"] is None
+
+
+BOOL_DECLARATION = dedent(
+    """\
+    [tool.scikit-build.config-setting."zmq.bundled"]
+    type = "bool"
+    default = false
+    """
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("ON", True), ("1", True), ("off", False), ("false", False)],
+)
+def test_bool_type(tmp_path: Path, value: str, expected: bool):
+    pyproject_toml = write_pyproject(tmp_path, BOOL_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.bundled": value})
+    assert settings_reader.custom_config_settings["zmq.bundled"] is expected
+
+
+def test_bool_type_gpep517_bool(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, BOOL_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.bundled": True})
+    assert settings_reader.custom_config_settings["zmq.bundled"] is True
+
+
+def test_choices_violation(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml, {"zmq.libzmq": "vendored"})
+    assert exc.value.code == 7
+    _, err = capsys.readouterr()
+    assert "bundled" in err
+    assert "system" in err
+
+
+# ---------------------------------------------------------------------------
+# CMake define binding
+# ---------------------------------------------------------------------------
+
+
+def test_define_reference(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = {config-setting = "zmq.prefix"}
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/foo"
+
+
+def test_define_reference_unset_dropped(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = {config-setting = "zmq.prefix"}
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert "ZMQ_PREFIX" not in settings_reader.settings.cmake.define
+
+
+def test_define_reference_bool(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        BOOL_DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_BUNDLED = {config-setting = "zmq.bundled"}
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.bundled": "on"})
+    assert settings_reader.settings.cmake.define["ZMQ_BUNDLED"] == "TRUE"
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert settings_reader.settings.cmake.define["ZMQ_BUNDLED"] == "FALSE"
+
+
+def test_define_reference_undeclared(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = {config-setting = "zmq.prefix"}
+            """
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml)
+    assert exc.value.code == 7
+
+
+def test_define_reference_extra_keys(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = {config-setting = "zmq.prefix", default = "/dflt"}
+            """
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml)
+    assert exc.value.code == 7
+
+
+def test_define_conf_beats_toml_reference(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = {config-setting = "zmq.prefix"}
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml,
+        {"zmq.prefix": "/foo", "cmake.define.ZMQ_PREFIX": "/explicit"},
+    )
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/explicit"
+
+
+ALIAS_DECLARATION = dedent(
+    """\
+    [tool.scikit-build.config-setting."zmq.prefix"]
+    help = "Prefix to search for libzmq"
+    env = "ZMQ_PREFIX"
+    cmake = "ZMQ_PREFIX"
+    """
+)
+
+
+def test_cmake_alias(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/foo"
+
+
+def test_cmake_alias_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ZMQ_PREFIX", "/from-env")
+    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/from-env"
+
+
+def test_cmake_alias_unset_absent(tmp_path: Path):
+    pyproject_toml = write_pyproject(tmp_path, ALIAS_DECLARATION)
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    assert "ZMQ_PREFIX" not in settings_reader.settings.cmake.define
+
+
+def test_cmake_alias_explicit_define_wins(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        ALIAS_DECLARATION
+        + dedent(
+            """\
+            [tool.scikit-build.cmake.define]
+            ZMQ_PREFIX = "/explicit"
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/explicit"
+
+
+def test_cmake_alias_override_define_wins(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        ALIAS_DECLARATION
+        + dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            cmake.define.ZMQ_PREFIX = "/override"
+            """
+        ),
+    )
+    settings_reader = SettingsReader.from_file(
+        pyproject_toml, {"zmq.prefix": "/foo"}, state="wheel"
+    )
+    assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/override"
+
+
+@pytest.mark.parametrize("with_decl", [True, False])
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        pytest.param('cmake = "x"', id="cmake"),
+        pytest.param('cmake.define = "x"', id="define"),
+    ],
+)
+def test_malformed_cmake_table(tmp_path: Path, malformed: str, with_decl: bool):
+    """A non-table cmake value must hit the normal conversion error, not an
+    internal AttributeError in the config-setting resolution helpers."""
+    content = f"[tool.scikit-build]\n{malformed}\n"
+    if with_decl:
+        content += ALIAS_DECLARATION
+    pyproject_toml = write_pyproject(tmp_path, content)
+    with pytest.raises(Exception, match="Failed converting") as exc:
+        SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})
+    assert not isinstance(exc.value, AttributeError)
+
+
+# ---------------------------------------------------------------------------
+# minimum-version gate
+# ---------------------------------------------------------------------------
+
+
+def test_minimum_version_gate_too_old(tmp_path: Path):
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        'tool.scikit-build.minimum-version = "1.0"\n' + DECLARATION,
+    )
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml)
+    assert exc.value.code == 7
+
+
+def test_minimum_version_gate_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "scikit_build_core.settings.skbuild_read_settings.__version__", "1.1.0"
+    )
+    pyproject_toml = write_pyproject(
+        tmp_path,
+        'tool.scikit-build.minimum-version = "1.1"\n' + DECLARATION,
+    )
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    settings_reader.validate_may_exit()
+
+
+# ---------------------------------------------------------------------------
+# Integration: values reach CMake
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.configure
+@pytest.mark.parametrize("source", ["conf", "env"])
+def test_config_settings_reach_cmake(
+    source: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scikit_build_core.builder.builder import Builder
+    from scikit_build_core.cmake import CMake, CMaker
+
+    source_dir = DIR / "packages" / "config_settings"
+    binary_dir = tmp_path / "build"
+
+    config_settings: dict[str, str] = {"zmq.libzmq": "bundled"}
+    if source == "conf":
+        config_settings["zmq.prefix"] = "/opt/zmq"
+    else:
+        monkeypatch.setenv("ZMQ_PREFIX", "/opt/zmq")
+
+    reader = SettingsReader.from_file(
+        source_dir / "pyproject.toml", config_settings, state="wheel"
+    )
+    reader.validate_may_exit()
+
+    config = CMaker(
+        CMake.default_search(),
+        source_dir=source_dir,
+        build_dir=binary_dir,
+        build_type="Release",
+    )
+    builder = Builder(reader.settings, config)
+    builder.configure(defines={})
+
+    configure_log = Path.read_text(binary_dir / "log.txt")
+    assert configure_log == dedent(
+        """\
+        ZMQ_PREFIX = /opt/zmq
+        ZMQ_LIBZMQ = bundled
+        """
+    )

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -16,7 +16,6 @@ DECLARATION = dedent(
 
     [tool.scikit-build.config-setting."zmq.libzmq"]
     help = "Where libzmq comes from"
-    choices = ["bundled", "system"]
     default = "system"
     """
 )
@@ -40,7 +39,6 @@ def test_declaration_minimal(tmp_path: Path):
     decls = settings_reader.config_setting_decls
     assert set(decls) == {"zmq.prefix", "zmq.libzmq"}
     assert decls["zmq.prefix"].help == "Prefix to search for libzmq"
-    assert decls["zmq.libzmq"].choices == ["bundled", "system"]
     assert decls["zmq.libzmq"].default == "system"
 
 
@@ -54,7 +52,7 @@ def test_declaration_minimal(tmp_path: Path):
         pytest.param('"cmake.prefix" = {help = "reserved"}', id="reserved-segment"),
         pytest.param('"skbuild.x" = {help = "reserved"}', id="skbuild-segment"),
         pytest.param(
-            '"zmq.bundled" = {type = "bool", choices = ["a"]}', id="choices-on-bool"
+            '"zmq.libzmq" = {choices = ["bundled"]}', id="removed-choices-key"
         ),
         pytest.param(
             '"zmq.bundled" = {type = "bool", default = "yes"}', id="bad-default-bool"
@@ -188,16 +186,6 @@ def test_bool_type_gpep517_bool(tmp_path: Path):
     pyproject_toml = write_pyproject(tmp_path, BOOL_DECLARATION)
     settings_reader = SettingsReader.from_file(pyproject_toml, {"zmq.bundled": True})
     assert settings_reader.custom_config_settings["zmq.bundled"] is True
-
-
-def test_choices_violation(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-    pyproject_toml = write_pyproject(tmp_path, DECLARATION)
-    with pytest.raises(SystemExit) as exc:
-        SettingsReader.from_file(pyproject_toml, {"zmq.libzmq": "vendored"})
-    assert exc.value.code == 7
-    _, err = capsys.readouterr()
-    assert "bundled" in err
-    assert "system" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -387,7 +387,15 @@ def test_malformed_cmake_table(tmp_path: Path, malformed: str, with_decl: bool):
 # ---------------------------------------------------------------------------
 
 
-def test_minimum_version_gate_too_old(tmp_path: Path):
+def test_minimum_version_gate_too_old(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    # CI shallow clones report 0.1.devN, tripping the backend-too-old check first
+    monkeypatch.setattr(
+        "scikit_build_core.settings.skbuild_read_settings.__version__", "1.1.0"
+    )
     pyproject_toml = write_pyproject(
         tmp_path,
         'tool.scikit-build.minimum-version = "1.0"\n' + DECLARATION,
@@ -395,6 +403,8 @@ def test_minimum_version_gate_too_old(tmp_path: Path):
     with pytest.raises(SystemExit) as exc:
         SettingsReader.from_file(pyproject_toml)
     assert exc.value.code == 7
+    _, err = capsys.readouterr()
+    assert "minimum-version must be at least 1.1" in err
 
 
 def test_minimum_version_gate_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -289,15 +289,6 @@ def test_define_conf_beats_toml_reference(tmp_path: Path):
     assert settings_reader.settings.cmake.define["ZMQ_PREFIX"] == "/explicit"
 
 
-PREFIX_DECLARATION = dedent(
-    """\
-    [tool.scikit-build.config-setting."zmq.prefix"]
-    help = "Prefix to search for libzmq"
-    env = "ZMQ_PREFIX"
-    """
-)
-
-
 @pytest.mark.parametrize("with_decl", [True, False])
 @pytest.mark.parametrize(
     "malformed",
@@ -311,7 +302,7 @@ def test_malformed_cmake_table(tmp_path: Path, malformed: str, with_decl: bool):
     internal AttributeError in the config-setting resolution helpers."""
     content = f"[tool.scikit-build]\n{malformed}\n"
     if with_decl:
-        content += PREFIX_DECLARATION
+        content += ENV_DECLARATION
     pyproject_toml = write_pyproject(tmp_path, content)
     with pytest.raises(Exception, match="Failed converting") as exc:
         SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/foo"})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -69,6 +69,22 @@ def test_valid_schemas_files(filepath: Path) -> None:
         {"cmake": {"define": {"FOO": {"default": False}}}},
         {"env": {"FOO": {"unknown": "x"}}},
         {"env": {"FOO": {"force": "not-a-bool"}}},
+        {"config-setting": {"nodot": {"help": "x"}}},
+        {"config-setting": {"zmq.prefix": {"unknown": "x"}}},
+        {"config-setting": {"zmq.prefix": {"type": "int"}}},
+        {"config-setting": {"zmq.prefix": {"env": ""}}},
+        {"config-setting": {"zmq.prefix": {"choices": "bundled"}}},
+        {"cmake": {"define": {"FOO": {"config-setting": ""}}}},
+        {
+            "cmake": {
+                "define": {"FOO": {"config-setting": "zmq.prefix", "default": "x"}}
+            }
+        },
+        {
+            "overrides": [
+                {"if": {"config-setting": {}}, "cmake": {"args": ["-DFOO=BAR"]}}
+            ]
+        },
     ],
 )
 def test_invalid_schemas(addition: dict[str, Any]) -> None:
@@ -115,6 +131,22 @@ def test_invalid_schemas(addition: dict[str, Any]) -> None:
         {"env": {"CMAKE_BUILD_PARALLEL_LEVEL": {"env": "MAX_JOBS"}}},
         {"env": {"FOO": {"env": "BAR", "default": "baz"}}},
         {"env": {"FOO": {"default": "bar", "force": True}}},
+        {
+            "config-setting": {
+                "zmq.prefix": {"help": "Location", "env": "ZMQ_PREFIX"},
+                "zmq.libzmq": {"choices": ["bundled", "system"], "default": "system"},
+                "zmq.bundled": {"type": "bool", "default": False, "cmake": "BUNDLED"},
+            }
+        },
+        {"cmake": {"define": {"FOO": {"config-setting": "zmq.prefix"}}}},
+        {
+            "overrides": [
+                {
+                    "if": {"config-setting": {"zmq.libzmq": "bundled"}},
+                    "cmake": {"define": {"ZMQ_LIBZMQ": "ON"}},
+                }
+            ]
+        },
     ],
 )
 def test_valid_schemas(addition: dict[str, Any]) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -73,7 +73,7 @@ def test_valid_schemas_files(filepath: Path) -> None:
         {"config-setting": {"zmq.prefix": {"unknown": "x"}}},
         {"config-setting": {"zmq.prefix": {"type": "int"}}},
         {"config-setting": {"zmq.prefix": {"env": ""}}},
-        {"config-setting": {"zmq.prefix": {"choices": "bundled"}}},
+        {"config-setting": {"zmq.prefix": {"choices": ["bundled"]}}},
         {"config-setting": {"zmq.prefix": {"cmake": "ZMQ_PREFIX"}}},
         {"cmake": {"define": {"FOO": {"config-setting": ""}}}},
         {
@@ -135,7 +135,7 @@ def test_invalid_schemas(addition: dict[str, Any]) -> None:
         {
             "config-setting": {
                 "zmq.prefix": {"help": "Location", "env": "ZMQ_PREFIX"},
-                "zmq.libzmq": {"choices": ["bundled", "system"], "default": "system"},
+                "zmq.libzmq": {"help": "Where libzmq comes from", "default": "system"},
                 "zmq.bundled": {"type": "bool", "default": False},
             }
         },

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -74,6 +74,7 @@ def test_valid_schemas_files(filepath: Path) -> None:
         {"config-setting": {"zmq.prefix": {"type": "int"}}},
         {"config-setting": {"zmq.prefix": {"env": ""}}},
         {"config-setting": {"zmq.prefix": {"choices": "bundled"}}},
+        {"config-setting": {"zmq.prefix": {"cmake": "ZMQ_PREFIX"}}},
         {"cmake": {"define": {"FOO": {"config-setting": ""}}}},
         {
             "cmake": {
@@ -135,7 +136,7 @@ def test_invalid_schemas(addition: dict[str, Any]) -> None:
             "config-setting": {
                 "zmq.prefix": {"help": "Location", "env": "ZMQ_PREFIX"},
                 "zmq.libzmq": {"choices": ["bundled", "system"], "default": "system"},
-                "zmq.bundled": {"type": "bool", "default": False, "cmake": "BUNDLED"},
+                "zmq.bundled": {"type": "bool", "default": False},
             }
         },
         {"cmake": {"define": {"FOO": {"config-setting": "zmq.prefix"}}}},

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -1280,3 +1280,191 @@ def test_skbuild_overrides_force_include_from_sdist(
         assert settings.wheel.force_include == {"vendored/blob.txt": "pkg/blob.txt"}
     else:
         assert settings.wheel.force_include == {"../outside.txt": "pkg/blob.txt"}
+
+
+CONFIG_SETTING_PYPROJECT = dedent(
+    """\
+    [tool.scikit-build.config-setting."zmq.libzmq"]
+    help = "Where libzmq comes from"
+    env = "ZMQ_LIBZMQ"
+    choices = ["bundled", "system"]
+    default = "system"
+
+    [[tool.scikit-build.overrides]]
+    if.config-setting."zmq.libzmq" = "bundled"
+    cmake.define.ZMQ_LIBZMQ = "ON"
+    """
+)
+
+
+@pytest.mark.parametrize("source", ["conf", "env"])
+def test_override_config_setting(
+    source: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """-C and the bound env var must behave identically in if.config-setting."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(CONFIG_SETTING_PYPROJECT, encoding="utf-8")
+
+    config_settings = {}
+    if source == "conf":
+        config_settings["zmq.libzmq"] = "bundled"
+    else:
+        monkeypatch.setenv("ZMQ_LIBZMQ", "bundled")
+
+    settings = SettingsReader.from_file(pyproject_toml, config_settings).settings
+    assert settings.cmake.define["ZMQ_LIBZMQ"] == "ON"
+
+
+def test_override_config_setting_default_no_match(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(CONFIG_SETTING_PYPROJECT, encoding="utf-8")
+
+    settings = SettingsReader.from_file(pyproject_toml).settings
+    assert "ZMQ_LIBZMQ" not in settings.cmake.define
+
+
+def test_override_config_setting_regex(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build.config-setting."zmq.prefix"]
+            help = "Prefix"
+
+            [[tool.scikit-build.overrides]]
+            if.config-setting."zmq.prefix" = "^/opt/"
+            cmake.define.FROM_OPT = "ON"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings = SettingsReader.from_file(
+        pyproject_toml, {"zmq.prefix": "/opt/zmq"}
+    ).settings
+    assert settings.cmake.define["FROM_OPT"] == "ON"
+
+    settings = SettingsReader.from_file(pyproject_toml, {"zmq.prefix": "/usr"}).settings
+    assert "FROM_OPT" not in settings.cmake.define
+
+    # Unset never matches a string condition
+    settings = SettingsReader.from_file(pyproject_toml).settings
+    assert "FROM_OPT" not in settings.cmake.define
+
+
+@pytest.mark.parametrize(
+    ("value", "condition", "matched"),
+    [
+        ("on", "true", True),
+        ("off", "true", False),
+        ("on", "false", False),
+        ("off", "false", True),
+        (None, "false", True),
+        (None, "true", False),
+    ],
+)
+def test_override_config_setting_bool(
+    value: str | None, condition: str, matched: bool, tmp_path: Path
+):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            f"""\
+            [tool.scikit-build.config-setting."zmq.bundled"]
+            type = "bool"
+
+            [[tool.scikit-build.overrides]]
+            if.config-setting."zmq.bundled" = {condition}
+            cmake.define.ZMQ_BUNDLED = "ON"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config_settings = {} if value is None else {"zmq.bundled": value}
+    settings = SettingsReader.from_file(pyproject_toml, config_settings).settings
+    assert ("ZMQ_BUNDLED" in settings.cmake.define) == matched
+
+
+def test_override_config_setting_any(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build.config-setting."zmq.libzmq"]
+            default = "system"
+
+            [[tool.scikit-build.overrides]]
+            if.any.config-setting."zmq.libzmq" = "bundled"
+            if.any.env.ZMQ_FORCE_BUNDLED = true
+            cmake.define.ZMQ_LIBZMQ = "ON"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings = SettingsReader.from_file(
+        pyproject_toml, {"zmq.libzmq": "bundled"}
+    ).settings
+    assert settings.cmake.define["ZMQ_LIBZMQ"] == "ON"
+
+    settings = SettingsReader.from_file(pyproject_toml).settings
+    assert "ZMQ_LIBZMQ" not in settings.cmake.define
+
+
+def test_override_config_setting_undeclared(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.config-setting."zmq.libzmq" = "bundled"
+            cmake.define.ZMQ_LIBZMQ = "ON"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match=r"zmq\.libzmq"):
+        SettingsReader.from_file(pyproject_toml)
+
+
+def test_override_contributed_define_reference(tmp_path: Path):
+    """An override can contribute a {config-setting = ...} define reference."""
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.scikit-build.config-setting."zmq.prefix"]
+            help = "Prefix"
+
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            cmake.define.ZMQ_PREFIX = {config-setting = "zmq.prefix"}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings = SettingsReader.from_file(
+        pyproject_toml, {"zmq.prefix": "/foo"}, state="wheel"
+    ).settings
+    assert settings.cmake.define["ZMQ_PREFIX"] == "/foo"
+
+
+def test_override_may_not_set_config_setting(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.state = "wheel"
+            config-setting."zmq.prefix" = {help = "sneaky"}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        SettingsReader.from_file(pyproject_toml, state="wheel")
+    assert exc.value.code == 7

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -1287,7 +1287,6 @@ CONFIG_SETTING_PYPROJECT = dedent(
     [tool.scikit-build.config-setting."zmq.libzmq"]
     help = "Where libzmq comes from"
     env = "ZMQ_LIBZMQ"
-    choices = ["bundled", "system"]
     default = "system"
 
     [[tool.scikit-build.overrides]]


### PR DESCRIPTION
Design choices:

* User config-settings require a `.` (namespaced)
* Explicit strings required (keeps schema simple and avoids TOML dict collisions)

:robot: _AI text below_ :robot:

Implements the design discussed in #1468 (targeting **1.1**, not 1.0): packages can declare their own config-settings in a `tool.scikit-build.config-setting` table, giving users a documented, package-level interface instead of raw CMake defines.

```toml
[tool.scikit-build.config-setting."zmq.prefix"]
help = "Prefix to search for libzmq"
env = "ZMQ_PREFIX"          # env > -C > default

[tool.scikit-build.config-setting."zmq.libzmq"]
default = "system"

[tool.scikit-build.cmake.define]
ZMQ_PREFIX = {config-setting = "zmq.prefix"}   # forwarded to CMake; dropped when unset

[[tool.scikit-build.overrides]]
if.config-setting."zmq.libzmq" = "bundled"     # matches the resolved value
cmake.define.ZMQ_LIBZMQ = "ON"
```

Notes:

- The declaration table is popped from the raw TOML like `overrides` (not a settings field, not an override target); values resolve before override processing so `if.config-setting` sees them.
- Declared keys are whitelisted in `ConfSource` (new `extra_keys`) and get "did you mean" suggestions; `skbuild.`-prefixed custom keys stay rejected, and unknown-key strict-config behavior is otherwise unchanged.
- Declarations are pyproject-only (rejected in overrides, extra settings, and entry-point config) and gated on `minimum-version >= 1.1`.
- Types: `str` and `bool` (strtobool semantics); repeated `-C` values error. A `choices` key for enumerated values was cut to keep the initial surface minimal (a code comment notes how to re-add it).
- The CMake binding is the `cmake.define = {config-setting = "..."}` reference form only; an earlier inline `cmake =` declaration alias was dropped as redundant.
- Also fixes a pre-existing crash where a malformed non-table `cmake` value raised `AttributeError` (in the `force_auto_cmake` lookup) instead of the normal conversion error; the new resolution helpers are guarded the same way.

Beyond CI: verified end-to-end through the real `build_wheel` hook that the env var and `-C` spellings land in CMake identically and the override fires.
