### PR TITLE
docs: prepare changelog for 1.0.2

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 1.0.2
+
+This patch release fixes redirect editable installs so that PEP 302 import
+hooks (such as `beartype.claw`) that register a `sys.path_hooks` entry are
+honored for redirected modules.
+
+Fixes:
+
+- Resolve redirected modules through `sys.path_hooks` by @henryiii in #1493
+
+Internal:
+
+- Stop using deprecated `build.util.project_wheel_metadata` in #1494
+
 ## Version 1.0.1
 
 This patch release fixes two bugs: shared namespace packages were being

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -2,9 +2,9 @@
 
 ## Version 1.0.2
 
-This patch release fixes redirect editable installs so that PEP 302 import
-hooks (such as `beartype.claw`) that register a `sys.path_hooks` entry are
-honored for redirected modules.
+This patch release fixes redirect editable installs so that PEP 302 import hooks
+(such as `beartype.claw`) that register a `sys.path_hooks` entry are honored for
+redirected modules.
 
 Fixes:
 

--- a/docs/about/projects.md
+++ b/docs/about/projects.md
@@ -48,6 +48,7 @@ for project in projects["project"]:
 * [deflate](https://pypi.org/project/deflate) ([source](https://github.com/dcwatson/deflate/blob/HEAD/pyproject.toml))
 * [ducc0](https://pypi.org/project/ducc0) ([source](https://github.com/mreineck/ducc/blob/HEAD/pyproject.toml))
 * [faiss-cpu](https://pypi.org/project/faiss-cpu) ([source](https://github.com/facebookresearch/faiss/blob/HEAD/pyproject.toml))
+* [fandango-fuzzer](https://pypi.org/project/fandango-fuzzer) ([source](https://github.com/fandango-fuzzer/fandango/blob/HEAD/pyproject.toml))
 * [freud-analysis](https://pypi.org/project/freud-analysis) ([source](https://github.com/glotzerlab/freud/blob/HEAD/pyproject.toml))
 * [gdstk](https://pypi.org/project/gdstk) ([source](https://github.com/heitzmann/gdstk/blob/HEAD/pyproject.toml))
 * [gemmi](https://pypi.org/project/gemmi) ([source](https://github.com/project-gemmi/gemmi/blob/HEAD/pyproject.toml))
@@ -105,7 +106,7 @@ for project in projects["project"]:
 * [viennaps](https://pypi.org/project/viennaps) ([source](https://github.com/ViennaTools/ViennaPS/blob/HEAD/pyproject.toml))
 * [xgrammar](https://pypi.org/project/xgrammar) ([source](https://github.com/mlc-ai/xgrammar/blob/HEAD/pyproject.toml))
 * [xtgeo](https://pypi.org/project/xtgeo) ([source](https://github.com/equinor/xtgeo/blob/HEAD/pyproject.toml))
-<!--[[[end]]] (sum: Dz4otQAPQ9)-->
+<!--[[[end]]] (sum: rugOlZQc/x)-->
 
 <!-- prettier-ignore-end -->
 

--- a/docs/data/projects.toml
+++ b/docs/data/projects.toml
@@ -52,6 +52,10 @@ pypi = "faiss-cpu"
 github = "facebookresearch/faiss"
 
 [[project]]
+pypi = "fandango-fuzzer"
+github = "fandango-fuzzer/fandango"
+
+[[project]]
 pypi = "freud-analysis"
 github = "glotzerlab/freud"
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Changelog entry for the 1.0.2 patch release, covering the two commits since v1.0.1: the redirect editable `sys.path_hooks` fix (#1493) and the deprecated `project_wheel_metadata` test cleanup (#1494).