### PR TITLE
fix(setuptools): complete the setuptools SubCommand protocol

### DIFF
--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -126,13 +126,17 @@ list your CMake sources explicitly:
 
 ```toml
 [tool.scikit-build]
+sdist.inclusion-mode = "explicit"
 sdist.include = ["src/*.c", "cmake/"]
 ```
 
-This selection is purely additive and opt-in, so the backend's gitignore-based
-{confval}`sdist.inclusion-mode` does not apply, and neither do the options that
+Because setuptools owns the default file list, this selection is purely additive
+and opt-in: only the `"explicit"` {confval}`sdist.inclusion-mode` is supported,
+and using {confval}`sdist.include` requires setting it, so the configuration
+means the same thing here as it does in the main build backend. The options that
 control how the backend assembles its own SDists ({confval}`sdist.reproducible`,
-{confval}`sdist.cmake`, {confval}`sdist.force-include`).
+{confval}`sdist.cmake`, {confval}`sdist.force-include`) are not used in
+setuptools mode.
 
 ```{versionadded} 1.0
 

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -130,15 +130,12 @@ sdist.inclusion-mode = "explicit"
 sdist.include = ["src/*.c", "cmake/"]
 ```
 
-Because setuptools owns the default file list, this selection is purely additive
-and opt-in: only the `"explicit"` {confval}`sdist.inclusion-mode` is supported,
-and using {confval}`sdist.include` requires setting it, so the configuration
-means the same thing here as it does in the main build backend. The options that
-control how the backend assembles its own SDists ({confval}`sdist.reproducible`,
-{confval}`sdist.cmake`, {confval}`sdist.force-include`) are not used in
-setuptools mode.
+Because setuptools owns the default file list, only the
+`"explicit"` {confval}`sdist.inclusion-mode` is supported, and using
+{confval}`sdist.include` requires setting it. Other `sdist` options are not used
+in setuptools mode.
 
-```{versionadded} 1.0
+```{versionadded} 1.0.3
 
 ```
 

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -115,6 +115,29 @@ The `SKBUILD_CONFIGURE_OPTIONS` and `SKBUILD_BUILD_OPTIONS` environment
 variables (honored by the `wrapper.setup` shim).
 ```
 
+## SDists
+
+Setuptools builds the SDist, so its normal mechanisms (package discovery,
+`MANIFEST.in`) control the file list. The plugin contributes the CMake side on
+setuptools 62.4+: the entry-point `CMakeLists.txt`, plus any files matching
+{confval}`sdist.include`, trimmed by {confval}`sdist.exclude` (both gitignore
+syntax). Since the full CMake source tree can't be known before configuring,
+list your CMake sources explicitly:
+
+```toml
+[tool.scikit-build]
+sdist.include = ["src/*.c", "cmake/"]
+```
+
+This selection is purely additive and opt-in, so the backend's gitignore-based
+{confval}`sdist.inclusion-mode` does not apply, and neither do the options that
+control how the backend assembles its own SDists ({confval}`sdist.reproducible`,
+{confval}`sdist.cmake`, {confval}`sdist.force-include`).
+
+```{versionadded} 1.0
+
+```
+
 ## Editable installs
 
 ```{versionadded} 1.0

--- a/docs/plugins/setuptools.md
+++ b/docs/plugins/setuptools.md
@@ -130,10 +130,9 @@ sdist.inclusion-mode = "explicit"
 sdist.include = ["src/*.c", "cmake/"]
 ```
 
-Because setuptools owns the default file list, only the
-`"explicit"` {confval}`sdist.inclusion-mode` is supported, and using
-{confval}`sdist.include` requires setting it. Other `sdist` options are not used
-in setuptools mode.
+Because setuptools owns the default file list, only the `"explicit"`
+{confval}`sdist.inclusion-mode` is supported, and using {confval}`sdist.include`
+requires setting it. Other `sdist` options are not used in setuptools mode.
 
 ```{versionadded} 1.0.3
 

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -425,8 +425,11 @@ class BuildCMake(setuptools.Command):
     cmake_args: list[str] | str | None = None
     _editable_install_dir: Path | None
     _installed_files: list[Path]
-    # Underscored so setuptools' editable_wheel doesn't clobber it with a bool
-    # True (it matches the attribute name "editable_mode" exactly).
+    # The SubCommand protocol flag: editable_wheel sets it to True directly on
+    # build sub-commands. Folded into _editable_mode by _get_editable_mode().
+    editable_mode: bool
+    # Underscored so setuptools' editable_wheel doesn't clobber the enum with
+    # a bool True (it sets the attribute named "editable_mode" exactly).
     _editable_mode: _EditableMode
 
     build_lib: str | None
@@ -449,6 +452,7 @@ class BuildCMake(setuptools.Command):
         self.build_lib = None
         self.build_temp = None
         self.debug = None
+        self.editable_mode = False
         self._editable_mode = _EditableMode.DISABLED
         self.parallel = None
         self.plat_name = None
@@ -474,10 +478,11 @@ class BuildCMake(setuptools.Command):
             ]
 
     def _get_editable_mode(self) -> _EditableMode:
+        # setuptools marks a PEP 660 editable build by setting editable_mode
+        # directly on build sub-commands (the SubCommand protocol) and on
+        # build_ext; a direct "build_ext --inplace" sets just inplace.
         build_ext = self.distribution.get_command_obj("build_ext")
-        # setuptools sets editable_mode on build_ext only when building a PEP
-        # 660 editable wheel; a direct "build_ext --inplace" sets just inplace.
-        if getattr(build_ext, "editable_mode", False):
+        if self.editable_mode or getattr(build_ext, "editable_mode", False):
             # Strict editables copy build_lib outputs into a persistent aux dir
             # (_LinkTree), keeping the source tree clean. editable_wheel is
             # internal, so probe defensively and fall back to in-tree (LENIENT).
@@ -489,6 +494,12 @@ class BuildCMake(setuptools.Command):
         if getattr(build_ext, "inplace", False):
             return _EditableMode.INPLACE
         return _EditableMode.DISABLED
+
+    def _get_source_dir(self) -> str | None:
+        # dist.cmake_source_dir (setup.py kwarg) takes priority over the
+        # source-dir configured via pyproject.toml/self.source_dir.
+        dist_source_dir = getattr(self.distribution, "cmake_source_dir", None)
+        return self.source_dir if dist_source_dir is None else dist_source_dir
 
     def _get_install_subdir(self) -> Path:
         dist_cmake_install_dir = (
@@ -645,8 +656,7 @@ class BuildCMake(setuptools.Command):
         self._set_generated_data_files()
 
         dist = self.distribution
-        dist_source_dir = getattr(self.distribution, "cmake_source_dir", None)
-        source_dir = self.source_dir if dist_source_dir is None else dist_source_dir
+        source_dir = self._get_source_dir()
         assert source_dir is not None, "This should not be reachable"
 
         assert self.cmake_args is None or isinstance(self.cmake_args, list)
@@ -764,8 +774,15 @@ class BuildCMake(setuptools.Command):
             return sorted(self.get_output_mapping())
         return sorted(os.fspath(path) for path in self._installed_files)
 
-    # def "get_source_file"(self) -> list[str]:
-    #    return ["CMakeLists.txt"]
+    def get_source_files(self) -> list[str]:
+        # Conservative: just the CMake entry point, so sdist/egg_info know
+        # about it. The full CMake source tree can't be enumerated here (the
+        # file API reply isn't available before configuring).
+        source_dir = self._get_source_dir()
+        if source_dir is None:
+            return []
+        cmake_lists = Path(source_dir) / "CMakeLists.txt"
+        return [cmake_lists.as_posix()] if cmake_lists.is_file() else []
 
     def get_output_mapping(self) -> dict[str, str]:
         # Strict editable outputs are generated, not source files, so they have

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -6,6 +6,7 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat.setuptools.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.build._file_processor",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.builder.builder",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.builder.macos",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.cmake",
@@ -39,6 +40,7 @@ from .._check_extra import warn_missing_extra
 from .._compat import tomllib
 from .._compat.setuptools.errors import SetupError
 from .._logging import LEVEL_VALUE, raw_logger
+from ..build._file_processor import each_unignored_file
 from ..builder.builder import Builder, get_archs
 from ..builder.macos import normalize_macos_version
 from ..cmake import CMake, CMaker
@@ -775,14 +777,31 @@ class BuildCMake(setuptools.Command):
         return sorted(os.fspath(path) for path in self._installed_files)
 
     def get_source_files(self) -> list[str]:
-        # Conservative: just the CMake entry point, so sdist/egg_info know
-        # about it. The full CMake source tree can't be enumerated here (the
-        # file API reply isn't available before configuring).
+        # Contribute the CMake sources to egg_info/sdist: the entry-point
+        # CMakeLists.txt plus anything sdist.include opts in, trimmed by
+        # sdist.exclude. The full CMake source tree can't be enumerated here
+        # (the file API reply isn't available before configuring), and
+        # setuptools owns the rest of the sdist file list, so the
+        # gitignore-reading inclusion modes don't apply.
+        settings = _load_settings()
+        include = list(settings.sdist.include)
         source_dir = self._get_source_dir()
-        if source_dir is None:
+        if source_dir is not None:
+            cmake_lists = Path(source_dir) / "CMakeLists.txt"
+            if cmake_lists.is_file():
+                # Anchored: a bare "CMakeLists.txt" would match at any depth.
+                include.append(f"/{cmake_lists.as_posix()}")
+        if not include:
             return []
-        cmake_lists = Path(source_dir) / "CMakeLists.txt"
-        return [cmake_lists.as_posix()] if cmake_lists.is_file() else []
+        return sorted(
+            path.as_posix()
+            for path in each_unignored_file(
+                Path(),
+                include=include,
+                exclude=settings.sdist.exclude,
+                mode="explicit",
+            )
+        )
 
     def get_output_mapping(self) -> dict[str, str]:
         # Strict editable outputs are generated, not source files, so they have

--- a/src/scikit_build_core/setuptools/build_cmake.py
+++ b/src/scikit_build_core/setuptools/build_cmake.py
@@ -781,10 +781,17 @@ class BuildCMake(setuptools.Command):
         # CMakeLists.txt plus anything sdist.include opts in, trimmed by
         # sdist.exclude. The full CMake source tree can't be enumerated here
         # (the file API reply isn't available before configuring), and
-        # setuptools owns the rest of the sdist file list, so the
-        # gitignore-reading inclusion modes don't apply.
+        # setuptools owns the rest of the sdist file list, so only the
+        # explicit opt-in selection is supported.
         settings = _load_settings()
         include = list(settings.sdist.include)
+        if include and settings.sdist.inclusion_mode != "explicit":
+            msg = (
+                'sdist.include requires sdist.inclusion-mode = "explicit" in '
+                "setuptools mode; setuptools owns the default sdist file list, "
+                "so the gitignore-reading inclusion modes are not supported"
+            )
+            raise SetupError(msg)
         source_dir = self._get_source_dir()
         if source_dir is not None:
             cmake_lists = Path(source_dir) / "CMakeLists.txt"

--- a/tests/packages/simple_setuptools_ext/pyproject.toml
+++ b/tests/packages/simple_setuptools_ext/pyproject.toml
@@ -6,3 +6,4 @@ build-backend = "scikit_build_core.setuptools.build_meta"
 
 [tool.scikit-build]
 editable.mode = "inplace"
+sdist.include = ["src/main.c"]

--- a/tests/packages/simple_setuptools_ext/pyproject.toml
+++ b/tests/packages/simple_setuptools_ext/pyproject.toml
@@ -6,4 +6,5 @@ build-backend = "scikit_build_core.setuptools.build_meta"
 
 [tool.scikit-build]
 editable.mode = "inplace"
+sdist.inclusion-mode = "explicit"
 sdist.include = ["src/main.c"]

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -126,10 +126,11 @@ def test_pep517_sdist(tmp_path: Path):
         "setup.cfg",
         "setup.py",
         "LICENSE",
-        # TODO: "src/main.c",
     ]
     if SDIST_USES_SUBCOMMAND_SOURCES:
         expected.append("CMakeLists.txt")
+        # Opted in via sdist.include in the package's pyproject.toml.
+        expected.append("src/main.c")
 
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())
@@ -707,8 +708,10 @@ def test_finalize_options_honors_directly_set_editable_mode():
 
 def test_get_source_files_finds_configured_cmakelists(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "deps").mkdir(parents=True)
     (tmp_path / "sub" / "CMakeLists.txt").touch()
+    # The entry-point pattern is anchored, so nested ones don't match.
+    (tmp_path / "sub" / "deps" / "CMakeLists.txt").touch()
 
     dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
     cmd = build_cmake.BuildCMake(dist)
@@ -727,6 +730,32 @@ def test_get_source_files_empty_when_missing(tmp_path, monkeypatch):
     cmd.source_dir = "sub"  # never created
 
     assert cmd.get_source_files() == []
+
+
+def test_get_source_files_honors_sdist_include_exclude(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CMakeLists.txt").touch()
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.c").touch()
+    (src / "vendored.c").touch()
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            sdist.include = ["src/*.c"]
+            sdist.exclude = ["src/vendored.c"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.source_dir = "."
+
+    assert cmd.get_source_files() == ["CMakeLists.txt", "src/main.c"]
 
 
 def test_validate_settings_editable_mode_only_required_for_pep660():

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -110,7 +110,7 @@ def test_pep517_sdist(tmp_path: Path):
         assert file_names == {
             f"{cmake_example}-0.0.1/{x}"
             for x in (
-                # TODO: "CMakeLists.txt",
+                "CMakeLists.txt",
                 "PKG-INFO",
                 "src",
                 "src/cmake_example.egg-info",
@@ -326,7 +326,7 @@ def test_toml_sdist(tmp_path: Path):
         assert file_names == {
             f"{cmake_example}-0.0.1/{x}"
             for x in (
-                # TODO: "CMakeLists.txt",
+                "CMakeLists.txt",
                 "PKG-INFO",
                 "src",
                 "src/cmake_example.egg-info",
@@ -676,6 +676,46 @@ def test_editable_install_dir_honors_per_package_dir(tmp_path, monkeypatch):
     # aliasing (RUNNER~1 vs runneradmin) that resolve() misses on cygwin.
     assert install_dir.is_absolute()
     assert install_dir.samefile(tmp_path / "src" / "wrapper_example")
+
+
+def test_finalize_options_honors_directly_set_editable_mode():
+    # editable_wheel's SubCommand protocol sets cmd.editable_mode = True
+    # directly on build sub-commands before finalize_options runs; build_ext's
+    # own flags (editable_mode/inplace both False here) must not clobber it.
+    dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.editable_mode = True
+
+    cmd.finalize_options()
+
+    assert cmd.editable_mode is True
+    # No editable_wheel command object with mode="strict", so LENIENT.
+    assert cmd._editable_mode is build_cmake._EditableMode.LENIENT
+
+
+def test_get_source_files_finds_configured_cmakelists(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "CMakeLists.txt").touch()
+
+    dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.source_dir = "sub"
+
+    assert cmd.get_source_files() == ["sub/CMakeLists.txt"]
+
+
+def test_get_source_files_empty_when_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.source_dir = "sub"  # never created
+
+    assert cmd.get_source_files() == []
 
 
 def test_validate_settings_editable_mode_only_required_for_pep660():

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 import setuptools
+import setuptools.command.sdist
 from conftest import VEnv
 from packaging.version import Version
 
@@ -27,6 +28,12 @@ except ImportError:  # pragma: no cover - setuptools-scm < 10 or missing depende
 pytestmark = pytest.mark.setuptools
 setuptools_version = Version(importlib.metadata.version("setuptools"))
 build_editable = getattr(setuptools_build_meta, "build_editable", None)
+
+# sdist consults build sub-commands' get_source_files() only since
+# setuptools 62.4; older versions won't pick up CMakeLists.txt.
+SDIST_USES_SUBCOMMAND_SOURCES = hasattr(
+    setuptools.command.sdist.sdist, "_add_defaults_build_sub_commands"
+)
 
 
 @dataclass(frozen=True)
@@ -105,28 +112,30 @@ def test_pep517_sdist(tmp_path: Path):
     assert sdist == dist / out
     cmake_example = sdist.name[:13]
 
+    expected = [
+        "PKG-INFO",
+        "src",
+        "src/cmake_example.egg-info",
+        "src/cmake_example.egg-info/PKG-INFO",
+        "src/cmake_example.egg-info/SOURCES.txt",
+        "src/cmake_example.egg-info/dependency_links.txt",
+        "src/cmake_example.egg-info/not-zip-safe",
+        "src/cmake_example.egg-info/requires.txt",
+        "src/cmake_example.egg-info/top_level.txt",
+        "pyproject.toml",
+        "setup.cfg",
+        "setup.py",
+        "LICENSE",
+        # TODO: "src/main.c",
+    ]
+    if SDIST_USES_SUBCOMMAND_SOURCES:
+        expected.append("CMakeLists.txt")
+
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())
-        assert file_names == {
-            f"{cmake_example}-0.0.1/{x}"
-            for x in (
-                "CMakeLists.txt",
-                "PKG-INFO",
-                "src",
-                "src/cmake_example.egg-info",
-                "src/cmake_example.egg-info/PKG-INFO",
-                "src/cmake_example.egg-info/SOURCES.txt",
-                "src/cmake_example.egg-info/dependency_links.txt",
-                "src/cmake_example.egg-info/not-zip-safe",
-                "src/cmake_example.egg-info/requires.txt",
-                "src/cmake_example.egg-info/top_level.txt",
-                "pyproject.toml",
-                "setup.cfg",
-                "setup.py",
-                "LICENSE",
-                # TODO: "src/main.c",
-            )
-        } | {f"{cmake_example}-0.0.1"}
+        assert file_names == {f"{cmake_example}-0.0.1/{x}" for x in expected} | {
+            f"{cmake_example}-0.0.1"
+        }
         pkg_info = f.extractfile(f"{cmake_example}-0.0.1/PKG-INFO")
         assert pkg_info
         pkg_info_contents = set(pkg_info.read().decode().strip().splitlines())
@@ -321,25 +330,27 @@ def test_toml_sdist(tmp_path: Path):
     assert sdist == dist / out
     cmake_example = sdist.name[:13]
 
+    expected = [
+        "PKG-INFO",
+        "src",
+        "src/cmake_example.egg-info",
+        "src/cmake_example.egg-info/PKG-INFO",
+        "src/cmake_example.egg-info/SOURCES.txt",
+        "src/cmake_example.egg-info/dependency_links.txt",
+        "src/cmake_example.egg-info/top_level.txt",
+        "pyproject.toml",
+        "setup.cfg",
+        "LICENSE",
+        # TODO: "src/main.c",
+    ]
+    if SDIST_USES_SUBCOMMAND_SOURCES:
+        expected.append("CMakeLists.txt")
+
     with tarfile.open(sdist) as f:
         file_names = set(f.getnames())
-        assert file_names == {
-            f"{cmake_example}-0.0.1/{x}"
-            for x in (
-                "CMakeLists.txt",
-                "PKG-INFO",
-                "src",
-                "src/cmake_example.egg-info",
-                "src/cmake_example.egg-info/PKG-INFO",
-                "src/cmake_example.egg-info/SOURCES.txt",
-                "src/cmake_example.egg-info/dependency_links.txt",
-                "src/cmake_example.egg-info/top_level.txt",
-                "pyproject.toml",
-                "setup.cfg",
-                "LICENSE",
-                # TODO: "src/main.c",
-            )
-        } | {f"{cmake_example}-0.0.1"}
+        assert file_names == {f"{cmake_example}-0.0.1/{x}" for x in expected} | {
+            f"{cmake_example}-0.0.1"
+        }
         pkg_info = f.extractfile(f"{cmake_example}-0.0.1/PKG-INFO")
         assert pkg_info
         pkg_info_contents = set(pkg_info.read().decode().strip().splitlines())

--- a/tests/test_setuptools_pep517.py
+++ b/tests/test_setuptools_pep517.py
@@ -743,6 +743,7 @@ def test_get_source_files_honors_sdist_include_exclude(tmp_path, monkeypatch):
         textwrap.dedent(
             """\
             [tool.scikit-build]
+            sdist.inclusion-mode = "explicit"
             sdist.include = ["src/*.c"]
             sdist.exclude = ["src/vendored.c"]
             """
@@ -756,6 +757,28 @@ def test_get_source_files_honors_sdist_include_exclude(tmp_path, monkeypatch):
     cmd.source_dir = "."
 
     assert cmd.get_source_files() == ["CMakeLists.txt", "src/main.c"]
+
+
+def test_get_source_files_requires_explicit_inclusion_mode(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CMakeLists.txt").touch()
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [tool.scikit-build]
+            sdist.include = ["src/*.c"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    dist = setuptools.Distribution({"name": "cmake-example", "version": "0.0.1"})
+    cmd = build_cmake.BuildCMake(dist)
+    cmd.initialize_options()
+    cmd.source_dir = "."
+
+    with pytest.raises(SetupError, match=r"inclusion-mode = .explicit."):
+        cmd.get_source_files()
 
 
 def test_validate_settings_editable_mode_only_required_for_pep660():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `BuildCMake.finalize_options()`/`run()` unconditionally overwrote `editable_mode` with a value derived only from `build_ext`'s flags, discarding a directly-set `editable_mode = True` from `editable_wheel`'s SubCommand protocol. `editable_mode` is now a declared protocol attribute again, and `_get_editable_mode()` treats it (or `build_ext.editable_mode`) as the PEP 660 signal when resolving the internal `_EditableMode` enum, so `build_ext --inplace` still doesn't count as PEP 660.
- Implemented `get_source_files()` using the backend's file-selection walk in its explicit inclusion mode: the configured `CMakeLists.txt` (anchored) plus anything matching `sdist.include`, trimmed by `sdist.exclude`. setuptools/`MANIFEST.in` still own the default sdist file list, so using `sdist.include` requires `sdist.inclusion-mode = "explicit"` (the only supported mode), keeping the configuration portable to the main backend. Documented in the plugin docs, and `simple_setuptools_ext` now ships `src/main.c` in its sdist via `sdist.include` (resolving an old test TODO).

`get_source_files()` is only consulted by setuptools 62.4+ (`sdist._add_defaults_build_sub_commands`); the sdist tests feature-detect that.