### PR TITLE
fix(editable): resolve redirected modules through sys.path_hooks

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -525,11 +525,35 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         submodule_search_locations: list[str] | None,
     ) -> importlib.machinery.ModuleSpec | None:
         is_pkg = origin.endswith(("__init__.py", "__init__.pyc"))
-        spec = importlib.util.spec_from_file_location(
-            fullname,
-            origin,
-            submodule_search_locations=submodule_search_locations if is_pkg else None,
-        )
+        # Resolve the loader through the standard sys.path_hooks machinery (PEP
+        # 302) so instrumenting path hooks (e.g. beartype.claw) see redirected
+        # modules (#1492). Searching only the directory holding our chosen file
+        # keeps the redirect mapping authoritative; the spec is accepted only if
+        # it resolves to that same file.
+        search = os.path.dirname(origin)
+        if is_pkg:
+            search = os.path.dirname(search)
+        spec = importlib.machinery.PathFinder.find_spec(fullname, [search])
+        if (
+            spec is not None
+            and spec.loader is not None
+            and spec.origin is not None
+            and os.path.normcase(spec.origin) == os.path.normcase(origin)
+        ):
+            spec.submodule_search_locations = (
+                submodule_search_locations if is_pkg else None
+            )
+        else:
+            # The mapping cannot be reproduced by the path machinery (e.g. the
+            # file's name does not match the module name), so build the spec
+            # directly with the stock loader.
+            spec = importlib.util.spec_from_file_location(
+                fullname,
+                origin,
+                submodule_search_locations=submodule_search_locations
+                if is_pkg
+                else None,
+            )
         # Wrap the loader so it exposes a rebuild() hook (reachable as
         # module.__loader__.rebuild()). Packages with more than one search
         # location (e.g. a source tree and a CMake install tree) additionally get

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -309,6 +309,13 @@ def test_editable_with_beartype_claw(isolated, isolate, editable):
     Path("src/simplest/typed.py").write_text("def f(x: int) -> int:\n    return x\n")
 
     isolated.install("beartype")
+    # beartype may not support the newest Python yet (e.g. 0.22.9 fails to
+    # import on 3.15); skip rather than fail, and un-skip automatically once
+    # a supporting release is out.
+    try:
+        isolated.execute("import beartype")
+    except SystemExit:
+        pytest.skip("beartype cannot be imported on this Python")
     isolated.install(
         "-v",
         *isolate.flags,

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -289,3 +289,47 @@ def test_importlib_resources(editable, isolated):
             """
         )
     )
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.integration
+@pytest.mark.parametrize("package", ["simplest_c"], indirect=True)
+@pytest.mark.parametrize("isolate", {False}, indirect=True)
+@pytest.mark.parametrize("editable", ["redirect", "inplace"], indirect=True)
+@pytest.mark.usefixtures("package")
+def test_editable_with_beartype_claw(isolated, isolate, editable):
+    """beartype.claw instruments editable modules (#1492).
+
+    beartype.claw registers a PEP 302 sys.path_hooks loader that rewrites
+    modules of registered packages at load time. The editable finders must
+    resolve loaders through that machinery, or instrumentation is silently
+    skipped.
+    """
+    Path("src/simplest/typed.py").write_text("def f(x: int) -> int:\n    return x\n")
+
+    isolated.install("beartype")
+    isolated.install(
+        "-v",
+        *isolate.flags,
+        *editable.flags,
+        ".",
+        installer="pip",
+    )
+
+    result = isolated.execute(
+        textwrap.dedent(
+            """
+            from beartype.claw import beartype_package
+            beartype_package("simplest")
+            import simplest.typed
+            try:
+                simplest.typed.f("not an int")
+            except Exception as exc:
+                print(type(exc).__name__)
+            else:
+                print("no error raised")
+            """
+        )
+    )
+    assert result.splitlines()[-1] == "BeartypeCallHintParamViolation"

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -13,6 +13,10 @@ from scikit_build_core.resources._editable_redirect import (
     install_inplace,
 )
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import types
+
 
 def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
     return {k: {str(Path(x)) for x in v} for k, v in d.items()}
@@ -161,6 +165,111 @@ def test_install_multiple_packages():
     install(*pkg_a, None)
     install(*pkg_b, None)
     assert count_finders() == 2
+
+
+def test_redirect_resolves_through_path_hooks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression (#1492): redirected modules resolve loaders via sys.path_hooks.
+
+    PEP 302 instrumenting import hooks (e.g. beartype.claw) register a path hook
+    whose loader rewrites modules at load time. Building specs with
+    spec_from_file_location hard-wires the stock SourceFileLoader, silently
+    bypassing such hooks, so the finder must resolve through PathFinder instead.
+    """
+    import importlib.machinery
+    import importlib.util
+
+    class InstrumentingLoader(importlib.machinery.SourceFileLoader):
+        def source_to_code(self, data: bytes, path: str) -> types.CodeType:  # type: ignore[override]
+            return super().source_to_code(b"instrumented = True\n" + data, path)
+
+    hook = importlib.machinery.FileFinder.path_hook(
+        (InstrumentingLoader, importlib.machinery.SOURCE_SUFFIXES)
+    )
+    monkeypatch.setattr(sys, "path_hooks", [hook, *sys.path_hooks])
+    monkeypatch.setattr(sys, "path_importer_cache", {})
+
+    src_pkg = tmp_path / "src" / "pkg"
+    src_pkg.mkdir(parents=True)
+    init = src_pkg / "__init__.py"
+    init.write_text("")
+    mod = src_pkg / "mod.py"
+    mod.write_text("value = 42\n")
+    wheel_pkg = tmp_path / "site-packages" / "pkg"
+    wheel_pkg.mkdir(parents=True)
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"pkg": str(init), "pkg.mod": str(mod)},
+        known_wheel_files={},
+        known_directories={"pkg": [str(src_pkg), str(wheel_pkg)]},
+        known_packages=["pkg"],
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path / "site-packages"),
+        install_dir="",
+    )
+
+    spec = finder.find_spec("pkg.mod")
+    assert spec is not None
+    assert spec.origin == str(mod)
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert getattr(module, "instrumented", False), "path-hook loader was bypassed"
+    assert module.value == 42
+    # The rebuild hook is still exposed on the wrapped loader.
+    assert hasattr(spec.loader, "rebuild")
+
+    # A package keeps its merged (source + install tree) __path__ and the
+    # multi-location resource reader.
+    pkg_spec = finder.find_spec("pkg")
+    assert pkg_spec is not None
+    assert pkg_spec.origin == str(init)
+    assert set(pkg_spec.submodule_search_locations or []) == {
+        str(src_pkg),
+        str(wheel_pkg),
+    }
+    assert pkg_spec.loader is not None
+    assert hasattr(pkg_spec.loader, "get_resource_reader")
+
+
+def test_redirect_falls_back_when_path_hooks_miss(tmp_path: Path):
+    """A mapping PathFinder cannot reproduce still resolves to the mapped file.
+
+    If the mapped file's name does not match the module name (so the standard
+    sys.path_hooks machinery cannot find it), the finder falls back to building
+    the spec directly, exactly as before #1492.
+    """
+    import importlib.util
+
+    actual = tmp_path / "actual_name.py"
+    actual.write_text("value = 7\n")
+
+    finder = ScikitBuildRedirectingFinder(
+        known_source_files={"pkg.aliased": str(actual)},
+        known_wheel_files={},
+        known_directories={},
+        known_packages=[],
+        path=None,
+        rebuild=False,
+        verbose=False,
+        build_options=[],
+        install_options=[],
+        dir=str(tmp_path / "site-packages"),
+        install_dir="",
+    )
+
+    spec = finder.find_spec("pkg.aliased")
+    assert spec is not None
+    assert spec.origin == str(actual)
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.value == 7
 
 
 def _make_finder(tmp_path: Path, *, verbose: bool) -> ScikitBuildRedirectingFinder:

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -13,10 +13,6 @@ from scikit_build_core.resources._editable_redirect import (
     install_inplace,
 )
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    import types
-
 
 def process_dict_set(d: dict[str, set[str]]) -> dict[str, set[str]]:
     return {k: {str(Path(x)) for x in v} for k, v in d.items()}
@@ -181,8 +177,11 @@ def test_redirect_resolves_through_path_hooks(
     import importlib.util
 
     class InstrumentingLoader(importlib.machinery.SourceFileLoader):
-        def source_to_code(self, data: bytes, path: str) -> types.CodeType:  # type: ignore[override]
-            return super().source_to_code(b"instrumented = True\n" + data, path)
+        # Untyped signature: Python 3.15 adds an extra positional argument.
+        def source_to_code(self, data, path, *args, **kwargs):  # type: ignore[override]
+            return super().source_to_code(
+                b"instrumented = True\n" + data, path, *args, **kwargs
+            )
 
     hook = importlib.machinery.FileFinder.path_hook(
         (InstrumentingLoader, importlib.machinery.SOURCE_SUFFIXES)

--- a/tests/utils/download_wheels.py
+++ b/tests/utils/download_wheels.py
@@ -26,6 +26,7 @@ if importlib.util.find_spec("ninja") is not None:
 PYBIND11 = ["pybind11"] if importlib.util.find_spec("pybind11") is not None else []
 
 WHEELS = [
+    "beartype",
     "build",
     "cython",
     "hatchling",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1492.

In redirect editable mode, `ScikitBuildRedirectingFinder` built specs with `spec_from_file_location`, hard-wiring the stock `SourceFileLoader` and never consulting `sys.path_hooks`. PEP 302 instrumenting import hooks — e.g. `beartype.claw`, which registers a path hook whose loader rewrites modules at load time (see beartype/beartype#556) — were silently bypassed.

`_make_spec` now resolves the loader through `importlib.machinery.PathFinder` against the directory holding the mapped file, so registered path hooks are honored. The redirect mapping stays authoritative: the spec is accepted only if it resolves to the exact mapped file (compared case-insensitively), packages get their merged source+build-tree `__path__` reapplied, and anything the path machinery can't reproduce (mismatched filename, `__init__.pyc`, missing file) falls back to the previous behavior. Loader wrapping for `rebuild()` and the multi-location resource reader are unchanged.

The inplace finder already delegated to `PathFinder` and was unaffected; the new integration test covers both modes with real beartype (added to the test wheelhouse), and a unit test covers the same via a stub instrumenting path hook with no new dependency. Both were verified to fail before the fix.

No new option is needed, and downstream workarounds that strip the finder from `sys.meta_path` can be dropped.