### PR TITLE
fix(setuptools): thread config_settings to the build command

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -91,8 +91,13 @@ possible. If you don't use that, you get more reasonable modern defaults.
 ## Configuration
 
 All other configuration is available as normal `tool.scikit-build` in
-`pyproject.toml` or environment variables as applicable. Config-settings is
-_not_ supported, as setuptools has very poor support for config-settings.
+`pyproject.toml` or environment variables as applicable. Config-settings (`-C`)
+is supported when building through the PEP 517 backend
+(`scikit_build_core.setuptools.build_meta`), e.g.
+`pip install . -C cmake.build-type=Debug`. It is _not_ available when driving
+`setup.py` directly or via the `wrapper.setup` shim, since setuptools' command
+machinery never receives the PEP 517 `config_settings`; use `SKBUILD_*`
+environment variables there instead.
 
 For classic scikit-build compatibility, two environment variables are honored,
 but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -94,10 +94,8 @@ All other configuration is available as normal `tool.scikit-build` in
 `pyproject.toml` or environment variables as applicable. Config-settings (`-C`)
 is supported when building through the PEP 517 backend
 (`scikit_build_core.setuptools.build_meta`), e.g.
-`pip install . -C cmake.build-type=Debug`. It is _not_ available when driving
-`setup.py` directly or via the `wrapper.setup` shim, since setuptools' command
-machinery never receives the PEP 517 `config_settings`; use `SKBUILD_*`
-environment variables there instead.
+`pip install . -C cmake.build-type=Debug`. It is _not_ available if you
+use `setuptools.build_meta` or `setup.py` directly.
 
 For classic scikit-build compatibility, two environment variables are honored,
 but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -94,8 +94,8 @@ All other configuration is available as normal `tool.scikit-build` in
 `pyproject.toml` or environment variables as applicable. Config-settings (`-C`)
 is supported when building through the PEP 517 backend
 (`scikit_build_core.setuptools.build_meta`), e.g.
-`pip install . -C cmake.build-type=Debug`. It is _not_ available if you
-use `setuptools.build_meta` or `setup.py` directly.
+`pip install . -C cmake.build-type=Debug`. It is _not_ available if you use
+`setuptools.build_meta` or `setup.py` directly.
 
 For classic scikit-build compatibility, two environment variables are honored,
 but only when using the `scikit_build_core.setuptools.wrapper.setup` shim (they

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -19,6 +19,8 @@ __lazy_modules__ = {
     "typing",
 }
 
+import contextlib
+import contextvars
 import enum
 import os
 import shlex
@@ -45,7 +47,7 @@ from ..settings.skbuild_read_settings import SettingsReader
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from setuptools.dist import Distribution
 
@@ -66,6 +68,13 @@ __all__ = [
 # install-dir translation, classic layout staging, and SKBUILD_*_OPTIONS env vars.
 WRAPPER_COMPAT = "_scikit_build_wrapper_compat"
 ORIGINAL_DATA_FILES = "_scikit_build_original_data_files"
+
+# PEP 517 config_settings for the in-flight build. The build_cmake command runs
+# inside setuptools' setup(), which never receives the PEP 517 config_settings
+# dict, so the build_meta hooks stash it here for _load_settings to read.
+_CONFIG_SETTINGS: contextvars.ContextVar[dict[str, str | list[str]] | None] = (
+    contextvars.ContextVar("skbuild_setuptools_config_settings", default=None)
+)
 
 
 def __dir__() -> list[str]:
@@ -93,6 +102,18 @@ class _EditableMode(enum.Enum):
         """True when CMake installs into the source tree; otherwise the build
         stages into build_lib."""
         return self in {_EditableMode.INPLACE, _EditableMode.LENIENT}
+
+
+@contextlib.contextmanager
+def set_config_settings(
+    config_settings: dict[str, str | list[str]] | None,
+) -> Iterator[None]:
+    """Scope PEP 517 config_settings for nested build_cmake invocations."""
+    token = _CONFIG_SETTINGS.set(config_settings)
+    try:
+        yield
+    finally:
+        _CONFIG_SETTINGS.reset(token)
 
 
 def _apply_cmake_install_target(
@@ -138,8 +159,10 @@ def _load_settings(
     # setup.py-only projects (common with the classic scikit-build wrapper)
     # don't have a pyproject.toml.
     if not Path("pyproject.toml").is_file():
-        return SettingsReader({}, {}, state=state).settings
-    return SettingsReader.from_file("pyproject.toml", state=state).settings
+        return SettingsReader({}, _CONFIG_SETTINGS.get() or {}, state=state).settings
+    return SettingsReader.from_file(
+        "pyproject.toml", _CONFIG_SETTINGS.get(), state=state
+    ).settings
 
 
 def get_source_dir_from_pyproject_toml() -> str | None:

--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -12,15 +12,40 @@ __lazy_modules__ = {
 from typing import Literal
 
 import setuptools.build_meta
-from setuptools.build_meta import (
-    build_sdist,
-    build_wheel,
-    prepare_metadata_for_build_wheel,
-)
 
 from ..builder.get_requires import GetRequires
 from ..settings.skbuild_read_settings import SettingsReader
-from .build_cmake import _validate_settings
+from .build_cmake import _validate_settings, set_config_settings
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    with set_config_settings(config_settings):
+        return setuptools.build_meta.build_wheel(
+            wheel_directory, config_settings, metadata_directory
+        )
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> str:
+    with set_config_settings(config_settings):
+        return setuptools.build_meta.build_sdist(sdist_directory, config_settings)
+
+
+def prepare_metadata_for_build_wheel(
+    metadata_directory: str,
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> str:
+    with set_config_settings(config_settings):
+        return setuptools.build_meta.prepare_metadata_for_build_wheel(
+            metadata_directory, config_settings
+        )
+
 
 if hasattr(setuptools.build_meta, "build_editable"):
 
@@ -41,10 +66,11 @@ if hasattr(setuptools.build_meta, "build_editable"):
         config_settings: dict[str, str | list[str]] | None = None,
         metadata_directory: str | None = None,
     ) -> str:
-        _validate_editable_settings(config_settings, state="editable")
-        return setuptools.build_meta.build_editable(
-            wheel_directory, config_settings, metadata_directory
-        )
+        with set_config_settings(config_settings):
+            _validate_editable_settings(config_settings, state="editable")
+            return setuptools.build_meta.build_editable(
+                wheel_directory, config_settings, metadata_directory
+            )
 
 
 if hasattr(setuptools.build_meta, "prepare_metadata_for_build_editable"):
@@ -53,10 +79,11 @@ if hasattr(setuptools.build_meta, "prepare_metadata_for_build_editable"):
         metadata_directory: str,
         config_settings: dict[str, str | list[str]] | None = None,
     ) -> str:
-        _validate_editable_settings(config_settings, state="metadata_editable")
-        return setuptools.build_meta.prepare_metadata_for_build_editable(
-            metadata_directory, config_settings
-        )
+        with set_config_settings(config_settings):
+            _validate_editable_settings(config_settings, state="metadata_editable")
+            return setuptools.build_meta.prepare_metadata_for_build_editable(
+                metadata_directory, config_settings
+            )
 
 
 __all__ = [

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -742,6 +742,42 @@ def test_load_settings_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     assert build_cmake._load_settings(state="editable").wheel.cmake is True
 
 
+@pytest.mark.skipif(
+    build_editable is None, reason="Requires setuptools editable support"
+)
+def test_build_editable_threads_config_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    # A config-setting like `pip install -e . -C editable.mode=inplace` must be
+    # visible to build_cmake, not only to the metadata/validation hook. Without
+    # threading, the build half loads default settings and rejects the install.
+    import setuptools.build_meta
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.scikit-build]\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    captured: dict[str, str] = {}
+
+    def fake_build_editable(
+        _wheel_directory: str,
+        _config_settings: dict[str, str | list[str]] | None = None,
+        _metadata_directory: str | None = None,
+    ) -> str:
+        settings = build_cmake._load_settings(state="editable")
+        captured["mode"] = settings.editable.mode
+        # Must not raise "requires editable.mode = 'inplace'".
+        build_cmake._validate_settings(settings, pep660_editable=True)
+        return "wheel"
+
+    monkeypatch.setattr(setuptools.build_meta, "build_editable", fake_build_editable)
+
+    assert build_editable is not None
+    result = build_editable(str(tmp_path), {"editable.mode": "inplace"})
+    assert result == "wheel"
+    assert captured["mode"] == "inplace"
+
+
 def test_wrapper_forwards_manifest_hook(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The setuptools plugin read settings inconsistently between two code paths. The metadata/validation hooks (`prepare_metadata_for_build_*`, `_validate_editable_settings`) passed PEP 517 `config_settings` to `SettingsReader`, but the `build_cmake` command reloaded settings via `_load_settings` **without** them. Because `build_cmake` runs inside setuptools' `setup()` (invoked by setuptools' `build_wheel`/`build_editable`), it never naturally receives the `config_settings` dict, so they were silently dropped for the actual CMake build.

Concretely, `pip install -e . -C editable.mode=inplace` against a project that does not set `editable.mode` in `pyproject.toml` **passed** the editable metadata hook but then **failed** inside `build_cmake` with `setuptools editable installs require editable.mode = 'inplace'`. Env vars (`SKBUILD_*`) already worked; only `config_settings` were lost.

## Change

- Stash the in-flight `config_settings` in a `contextvars.ContextVar` (`build_cmake.set_config_settings`), scoped via a context manager so nothing leaks between calls.
- All `build_meta` hooks now set the stash before delegating to setuptools: `build_wheel`, `build_editable`, `build_sdist`, `prepare_metadata_for_build_wheel`, and `prepare_metadata_for_build_editable` (`build_wheel`/`build_sdist`/`prepare_metadata_for_build_wheel` are now thin wrappers instead of re-exports).
- `_load_settings` reads the stash, so the build half sees the same config as the metadata half.

This makes `-C` / `--config-settings` work consistently across the setuptools editable and wheel paths, matching the existing env-var behavior.