### PR TITLE
fix(setuptools): keep source tree clean in strict editable mode

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -128,6 +128,20 @@ redirect mode is not supported here.
 
 Because of that, `editable.rebuild` is not supported in setuptools mode.
 
+### Strict mode
+
+setuptools' strict editable mode
+(`pip install -e . --config-settings editable_mode=strict`) keeps the source
+tree free of built artifacts. In this mode the plugin installs the CMake output
+into setuptools' `build_lib`, and setuptools' link-tree strategy copies it into
+a persistent auxiliary directory (`build/__editable__.<name>-<tag>/`) that the
+`.pth` file points at. This is closer to the backend's redirect editable mode.
+
+The trade-off is inherent to strict mode's contract: because the copied
+artifacts are a snapshot, a CMake rebuild (e.g. after changing C/C++ sources)
+requires reinstalling the editable to pick up the new build. Lenient mode (the
+default) keeps installing into the source tree in place.
+
 A direct `setup.py build_ext --inplace` builds into the source tree without
 producing an editable wheel, so it works without any `editable.mode` setting,
 just like scikit-build (classic).

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -385,6 +385,7 @@ class BuildCMake(setuptools.Command):
     build_temp: str | None
     debug: bool | None
     editable_mode: bool
+    editable_strict: bool
     parallel: int | None
     plat_name: str | None
 
@@ -403,6 +404,7 @@ class BuildCMake(setuptools.Command):
         self.build_temp = None
         self.debug = None
         self.editable_mode = False
+        self.editable_strict = False
         self.parallel = None
         self.plat_name = None
         self.source_dir = get_source_dir_from_pyproject_toml()
@@ -420,6 +422,7 @@ class BuildCMake(setuptools.Command):
             ("plat_name", "plat_name"),
         )
         self.editable_mode = self._get_editable_mode()
+        self.editable_strict = self._get_editable_strict()
 
         if isinstance(self.cmake_args, str):
             self.cmake_args = [
@@ -438,6 +441,20 @@ class BuildCMake(setuptools.Command):
         build_ext = self.distribution.get_command_obj("build_ext")
         return bool(getattr(build_ext, "editable_mode", False))
 
+    def _get_editable_strict(self) -> bool:
+        # Strict PEP 660 editables use setuptools' _LinkTree strategy, which
+        # copies build_lib outputs (that carry no source mapping) into a
+        # persistent auxiliary directory. Installing there instead of the
+        # source tree keeps it clean, the closest analog of the backend's
+        # redirect editable mode. editable_wheel is internal, so probe it
+        # defensively and fall back to the in-tree install if anything is
+        # missing. Never treat "build_ext --inplace" as strict.
+        if not self._is_pep660_editable():
+            return False
+        command_obj = getattr(self.distribution, "command_obj", None) or {}
+        editable_wheel = command_obj.get("editable_wheel")
+        return getattr(editable_wheel, "mode", None) == "strict"
+
     def _get_install_subdir(self) -> Path:
         dist_cmake_install_dir = (
             getattr(self.distribution, "cmake_install_dir", "") or ""
@@ -452,7 +469,12 @@ class BuildCMake(setuptools.Command):
         assert self.build_lib is not None
         install_subdir = self._get_install_subdir()
 
-        if not self.editable_mode:
+        # Non-editable builds and strict editables both stage into build_lib.
+        # For strict editables, setuptools' _LinkTree then copies the outputs
+        # into the persistent aux dir, leaving the source tree clean. Lenient
+        # editables must install in-tree: build_lib is a temporary directory
+        # discarded by the _StaticPth/_TopLevelFinder strategies.
+        if not self.editable_mode or self.editable_strict:
             return Path(self.build_lib).resolve() / install_subdir
 
         # The wrapper translates cmake_install_dir relative to the package base
@@ -576,6 +598,7 @@ class BuildCMake(setuptools.Command):
         warn_missing_extra("setuptools", "wheel-free-setuptools")
 
         self.editable_mode = self._get_editable_mode()
+        self.editable_strict = self._get_editable_strict()
         # run() is always a wheel or editable build; pass the matching state so
         # overrides (if.state = "wheel"/"editable") are applied correctly.
         settings = _load_settings(state="editable" if self.editable_mode else "wheel")
@@ -701,7 +724,12 @@ class BuildCMake(setuptools.Command):
             )
 
     def get_outputs(self) -> list[str]:
-        if self.editable_mode:
+        # Lenient editables install in-tree, so outputs come from the mapping
+        # (build_lib path -> source path). Non-editable builds and strict
+        # editables stage into build_lib, so report the real installed paths;
+        # for strict editables these carry no mapping, so _LinkTree copies them
+        # into the persistent aux dir.
+        if self.editable_mode and not self.editable_strict:
             return sorted(self.get_output_mapping())
         return sorted(os.fspath(path) for path in self._installed_files)
 
@@ -709,8 +737,11 @@ class BuildCMake(setuptools.Command):
     #    return ["CMakeLists.txt"]
 
     def get_output_mapping(self) -> dict[str, str]:
+        # Strict editable outputs are generated, not source files, so they have
+        # no mapping entry (reported via get_outputs and copied by _LinkTree).
         if (
             not self.editable_mode
+            or self.editable_strict
             or self._editable_install_dir is None
             or self.build_lib is None
         ):

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -19,6 +19,7 @@ __lazy_modules__ = {
     "typing",
 }
 
+import enum
 import os
 import shlex
 import shutil
@@ -62,8 +63,7 @@ __all__ = [
 
 # Marker set on the Distribution by the classic scikit-build compatibility shim
 # (scikit_build_core.setuptools.wrapper.setup) to opt into its behaviors:
-# install-dir translation, classic source-layout staging, and the
-# SKBUILD_CONFIGURE_OPTIONS / SKBUILD_BUILD_OPTIONS environment variables.
+# install-dir translation, classic layout staging, and SKBUILD_*_OPTIONS env vars.
 WRAPPER_COMPAT = "_scikit_build_wrapper_compat"
 ORIGINAL_DATA_FILES = "_scikit_build_original_data_files"
 
@@ -72,13 +72,35 @@ def __dir__() -> list[str]:
     return __all__
 
 
+class _EditableMode(enum.Enum):
+    """Editable flavor of the current build (DISABLED for a regular build)."""
+
+    DISABLED = "disabled"
+    INPLACE = "inplace"  # direct "build_ext --inplace"
+    LENIENT = "lenient"  # PEP 660 lenient (default) or compat editable
+    STRICT = "strict"  # PEP 660 strict editable
+
+    @property
+    def is_editable(self) -> bool:
+        return self is not _EditableMode.DISABLED
+
+    @property
+    def is_pep660(self) -> bool:
+        return self in {_EditableMode.LENIENT, _EditableMode.STRICT}
+
+    @property
+    def installs_in_tree(self) -> bool:
+        """True when CMake installs into the source tree; otherwise the build
+        stages into build_lib."""
+        return self in {_EditableMode.INPLACE, _EditableMode.LENIENT}
+
+
 def _apply_cmake_install_target(
     settings: ScikitBuildSettings, dist: Distribution
 ) -> None:
-    # Classic scikit-build's cmake_install_target picks the build target that
-    # performs the install; "install" is the default cmake --install path. A
-    # custom target installs via `cmake --build --target`, which is exactly what
-    # install.targets does.
+    # Classic scikit-build's cmake_install_target names the build target that
+    # performs the install; a non-default target maps directly onto
+    # install.targets ("install" is already the cmake --install default).
     target = getattr(dist, "cmake_install_target", None) or "install"
     if target != "install":
         settings.install.targets = [*settings.install.targets, target]
@@ -380,12 +402,13 @@ class BuildCMake(setuptools.Command):
     cmake_args: list[str] | str | None = None
     _editable_install_dir: Path | None
     _installed_files: list[Path]
+    # Underscored so setuptools' editable_wheel doesn't clobber it with a bool
+    # True (it matches the attribute name "editable_mode" exactly).
+    _editable_mode: _EditableMode
 
     build_lib: str | None
     build_temp: str | None
     debug: bool | None
-    editable_mode: bool
-    editable_strict: bool
     parallel: int | None
     plat_name: str | None
 
@@ -403,8 +426,7 @@ class BuildCMake(setuptools.Command):
         self.build_lib = None
         self.build_temp = None
         self.debug = None
-        self.editable_mode = False
-        self.editable_strict = False
+        self._editable_mode = _EditableMode.DISABLED
         self.parallel = None
         self.plat_name = None
         self.source_dir = get_source_dir_from_pyproject_toml()
@@ -421,39 +443,29 @@ class BuildCMake(setuptools.Command):
             ("parallel", "parallel"),
             ("plat_name", "plat_name"),
         )
-        self.editable_mode = self._get_editable_mode()
-        self.editable_strict = self._get_editable_strict()
+        self._editable_mode = self._get_editable_mode()
 
         if isinstance(self.cmake_args, str):
             self.cmake_args = [
                 b.strip() for a in self.cmake_args.split() for b in a.split(";")
             ]
 
-    def _get_editable_mode(self) -> bool:
-        # Both PEP 660 editable wheels and "build_ext --inplace" install into
-        # the source tree.
+    def _get_editable_mode(self) -> _EditableMode:
         build_ext = self.distribution.get_command_obj("build_ext")
-        return self._is_pep660_editable() or bool(getattr(build_ext, "inplace", False))
-
-    def _is_pep660_editable(self) -> bool:
-        # setuptools sets editable_mode only when building a PEP 660 editable
-        # wheel; a direct "build_ext --inplace" sets just inplace.
-        build_ext = self.distribution.get_command_obj("build_ext")
-        return bool(getattr(build_ext, "editable_mode", False))
-
-    def _get_editable_strict(self) -> bool:
-        # Strict PEP 660 editables use setuptools' _LinkTree strategy, which
-        # copies build_lib outputs (that carry no source mapping) into a
-        # persistent auxiliary directory. Installing there instead of the
-        # source tree keeps it clean, the closest analog of the backend's
-        # redirect editable mode. editable_wheel is internal, so probe it
-        # defensively and fall back to the in-tree install if anything is
-        # missing. Never treat "build_ext --inplace" as strict.
-        if not self._is_pep660_editable():
-            return False
-        command_obj = getattr(self.distribution, "command_obj", None) or {}
-        editable_wheel = command_obj.get("editable_wheel")
-        return getattr(editable_wheel, "mode", None) == "strict"
+        # setuptools sets editable_mode on build_ext only when building a PEP
+        # 660 editable wheel; a direct "build_ext --inplace" sets just inplace.
+        if getattr(build_ext, "editable_mode", False):
+            # Strict editables copy build_lib outputs into a persistent aux dir
+            # (_LinkTree), keeping the source tree clean. editable_wheel is
+            # internal, so probe defensively and fall back to in-tree (LENIENT).
+            command_obj = getattr(self.distribution, "command_obj", None) or {}
+            editable_wheel = command_obj.get("editable_wheel")
+            if getattr(editable_wheel, "mode", None) == "strict":
+                return _EditableMode.STRICT
+            return _EditableMode.LENIENT
+        if getattr(build_ext, "inplace", False):
+            return _EditableMode.INPLACE
+        return _EditableMode.DISABLED
 
     def _get_install_subdir(self) -> Path:
         dist_cmake_install_dir = (
@@ -469,18 +481,15 @@ class BuildCMake(setuptools.Command):
         assert self.build_lib is not None
         install_subdir = self._get_install_subdir()
 
-        # Non-editable builds and strict editables both stage into build_lib.
-        # For strict editables, setuptools' _LinkTree then copies the outputs
-        # into the persistent aux dir, leaving the source tree clean. Lenient
-        # editables must install in-tree: build_lib is a temporary directory
-        # discarded by the _StaticPth/_TopLevelFinder strategies.
-        if not self.editable_mode or self.editable_strict:
+        # Non-editable and strict editable builds stage into build_lib (strict
+        # outputs are then copied to the aux dir by _LinkTree). Lenient editables
+        # must install in-tree: their strategies discard build_lib.
+        if not self._editable_mode.installs_in_tree:
             return Path(self.build_lib).resolve() / install_subdir
 
         # The wrapper translates cmake_install_dir relative to the package base
-        # dir (which honors per-package package_dir), so the editable source
-        # root must use the same base or the extension lands beside the wrong
-        # tree (creating a junk directory).
+        # dir, so the editable source root must use the same base or the
+        # extension lands beside the wrong tree (creating a junk directory).
         if self._wrapper_compat_enabled():
             source_root = _package_base_dir(self.distribution)
         else:
@@ -532,7 +541,7 @@ class BuildCMake(setuptools.Command):
         return bool(getattr(self.distribution, WRAPPER_COMPAT, False))
 
     def _wrapper_classic_layout_compat_enabled(self) -> bool:
-        return not self.editable_mode and self._wrapper_compat_enabled()
+        return not self._editable_mode.is_editable and self._wrapper_compat_enabled()
 
     def _apply_wrapper_classic_layout_compat(
         self, *, staged_install_dir: Path, install_subdir: Path
@@ -597,12 +606,13 @@ class BuildCMake(setuptools.Command):
 
         warn_missing_extra("setuptools", "wheel-free-setuptools")
 
-        self.editable_mode = self._get_editable_mode()
-        self.editable_strict = self._get_editable_strict()
+        self._editable_mode = self._get_editable_mode()
         # run() is always a wheel or editable build; pass the matching state so
         # overrides (if.state = "wheel"/"editable") are applied correctly.
-        settings = _load_settings(state="editable" if self.editable_mode else "wheel")
-        _validate_settings(settings, pep660_editable=self._is_pep660_editable())
+        settings = _load_settings(
+            state="editable" if self._editable_mode.is_editable else "wheel"
+        )
+        _validate_settings(settings, pep660_editable=self._editable_mode.is_pep660)
         _apply_cmake_install_target(settings, self.distribution)
 
         build_tmp_folder = Path(self.build_temp)
@@ -724,12 +734,10 @@ class BuildCMake(setuptools.Command):
             )
 
     def get_outputs(self) -> list[str]:
-        # Lenient editables install in-tree, so outputs come from the mapping
-        # (build_lib path -> source path). Non-editable builds and strict
-        # editables stage into build_lib, so report the real installed paths;
-        # for strict editables these carry no mapping, so _LinkTree copies them
-        # into the persistent aux dir.
-        if self.editable_mode and not self.editable_strict:
+        # In-tree editables report outputs via the mapping (build_lib -> source).
+        # Non-editable and strict builds report the real staged paths; strict
+        # ones carry no mapping, so _LinkTree copies them to the aux dir.
+        if self._editable_mode.installs_in_tree:
             return sorted(self.get_output_mapping())
         return sorted(os.fspath(path) for path in self._installed_files)
 
@@ -740,8 +748,7 @@ class BuildCMake(setuptools.Command):
         # Strict editable outputs are generated, not source files, so they have
         # no mapping entry (reported via get_outputs and copied by _LinkTree).
         if (
-            not self.editable_mode
-            or self.editable_strict
+            not self._editable_mode.installs_in_tree
             or self._editable_install_dir is None
             or self.build_lib is None
         ):

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -210,6 +210,64 @@ def test_pep517_editable(virtualenv, tmp_path: Path):
 @pytest.mark.compile
 @pytest.mark.configure
 @pytest.mark.broken_on_urct
+@pytest.mark.skipif(
+    build_editable is None, reason="Requires setuptools editable support"
+)
+# _LinkTree emits an InformationOnly note about the aux dir on exit.
+@pytest.mark.filterwarnings("ignore:Editable installation")
+@pytest.mark.parametrize(
+    "config_settings",
+    [{"editable-mode": "strict"}, {"editable_mode": "strict"}],
+    ids=["dash", "underscore"],
+)
+@pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
+def test_pep517_editable_strict(virtualenv, package, config_settings, tmp_path: Path):
+    # Strict mode (pip install -e . --config-settings editable_mode=strict) uses
+    # setuptools' _LinkTree: unmapped build_lib outputs are copied into the
+    # persistent aux dir, so the CMake artifact must NOT touch the source tree.
+    assert build_editable is not None
+    dist = tmp_path / "dist"
+    out = build_editable(str(dist), config_settings=config_settings)
+    (wheel,) = dist.glob("cmake_example-0.0.1-0.editable-*.whl")
+    wheel = wheel.resolve()  # Windows mingw64 and UCRT now requires this
+    assert wheel == dist / out
+
+    with zipfile.ZipFile(wheel) as zf:
+        file_names = {Path(n).parts[0] for n in zf.namelist()}
+
+    assert file_names == {
+        "__editable__.cmake_example-0.0.1.pth",
+        "cmake_example-0.0.1.dist-info",
+    }
+
+    # The strict link tree lives in build/__editable__.<name>-<tag>/ and must
+    # hold the compiled extension.
+    (aux_dir,) = package.workdir.glob("build/__editable__.cmake_example-*")
+    assert any(p.suffix in {".so", ".pyd", ".dylib"} for p in aux_dir.rglob("*"))
+
+    # The key win over setuptools' build_ext: the source tree stays clean.
+    src_dir = package.workdir / "src"
+    assert not any(p.suffix in {".so", ".pyd", ".dylib"} for p in src_dir.rglob("*"))
+
+    virtualenv.install(wheel)
+
+    module_dir = virtualenv.execute(
+        "import pathlib, cmake_example; print(pathlib.Path(cmake_example.__file__).resolve().parent)"
+    )
+    assert Path(module_dir).resolve() == aux_dir.resolve()
+
+    version = virtualenv.execute(
+        "import cmake_example; print(cmake_example.__version__)"
+    )
+    assert version.strip() == "0.0.1"
+
+    add = virtualenv.execute("import cmake_example; print(cmake_example.add(1, 2))")
+    assert add.strip() == "3"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+@pytest.mark.broken_on_urct
 @pytest.mark.parametrize("package", ["simple_setuptools_ext"], indirect=True)
 def test_build_ext_inplace_without_editable_mode(package):
     # A direct "setup.py build_ext --inplace" involves no editable wheel, so it

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -669,7 +669,7 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     cmd = build_cmake.BuildCMake(dist)
     cmd.initialize_options()
     cmd.build_lib = str(tmp_path / "build")
-    cmd.editable_mode = True
+    cmd._editable_mode = build_cmake._EditableMode.LENIENT
 
     install_dir = cmd._get_install_dir()
     # samefile compares stat identity, immune to Windows 8.3 short-name


### PR DESCRIPTION
:robot: _AI text below_ :robot:

setuptools' strict editable mode (`pip install -e . --config-settings editable_mode=strict`) uses its `_LinkTree` strategy: it copies build sub-command outputs that have **no** source mapping from `build_lib` into a persistent auxiliary directory (`build/__editable__.<name>-<tag>/`) and points the `.pth` there.

This teaches the setuptools plugin to take advantage of that in strict mode:

- Detect strict mode from the running (internal) `editable_wheel` command's `.mode` attribute, defensively falling back to the current in-tree install if anything is missing. Only PEP 660 editables are considered, never `build_ext --inplace`.
- Install CMake artifacts into `build_lib` (out of tree) instead of the source directory.
- Report them via `get_outputs()` as real installed paths with an empty `get_output_mapping()`, so `_LinkTree` copies them into the aux dir.

**User-visible benefit:** in strict mode the source tree stays free of compiled artifacts (better than setuptools' own `build_ext`, which pollutes the tree even in strict mode), the closest supported analog of the backend's redirect editable mode. Lenient/in-place mode is unchanged.

**Caveat** (inherent to strict mode's contract): the copied artifacts are a snapshot, so a CMake rebuild requires reinstalling the editable to pick up the new build.