### PR TITLE
chore(fedora): Backport downstream changes

### DIFF
--- a/.distro/plans/examples.fmf
+++ b/.distro/plans/examples.fmf
@@ -1,14 +1,5 @@
 summary: Documentation examples
 discover+:
   filter: "tag: examples"
-prepare+:
-  # TODO: Remove when the package review is done
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2493460
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2493459
-  - name: Add copr repo for f2py-cmake and cython-cmake
-    how: artifact
-    provide:
-      - copr.repository:lecris/scikit-build-helpers
-    verify: false
 execute:
   how: tmt

--- a/.distro/python-scikit-build-core.spec
+++ b/.distro/python-scikit-build-core.spec
@@ -42,6 +42,9 @@ Provides:       bundled(python3dist(pyproject-metadata)) = 0.12.1
 
 %description -n python3-scikit-build-core %_description
 
+%pyproject_extras_subpkg -n python3-scikit-build-core setuptools
+%pyproject_extras_subpkg -n python3-scikit-build-core hatchling
+
 
 %prep
 %autosetup -n scikit_build_core-%{version}


### PR DESCRIPTION
- Missed adding the setuptools and hatchling subpackages
- f2py-cmake and cython-cmake have been packaged. Would take about 1 week for the stable branches to get it https://bodhi.fedoraproject.org/updates/FEDORA-2026-853945cfd5

Will move it out of draft when f2py-cmake and cython-cmake land on stable branches also