### PR TITLE
chore: forward -C config-settings in downstream editable install

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -326,7 +326,7 @@ def downstream(session: nox.Session) -> None:
         session.install(
             "-e.",
             "--no-build-isolation",
-            *(f"--config-settings={x}" for x in args.C),
+            *(f"-C{x}" for x in args.C),
         )
     else:
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -323,7 +323,11 @@ def downstream(session: nox.Session) -> None:
         session.chdir(args.subdir)
 
     if args.editable:
-        session.install("-e.", "--no-build-isolation")
+        session.install(
+            "-e.",
+            "--no-build-isolation",
+            *(f"--config-settings={x}" for x in args.C),
+        )
     else:
         session.run(
             "python",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `downstream` nox session parses repeatable `-C` config-settings and forwards them to `python -m build` in wheel mode, but silently dropped them in editable mode. This forwards them to the editable install (`session.install("-e.", ...)`) too, using `--config-settings=` (accepted by both uv and pip).