### PR TITLE
feat(setuptools): default to inplace editables in the wrapper

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -147,21 +147,26 @@ requires setting it. Other `sdist` options are not used in setuptools mode.
 PEP 660 editable installs (`pip install -e .`) are supported when the active
 setuptools version provides `build_editable` (setuptools 63+).
 
-Setuptools editable installs require:
+The setuptools plugin follows setuptools' native editable-wheel mechanism,
+placing CMake-installed extension modules into the source layout that setuptools
+exposes via its `.pth` file. This is effectively the setuptools equivalent of
+scikit-build-core's
+[`inplace` editable mode](../configuration/editable.md#inplace-mode), so the
+backend's own `redirect` mode is not supported here.
+
+Because this writes build artifacts into your source tree, the plugin requires
+opting in:
 
 ```toml
 [tool.scikit-build]
 editable.mode = "inplace"
 ```
 
-The setuptools plugin follows setuptools' editable-wheel mechanism, so editable
-builds place CMake-installed extension modules into the source layout that
-setuptools exposes via its `.pth` file. This is effectively the setuptools
-equivalent of scikit-build-core's
-[`inplace` editable mode](../configuration/editable.md#inplace-mode), so
-redirect mode is not supported here.
+The `scikit_build_core.setuptools.wrapper.setup` shim skips this requirement,
+since in-place editable installs are how scikit-build (classic) always behaved.
 
-Because of that, `editable.rebuild` is not supported in setuptools mode.
+Because setuptools owns the editable mechanism, `editable.rebuild` is not
+supported in setuptools mode.
 
 ### Strict mode
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -39,7 +39,7 @@ from packaging.version import Version
 from .._check_extra import warn_missing_extra
 from .._compat import tomllib
 from .._compat.setuptools.errors import SetupError
-from .._logging import LEVEL_VALUE, raw_logger
+from .._logging import LEVEL_VALUE, logger, raw_logger
 from ..build._file_processor import each_unignored_file
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
@@ -130,7 +130,10 @@ def _apply_cmake_install_target(
 
 
 def _validate_settings(
-    settings: ScikitBuildSettings, *, pep660_editable: bool = False
+    settings: ScikitBuildSettings,
+    *,
+    pep660_editable: bool = False,
+    wrapper_compat: bool | None = None,
 ) -> None:
     if settings.wheel.expand_macos_universal_tags:
         msg = "wheel.expand_macos_universal_tags is not supported in setuptools mode"
@@ -144,12 +147,22 @@ def _validate_settings(
     if len(normalize_build_types(settings.cmake.build_type)) > 1:
         msg = "cmake.build-type lists (multi-config) are not supported in setuptools mode, use a single build type"
         raise SetupError(msg)
-    # A direct "build_ext --inplace" builds in-place regardless of
-    # editable.mode; only PEP 660 editable wheels require the opt-in.
+    # A direct "build_ext --inplace" always builds in-place; PEP 660 editable
+    # wheels use the same mechanism, but since that writes into the source
+    # tree, the plain plugin requires the editable.mode = "inplace" opt-in.
+    # The classic scikit-build wrapper always behaved this way, so it proceeds
+    # by default. wrapper_compat=None means "unknown" (the early PEP 517
+    # validation runs before setup.py can enable the wrapper), deferring this
+    # check to the command-time validation.
     if pep660_editable:
-        if settings.editable.mode != "inplace":
-            msg = "setuptools editable installs require editable.mode = 'inplace'"
-            raise SetupError(msg)
+        if settings.editable.mode == "redirect" and wrapper_compat is not None:
+            if not wrapper_compat:
+                msg = "setuptools editable installs build into the source tree, set editable.mode = 'inplace' to opt in"
+                raise SetupError(msg)
+            logger.info(
+                "Using setuptools' native in-place editable mechanism (classic "
+                "scikit-build behavior)"
+            )
         if settings.editable.rebuild_enabled:
             msg = "editable.rebuild is not supported in setuptools mode"
             raise SetupError(msg)
@@ -648,7 +661,11 @@ class BuildCMake(setuptools.Command):
         settings = _load_settings(
             state="editable" if self._editable_mode.is_editable else "wheel"
         )
-        _validate_settings(settings, pep660_editable=self._editable_mode.is_pep660)
+        _validate_settings(
+            settings,
+            pep660_editable=self._editable_mode.is_pep660,
+            wrapper_compat=self._wrapper_compat_enabled(),
+        )
         _apply_cmake_install_target(settings, self.distribution)
 
         build_tmp_folder = Path(self.build_temp)

--- a/src/scikit_build_core/setuptools/build_meta.py
+++ b/src/scikit_build_core/setuptools/build_meta.py
@@ -59,6 +59,8 @@ if hasattr(setuptools.build_meta, "build_editable"):
             config_settings,
             state=state,
         ).settings
+        # wrapper_compat is unknown until setup.py runs, so the editable.mode
+        # check is deferred to the build_cmake command.
         _validate_settings(settings, pep660_editable=True)
 
     def build_editable(

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import logging
 import subprocess
 import sys
 import tarfile
@@ -215,6 +216,73 @@ def test_pep517_editable(virtualenv, tmp_path: Path):
 
     add = virtualenv.execute("import cmake_example; print(cmake_example.add(1, 2))")
     assert add.strip() == "3"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.broken_on_urct
+@pytest.mark.skipif(
+    build_editable is None, reason="Requires setuptools editable support"
+)
+@pytest.mark.parametrize("package", ["wrapper_setuptools_install_dir"], indirect=True)
+def test_pep517_editable_wrapper_without_editable_mode(
+    package, virtualenv, tmp_path: Path
+):
+    # The classic scikit-build wrapper always built editables in-place, so it
+    # must not require the editable.mode = "inplace" opt-in.
+    assert build_editable is not None
+    pyproject = package.workdir / "pyproject.toml"
+    contents = pyproject.read_text(encoding="utf-8")
+    assert 'editable.mode = "inplace"\n' in contents
+    pyproject.write_text(
+        contents.replace('editable.mode = "inplace"\n', ""), encoding="utf-8"
+    )
+
+    dist = tmp_path / "dist"
+    out = build_editable(str(dist))
+    (wheel,) = dist.glob("wrapper_example-0.0.1-0.editable-*.whl")
+    wheel = wheel.resolve()  # Windows mingw64 and UCRT now requires this
+    assert wheel == dist / out
+
+    virtualenv.install(wheel)
+
+    module_dir = virtualenv.execute(
+        "import pathlib, wrapper_example; print(pathlib.Path(wrapper_example.__file__).resolve().parent)"
+    )
+    assert Path(module_dir) == (package.workdir / "src/wrapper_example").resolve()
+
+    _assert_extension_import(virtualenv, "wrapper_example")
+
+
+@pytest.mark.skipif(
+    build_editable is None, reason="Requires setuptools editable support"
+)
+@pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
+def test_pep517_editable_plugin_requires_editable_mode(package, capfd, tmp_path: Path):
+    # The plain plugin requires the editable.mode = "inplace" opt-in, since
+    # editable installs write into the source tree. The check can't run in the
+    # early build_meta validation (wrapper-ness is only known once setup.py
+    # runs), so this exercises the deferred command-time check end-to-end.
+    assert build_editable is not None
+    pyproject = package.workdir / "pyproject.toml"
+    contents = pyproject.read_text(encoding="utf-8")
+    assert 'editable.mode = "inplace"\n' in contents
+    pyproject.write_text(
+        contents.replace('editable.mode = "inplace"\n', ""), encoding="utf-8"
+    )
+
+    dist = tmp_path / "dist"
+    # How the SetupError surfaces varies by setuptools version: SystemExit from
+    # distutils, or (with -W error) editable_wheel's _DebuggingTips warning.
+    with pytest.raises((SystemExit, SetupError, Warning)) as excinfo:
+        build_editable(str(dist))
+
+    expected = "set editable.mode = 'inplace' to opt in"
+    captured = capfd.readouterr()
+    # Older setuptools replaces the message, leaving it only in the printed
+    # traceback.
+    assert expected in str(excinfo.value) or expected in captured.err
+    assert not list(dist.glob("*.whl"))
 
 
 @pytest.mark.compile
@@ -781,13 +849,32 @@ def test_get_source_files_requires_explicit_inclusion_mode(tmp_path, monkeypatch
         cmd.get_source_files()
 
 
-def test_validate_settings_editable_mode_only_required_for_pep660():
+def test_validate_settings_editable_mode_inplace_default_wrapper_only(caplog):
     settings = build_cmake._load_settings()
     assert settings.editable.mode == "redirect"
-    # Plain builds (including build_ext --inplace) don't require the setting.
-    build_cmake._validate_settings(settings)
+    # Plain builds (including build_ext --inplace) never check editable.mode.
+    build_cmake._validate_settings(settings, wrapper_compat=False)
+
+    # wrapper_compat=None (the early PEP 517 validation) defers the check.
+    build_cmake._validate_settings(settings, pep660_editable=True)
+
+    # The plain plugin requires the explicit opt-in.
     with pytest.raises(SetupError, match=r"editable\.mode = 'inplace'"):
-        build_cmake._validate_settings(settings, pep660_editable=True)
+        build_cmake._validate_settings(
+            settings, pep660_editable=True, wrapper_compat=False
+        )
+
+    # The classic wrapper defaults to in-place, with only an info message.
+    caplog.set_level(logging.INFO, logger="scikit_build_core")
+    build_cmake._validate_settings(settings, pep660_editable=True, wrapper_compat=True)
+    assert "in-place editable" in caplog.text
+
+    # An explicit editable.mode = "inplace" is always silent.
+    caplog.clear()
+    settings.editable.mode = "inplace"
+    build_cmake._validate_settings(settings, pep660_editable=True, wrapper_compat=True)
+    build_cmake._validate_settings(settings, pep660_editable=True, wrapper_compat=False)
+    assert caplog.text == ""
 
 
 def test_wrapper_setup_raises_setup_error():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

setuptools' native editable mechanism is in-place building, and that is how scikit-build (classic) always behaved, so the wrapper (`scikit_build_core.setuptools.wrapper.setup`) no longer requires `editable.mode = "inplace"` for PEP 660 editable installs — it logs an informational line and proceeds. The plain plugin keeps requiring the explicit opt-in, since editable installs write into the source tree.

Since wrapper use is only known once `setup.py` runs, the early PEP 517 validation in `build_meta` defers the `editable.mode` check to the `build_cmake` command, where the wrapper compat flag is available.