### PR TITLE
docs: show the projects list as a card grid with language/binding badges

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -3,3 +3,81 @@
 .sidebar-tree {
   padding-bottom: 8rem;
 }
+
+/* Card grid for the projects list (docs/about/projects.md). Each list item is
+   a card: first link is the project name, second link the source repo. */
+.project-grid ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+  gap: 0.5rem;
+  list-style: none;
+  margin: 1rem 0;
+  padding: 0;
+}
+
+.project-grid li {
+  position: relative;
+  margin: 0;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.5rem;
+  background: var(--color-background-secondary);
+  transition: border-color 0.15s;
+}
+
+.project-grid li:hover {
+  border-color: var(--color-brand-content);
+}
+
+.project-grid li p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.project-grid li a:first-of-type {
+  display: block;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+/* Source link: GitHub mark in the top-right corner; the text (and the repo
+   slug in the title attribute) stays for screen readers and tooltips. */
+.project-grid a.sk-src {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  width: 1rem;
+  height: 1rem;
+  overflow: hidden;
+  color: transparent;
+  background-color: var(--color-foreground-muted);
+  -webkit-mask: var(--sk-github-icon) center / contain no-repeat;
+  mask: var(--sk-github-icon) center / contain no-repeat;
+}
+
+.project-grid a.sk-src:hover {
+  background-color: var(--color-brand-content);
+}
+
+.project-grid code.sk-lang,
+.project-grid code.sk-tool {
+  display: inline-block;
+  margin: 0.3rem 0.15rem 0 0;
+  padding: 0 0.5em;
+  border: 1px solid var(--color-background-border);
+  border-radius: 1em;
+  background: var(--color-background-primary);
+  color: var(--color-foreground-muted);
+  font-size: 0.7rem;
+  font-weight: 500;
+}
+
+.project-grid code.sk-tool {
+  border-color: color-mix(in srgb, var(--color-brand-content) 35%, transparent);
+  background: color-mix(in srgb, var(--color-brand-content) 8%, transparent);
+  color: var(--color-brand-content);
+}
+
+:root {
+  --sk-github-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'/%3E%3C/svg%3E");
+}

--- a/docs/about/projects.md
+++ b/docs/about/projects.md
@@ -9,6 +9,8 @@ scikit-build-core.
 
 <!-- prettier-ignore-start -->
 
+:::{container} project-grid
+
 <!--[[[cog
 import cog
 import collections
@@ -33,115 +35,220 @@ for project in projects["project"]:
     github = project["github"]
     path = project.get("path", "pyproject.toml")
 
-    cog.outl(f"* [{pypi}](https://pypi.org/project/{pypi}) ([source](https://github.com/{github}/blob/HEAD/{path}))")
+    entry = f'* [{pypi}](https://pypi.org/project/{pypi}) [GitHub](https://github.com/{github}/blob/HEAD/{path} "{github}"){{.sk-src}}'
+    badges = [f"`{lang.strip()}`{{.sk-lang}}" for lang in project.get("language", "").split(",") if lang.strip()]
+    badges += [f"`{tool.strip()}`{{.sk-tool}}" for tool in project.get("binding", "").split(",") if tool.strip()]
+    if badges:
+        entry += "\n  " + " ".join(badges)
+    cog.outl(entry)
 ]]]-->
-* [adios2](https://pypi.org/project/adios2) ([source](https://github.com/ornladios/ADIOS2/blob/HEAD/pyproject.toml))
-* [afdko](https://pypi.org/project/afdko) ([source](https://github.com/adobe-type-tools/afdko/blob/HEAD/pyproject.toml))
-* [ale-py](https://pypi.org/project/ale-py) ([source](https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/HEAD/pyproject.toml))
-* [antspyx](https://pypi.org/project/antspyx) ([source](https://github.com/ANTsX/ANTsPy/blob/HEAD/pyproject.toml))
-* [astyle](https://pypi.org/project/astyle) ([source](https://github.com/Freed-Wu/astyle-wheel/blob/HEAD/pyproject.toml))
-* [awkward-cpp](https://pypi.org/project/awkward-cpp) ([source](https://github.com/scikit-hep/awkward/blob/HEAD/awkward-cpp/pyproject.toml))
-* [bitsandbytes](https://pypi.org/project/bitsandbytes) ([source](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/HEAD/pyproject.toml))
-* [boost-histogram](https://pypi.org/project/boost-histogram) ([source](https://github.com/scikit-hep/boost-histogram/blob/HEAD/pyproject.toml))
-* [celerite2](https://pypi.org/project/celerite2) ([source](https://github.com/exoplanet-dev/celerite2/blob/HEAD/pyproject.toml))
-* [clang-format](https://pypi.org/project/clang-format) ([source](https://github.com/ssciwr/clang-format-wheel/blob/HEAD/pyproject.toml))
-* [cmake](https://pypi.org/project/cmake) ([source](https://github.com/scikit-build/cmake-python-distributions/blob/HEAD/pyproject.toml))
-* [CoolProp](https://pypi.org/project/CoolProp) ([source](https://github.com/CoolProp/CoolProp/blob/HEAD/pyproject.toml))
-* [coreforecast](https://pypi.org/project/coreforecast) ([source](https://github.com/Nixtla/coreforecast/blob/HEAD/pyproject.toml))
-* [deflate](https://pypi.org/project/deflate) ([source](https://github.com/dcwatson/deflate/blob/HEAD/pyproject.toml))
-* [ducc0](https://pypi.org/project/ducc0) ([source](https://github.com/mreineck/ducc/blob/HEAD/pyproject.toml))
-* [faiss-cpu](https://pypi.org/project/faiss-cpu) ([source](https://github.com/facebookresearch/faiss/blob/HEAD/pyproject.toml))
-* [fandango-fuzzer](https://pypi.org/project/fandango-fuzzer) ([source](https://github.com/fandango-fuzzer/fandango/blob/HEAD/pyproject.toml))
-* [freud-analysis](https://pypi.org/project/freud-analysis) ([source](https://github.com/glotzerlab/freud/blob/HEAD/pyproject.toml))
-* [gdstk](https://pypi.org/project/gdstk) ([source](https://github.com/heitzmann/gdstk/blob/HEAD/pyproject.toml))
-* [gemmi](https://pypi.org/project/gemmi) ([source](https://github.com/project-gemmi/gemmi/blob/HEAD/pyproject.toml))
-* [h3](https://pypi.org/project/h3) ([source](https://github.com/uber/h3-py/blob/HEAD/pyproject.toml))
-* [halide](https://pypi.org/project/halide) ([source](https://github.com/halide/Halide/blob/HEAD/pyproject.toml))
-* [highspy](https://pypi.org/project/highspy) ([source](https://github.com/ERGO-Code/HiGHS/blob/HEAD/pyproject.toml))
-* [imgui-bundle](https://pypi.org/project/imgui-bundle) ([source](https://github.com/pthom/imgui_bundle/blob/HEAD/pyproject.toml))
-* [iminuit](https://pypi.org/project/iminuit) ([source](https://github.com/scikit-hep/iminuit/blob/HEAD/pyproject.toml))
-* [implicit](https://pypi.org/project/implicit) ([source](https://github.com/benfred/implicit/blob/HEAD/pyproject.toml))
-* [islpy](https://pypi.org/project/islpy) ([source](https://github.com/inducer/islpy/blob/HEAD/pyproject.toml))
-* [JPype1](https://pypi.org/project/JPype1) ([source](https://github.com/jpype-project/jpype/blob/HEAD/pyproject.toml))
-* [kiss-icp](https://pypi.org/project/kiss-icp) ([source](https://github.com/PRBonn/kiss-icp/blob/HEAD/python/pyproject.toml))
-* [lammps](https://pypi.org/project/lammps) ([source](https://github.com/njzjz/lammps-wheel/blob/HEAD/pyproject.toml))
-* [laszip](https://pypi.org/project/laszip) ([source](https://github.com/tmontaigu/laszip-python/blob/HEAD/pyproject.toml))
-* [Levenshtein](https://pypi.org/project/Levenshtein) ([source](https://github.com/maxbachmann/Levenshtein/blob/HEAD/pyproject.toml))
-* [libigl](https://pypi.org/project/libigl) ([source](https://github.com/libigl/libigl-python-bindings/blob/HEAD/pyproject.toml))
-* [librapid](https://pypi.org/project/librapid) ([source](https://github.com/LibRapid/librapid/blob/HEAD/pyproject.toml))
-* [lightgbm](https://pypi.org/project/lightgbm) ([source](https://github.com/lightgbm-org/LightGBM/blob/HEAD/python-package/pyproject.toml))
-* [llama-cpp-python](https://pypi.org/project/llama-cpp-python) ([source](https://github.com/abetlen/llama-cpp-python/blob/HEAD/pyproject.toml))
-* [llamacpp](https://pypi.org/project/llamacpp) ([source](https://github.com/thomasantony/llamacpp-python/blob/HEAD/pyproject.toml))
-* [manifold3d](https://pypi.org/project/manifold3d) ([source](https://github.com/elalish/manifold/blob/HEAD/pyproject.toml))
-* [MaterialX](https://pypi.org/project/MaterialX) ([source](https://github.com/AcademySoftwareFoundation/MaterialX/blob/HEAD/pyproject.toml))
-* [mitsuba](https://pypi.org/project/mitsuba) ([source](https://github.com/mitsuba-renderer/mitsuba3/blob/HEAD/pyproject.toml))
-* [mqt-core](https://pypi.org/project/mqt-core) ([source](https://github.com/munich-quantum-toolkit/core/blob/HEAD/pyproject.toml))
-* [nanobind](https://pypi.org/project/nanobind) ([source](https://github.com/wjakob/nanobind/blob/HEAD/pyproject.toml))
-* [ncrystal](https://pypi.org/project/ncrystal) ([source](https://github.com/mctools/ncrystal/blob/HEAD/pyproject.toml))
-* [ninja](https://pypi.org/project/ninja) ([source](https://github.com/scikit-build/ninja-python-distributions/blob/HEAD/pyproject.toml))
-* [nodejs-wheel](https://pypi.org/project/nodejs-wheel) ([source](https://github.com/njzjz/nodejs-wheel/blob/HEAD/pyproject.toml))
-* [ompl](https://pypi.org/project/ompl) ([source](https://github.com/ompl/ompl/blob/HEAD/py-bindings/pyproject.toml))
-* [onnx](https://pypi.org/project/onnx) ([source](https://github.com/onnx/onnx/blob/HEAD/pyproject.toml))
-* [OpenEXR](https://pypi.org/project/OpenEXR) ([source](https://github.com/AcademySoftwareFoundation/OpenEXR/blob/HEAD/pyproject.toml))
-* [OpenImageIO](https://pypi.org/project/OpenImageIO) ([source](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/HEAD/pyproject.toml))
-* [osmium](https://pypi.org/project/osmium) ([source](https://github.com/osmcode/pyosmium/blob/HEAD/pyproject.toml))
-* [osqp](https://pypi.org/project/osqp) ([source](https://github.com/osqp/osqp-python/blob/HEAD/pyproject.toml))
-* [pedalboard](https://pypi.org/project/pedalboard) ([source](https://github.com/spotify/pedalboard/blob/HEAD/pyproject.toml))
-* [phik](https://pypi.org/project/phik) ([source](https://github.com/kaveio/phik/blob/HEAD/pyproject.toml))
-* [phono3py](https://pypi.org/project/phono3py) ([source](https://github.com/phonopy/phono3py/blob/HEAD/pyproject.toml))
-* [phonopy](https://pypi.org/project/phonopy) ([source](https://github.com/phonopy/phonopy/blob/HEAD/pyproject.toml))
-* [pikepdf](https://pypi.org/project/pikepdf) ([source](https://github.com/pikepdf/pikepdf/blob/HEAD/pyproject.toml))
-* [polyscope](https://pypi.org/project/polyscope) ([source](https://github.com/nmwsharp/polyscope-py/blob/HEAD/pyproject.toml))
-* [pyarrow](https://pypi.org/project/pyarrow) ([source](https://github.com/apache/arrow/blob/HEAD/python/pyproject.toml))
-* [pybind11](https://pypi.org/project/pybind11) ([source](https://github.com/pybind/pybind11/blob/HEAD/pyproject.toml))
-* [pycolmap](https://pypi.org/project/pycolmap) ([source](https://github.com/colmap/colmap/blob/HEAD/pyproject.toml))
-* [pygram11](https://pypi.org/project/pygram11) ([source](https://github.com/douglasdavis/pygram11/blob/HEAD/pyproject.toml))
-* [pyhmmer](https://pypi.org/project/pyhmmer) ([source](https://github.com/althonos/pyhmmer/blob/HEAD/pyproject.toml))
-* [pylibmagic](https://pypi.org/project/pylibmagic) ([source](https://github.com/kratsg/pylibmagic/blob/HEAD/pyproject.toml))
-* [pyopencl](https://pypi.org/project/pyopencl) ([source](https://github.com/inducer/pyopencl/blob/HEAD/pyproject.toml))
-* [pyradiomics](https://pypi.org/project/pyradiomics) ([source](https://github.com/AIM-Harvard/pyradiomics/blob/HEAD/pyproject.toml))
-* [pyresidfp](https://pypi.org/project/pyresidfp) ([source](https://github.com/pyresidfp/pyresidfp/blob/HEAD/pyproject.toml))
-* [pyslang](https://pypi.org/project/pyslang) ([source](https://github.com/MikePopoloski/slang/blob/HEAD/pyproject.toml))
-* [pyzmq](https://pypi.org/project/pyzmq) ([source](https://github.com/zeromq/pyzmq/blob/HEAD/pyproject.toml))
-* [rapidfuzz](https://pypi.org/project/rapidfuzz) ([source](https://github.com/rapidfuzz/RapidFuzz/blob/HEAD/pyproject.toml))
-* [roboticstoolbox-python](https://pypi.org/project/roboticstoolbox-python) ([source](https://github.com/petercorke/robotics-toolbox-python/blob/HEAD/pyproject.toml))
-* [root](https://pypi.org/project/root) ([source](https://github.com/root-project/root/blob/HEAD/pyproject.toml))
-* [s5cmd](https://pypi.org/project/s5cmd) ([source](https://github.com/ImagingDataCommons/s5cmd-python-distributions/blob/HEAD/pyproject.toml))
-* [shap](https://pypi.org/project/shap) ([source](https://github.com/shap/shap/blob/HEAD/pyproject.toml))
-* [SimpleITK](https://pypi.org/project/SimpleITK) ([source](https://github.com/SimpleITK/SimpleITK/blob/HEAD/pyproject.toml))
-* [simsopt](https://pypi.org/project/simsopt) ([source](https://github.com/hiddenSymmetries/simsopt/blob/HEAD/pyproject.toml))
-* [sparse-dot-topn](https://pypi.org/project/sparse-dot-topn) ([source](https://github.com/ing-bank/sparse_dot_topn/blob/HEAD/pyproject.toml))
-* [spglib](https://pypi.org/project/spglib) ([source](https://github.com/spglib/spglib/blob/HEAD/pyproject.toml))
-* [spherely](https://pypi.org/project/spherely) ([source](https://github.com/benbovy/spherely/blob/HEAD/pyproject.toml))
-* [stormpy](https://pypi.org/project/stormpy) ([source](https://github.com/stormchecker/stormpy/blob/HEAD/pyproject.toml))
-* [symusic](https://pypi.org/project/symusic) ([source](https://github.com/Yikai-Liao/symusic/blob/HEAD/pyproject.toml))
-* [tetgen](https://pypi.org/project/tetgen) ([source](https://github.com/pyvista/tetgen/blob/HEAD/pyproject.toml))
-* [tiledb](https://pypi.org/project/tiledb) ([source](https://github.com/TileDB-Inc/TileDB-Py/blob/HEAD/pyproject.toml))
-* [tomotopy](https://pypi.org/project/tomotopy) ([source](https://github.com/bab2min/tomotopy/blob/HEAD/pyproject.toml))
-* [viennals](https://pypi.org/project/viennals) ([source](https://github.com/ViennaTools/ViennaLS/blob/HEAD/pyproject.toml))
-* [viennaps](https://pypi.org/project/viennaps) ([source](https://github.com/ViennaTools/ViennaPS/blob/HEAD/pyproject.toml))
-* [voyager](https://pypi.org/project/voyager) ([source](https://github.com/spotify/voyager/blob/HEAD/python/pyproject.toml))
-* [xgrammar](https://pypi.org/project/xgrammar) ([source](https://github.com/mlc-ai/xgrammar/blob/HEAD/pyproject.toml))
-* [xtgeo](https://pypi.org/project/xtgeo) ([source](https://github.com/equinor/xtgeo/blob/HEAD/pyproject.toml))
-<!--[[[end]]] (sum: aPoX60a7Kd)-->
+* [adios2](https://pypi.org/project/adios2) [GitHub](https://github.com/ornladios/ADIOS2/blob/HEAD/pyproject.toml "ornladios/ADIOS2"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [afdko](https://pypi.org/project/afdko) [GitHub](https://github.com/adobe-type-tools/afdko/blob/HEAD/pyproject.toml "adobe-type-tools/afdko"){.sk-src}
+  `C`{.sk-lang} `C++`{.sk-lang} `Cython`{.sk-tool}
+* [ale-py](https://pypi.org/project/ale-py) [GitHub](https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/HEAD/pyproject.toml "Farama-Foundation/Arcade-Learning-Environment"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [antspyx](https://pypi.org/project/antspyx) [GitHub](https://github.com/ANTsX/ANTsPy/blob/HEAD/pyproject.toml "ANTsX/ANTsPy"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [astyle](https://pypi.org/project/astyle) [GitHub](https://github.com/Freed-Wu/astyle-wheel/blob/HEAD/pyproject.toml "Freed-Wu/astyle-wheel"){.sk-src}
+  `C++`{.sk-lang}
+* [awkward-cpp](https://pypi.org/project/awkward-cpp) [GitHub](https://github.com/scikit-hep/awkward/blob/HEAD/awkward-cpp/pyproject.toml "scikit-hep/awkward"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [bitsandbytes](https://pypi.org/project/bitsandbytes) [GitHub](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/HEAD/pyproject.toml "bitsandbytes-foundation/bitsandbytes"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `ctypes`{.sk-tool}
+* [boost-histogram](https://pypi.org/project/boost-histogram) [GitHub](https://github.com/scikit-hep/boost-histogram/blob/HEAD/pyproject.toml "scikit-hep/boost-histogram"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [celerite2](https://pypi.org/project/celerite2) [GitHub](https://github.com/exoplanet-dev/celerite2/blob/HEAD/pyproject.toml "exoplanet-dev/celerite2"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [clang-format](https://pypi.org/project/clang-format) [GitHub](https://github.com/ssciwr/clang-format-wheel/blob/HEAD/pyproject.toml "ssciwr/clang-format-wheel"){.sk-src}
+  `C++`{.sk-lang}
+* [cmake](https://pypi.org/project/cmake) [GitHub](https://github.com/scikit-build/cmake-python-distributions/blob/HEAD/pyproject.toml "scikit-build/cmake-python-distributions"){.sk-src}
+  `C++`{.sk-lang}
+* [CoolProp](https://pypi.org/project/CoolProp) [GitHub](https://github.com/CoolProp/CoolProp/blob/HEAD/pyproject.toml "CoolProp/CoolProp"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [coreforecast](https://pypi.org/project/coreforecast) [GitHub](https://github.com/Nixtla/coreforecast/blob/HEAD/pyproject.toml "Nixtla/coreforecast"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [deflate](https://pypi.org/project/deflate) [GitHub](https://github.com/dcwatson/deflate/blob/HEAD/pyproject.toml "dcwatson/deflate"){.sk-src}
+  `C`{.sk-lang} `C API`{.sk-tool}
+* [ducc0](https://pypi.org/project/ducc0) [GitHub](https://github.com/mreineck/ducc/blob/HEAD/pyproject.toml "mreineck/ducc"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [faiss-cpu](https://pypi.org/project/faiss-cpu) [GitHub](https://github.com/facebookresearch/faiss/blob/HEAD/pyproject.toml "facebookresearch/faiss"){.sk-src}
+  `C++`{.sk-lang} `SWIG`{.sk-tool}
+* [fandango-fuzzer](https://pypi.org/project/fandango-fuzzer) [GitHub](https://github.com/fandango-fuzzer/fandango/blob/HEAD/pyproject.toml "fandango-fuzzer/fandango"){.sk-src}
+  `C++`{.sk-lang} `C API`{.sk-tool}
+* [freud-analysis](https://pypi.org/project/freud-analysis) [GitHub](https://github.com/glotzerlab/freud/blob/HEAD/pyproject.toml "glotzerlab/freud"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [gdstk](https://pypi.org/project/gdstk) [GitHub](https://github.com/heitzmann/gdstk/blob/HEAD/pyproject.toml "heitzmann/gdstk"){.sk-src}
+  `C++`{.sk-lang} `C API`{.sk-tool}
+* [gemmi](https://pypi.org/project/gemmi) [GitHub](https://github.com/project-gemmi/gemmi/blob/HEAD/pyproject.toml "project-gemmi/gemmi"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [h3](https://pypi.org/project/h3) [GitHub](https://github.com/uber/h3-py/blob/HEAD/pyproject.toml "uber/h3-py"){.sk-src}
+  `C`{.sk-lang} `Cython`{.sk-tool}
+* [halide](https://pypi.org/project/halide) [GitHub](https://github.com/halide/Halide/blob/HEAD/pyproject.toml "halide/Halide"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [highspy](https://pypi.org/project/highspy) [GitHub](https://github.com/ERGO-Code/HiGHS/blob/HEAD/pyproject.toml "ERGO-Code/HiGHS"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [imgui-bundle](https://pypi.org/project/imgui-bundle) [GitHub](https://github.com/pthom/imgui_bundle/blob/HEAD/pyproject.toml "pthom/imgui_bundle"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [iminuit](https://pypi.org/project/iminuit) [GitHub](https://github.com/scikit-hep/iminuit/blob/HEAD/pyproject.toml "scikit-hep/iminuit"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [implicit](https://pypi.org/project/implicit) [GitHub](https://github.com/benfred/implicit/blob/HEAD/pyproject.toml "benfred/implicit"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+* [islpy](https://pypi.org/project/islpy) [GitHub](https://github.com/inducer/islpy/blob/HEAD/pyproject.toml "inducer/islpy"){.sk-src}
+  `C`{.sk-lang} `nanobind`{.sk-tool}
+* [JPype1](https://pypi.org/project/JPype1) [GitHub](https://github.com/jpype-project/jpype/blob/HEAD/pyproject.toml "jpype-project/jpype"){.sk-src}
+  `C++`{.sk-lang} `C API`{.sk-tool}
+* [kiss-icp](https://pypi.org/project/kiss-icp) [GitHub](https://github.com/PRBonn/kiss-icp/blob/HEAD/python/pyproject.toml "PRBonn/kiss-icp"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [lammps](https://pypi.org/project/lammps) [GitHub](https://github.com/njzjz/lammps-wheel/blob/HEAD/pyproject.toml "njzjz/lammps-wheel"){.sk-src}
+  `C++`{.sk-lang} `ctypes`{.sk-tool}
+* [laszip](https://pypi.org/project/laszip) [GitHub](https://github.com/tmontaigu/laszip-python/blob/HEAD/pyproject.toml "tmontaigu/laszip-python"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [Levenshtein](https://pypi.org/project/Levenshtein) [GitHub](https://github.com/maxbachmann/Levenshtein/blob/HEAD/pyproject.toml "maxbachmann/Levenshtein"){.sk-src}
+  `C++`{.sk-lang} `Cython`{.sk-tool}
+* [libigl](https://pypi.org/project/libigl) [GitHub](https://github.com/libigl/libigl-python-bindings/blob/HEAD/pyproject.toml "libigl/libigl-python-bindings"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [librapid](https://pypi.org/project/librapid) [GitHub](https://github.com/LibRapid/librapid/blob/HEAD/pyproject.toml "LibRapid/librapid"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [lightgbm](https://pypi.org/project/lightgbm) [GitHub](https://github.com/lightgbm-org/LightGBM/blob/HEAD/python-package/pyproject.toml "lightgbm-org/LightGBM"){.sk-src}
+  `C++`{.sk-lang} `ctypes`{.sk-tool}
+* [llama-cpp-python](https://pypi.org/project/llama-cpp-python) [GitHub](https://github.com/abetlen/llama-cpp-python/blob/HEAD/pyproject.toml "abetlen/llama-cpp-python"){.sk-src}
+  `C++`{.sk-lang} `ctypes`{.sk-tool}
+* [llamacpp](https://pypi.org/project/llamacpp) [GitHub](https://github.com/thomasantony/llamacpp-python/blob/HEAD/pyproject.toml "thomasantony/llamacpp-python"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [manifold3d](https://pypi.org/project/manifold3d) [GitHub](https://github.com/elalish/manifold/blob/HEAD/pyproject.toml "elalish/manifold"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [MaterialX](https://pypi.org/project/MaterialX) [GitHub](https://github.com/AcademySoftwareFoundation/MaterialX/blob/HEAD/pyproject.toml "AcademySoftwareFoundation/MaterialX"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [mitsuba](https://pypi.org/project/mitsuba) [GitHub](https://github.com/mitsuba-renderer/mitsuba3/blob/HEAD/pyproject.toml "mitsuba-renderer/mitsuba3"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [mqt-core](https://pypi.org/project/mqt-core) [GitHub](https://github.com/munich-quantum-toolkit/core/blob/HEAD/pyproject.toml "munich-quantum-toolkit/core"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [nanobind](https://pypi.org/project/nanobind) [GitHub](https://github.com/wjakob/nanobind/blob/HEAD/pyproject.toml "wjakob/nanobind"){.sk-src}
+  `C++`{.sk-lang}
+* [ncrystal](https://pypi.org/project/ncrystal) [GitHub](https://github.com/mctools/ncrystal/blob/HEAD/pyproject.toml "mctools/ncrystal"){.sk-src}
+  `C++`{.sk-lang} `C`{.sk-lang} `ctypes`{.sk-tool}
+* [ninja](https://pypi.org/project/ninja) [GitHub](https://github.com/scikit-build/ninja-python-distributions/blob/HEAD/pyproject.toml "scikit-build/ninja-python-distributions"){.sk-src}
+  `C++`{.sk-lang}
+* [nodejs-wheel](https://pypi.org/project/nodejs-wheel) [GitHub](https://github.com/njzjz/nodejs-wheel/blob/HEAD/pyproject.toml "njzjz/nodejs-wheel"){.sk-src}
+  `C++`{.sk-lang}
+* [ompl](https://pypi.org/project/ompl) [GitHub](https://github.com/ompl/ompl/blob/HEAD/py-bindings/pyproject.toml "ompl/ompl"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [onnx](https://pypi.org/project/onnx) [GitHub](https://github.com/onnx/onnx/blob/HEAD/pyproject.toml "onnx/onnx"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [OpenEXR](https://pypi.org/project/OpenEXR) [GitHub](https://github.com/AcademySoftwareFoundation/OpenEXR/blob/HEAD/pyproject.toml "AcademySoftwareFoundation/OpenEXR"){.sk-src}
+  `C++`{.sk-lang} `C`{.sk-lang} `pybind11`{.sk-tool}
+* [OpenImageIO](https://pypi.org/project/OpenImageIO) [GitHub](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/HEAD/pyproject.toml "AcademySoftwareFoundation/OpenImageIO"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [osmium](https://pypi.org/project/osmium) [GitHub](https://github.com/osmcode/pyosmium/blob/HEAD/pyproject.toml "osmcode/pyosmium"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [osqp](https://pypi.org/project/osqp) [GitHub](https://github.com/osqp/osqp-python/blob/HEAD/pyproject.toml "osqp/osqp-python"){.sk-src}
+  `C`{.sk-lang} `pybind11`{.sk-tool}
+* [pedalboard](https://pypi.org/project/pedalboard) [GitHub](https://github.com/spotify/pedalboard/blob/HEAD/pyproject.toml "spotify/pedalboard"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [phik](https://pypi.org/project/phik) [GitHub](https://github.com/kaveio/phik/blob/HEAD/pyproject.toml "kaveio/phik"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [phono3py](https://pypi.org/project/phono3py) [GitHub](https://github.com/phonopy/phono3py/blob/HEAD/pyproject.toml "phonopy/phono3py"){.sk-src}
+  `C`{.sk-lang} `nanobind`{.sk-tool}
+* [phonopy](https://pypi.org/project/phonopy) [GitHub](https://github.com/phonopy/phonopy/blob/HEAD/pyproject.toml "phonopy/phonopy"){.sk-src}
+  `C`{.sk-lang} `nanobind`{.sk-tool}
+* [pikepdf](https://pypi.org/project/pikepdf) [GitHub](https://github.com/pikepdf/pikepdf/blob/HEAD/pyproject.toml "pikepdf/pikepdf"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [polyscope](https://pypi.org/project/polyscope) [GitHub](https://github.com/nmwsharp/polyscope-py/blob/HEAD/pyproject.toml "nmwsharp/polyscope-py"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [pyarrow](https://pypi.org/project/pyarrow) [GitHub](https://github.com/apache/arrow/blob/HEAD/python/pyproject.toml "apache/arrow"){.sk-src}
+  `C++`{.sk-lang} `Cython`{.sk-tool}
+* [pybind11](https://pypi.org/project/pybind11) [GitHub](https://github.com/pybind/pybind11/blob/HEAD/pyproject.toml "pybind/pybind11"){.sk-src}
+  `C++`{.sk-lang}
+* [pycolmap](https://pypi.org/project/pycolmap) [GitHub](https://github.com/colmap/colmap/blob/HEAD/pyproject.toml "colmap/colmap"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [pygram11](https://pypi.org/project/pygram11) [GitHub](https://github.com/douglasdavis/pygram11/blob/HEAD/pyproject.toml "douglasdavis/pygram11"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [pyhmmer](https://pypi.org/project/pyhmmer) [GitHub](https://github.com/althonos/pyhmmer/blob/HEAD/pyproject.toml "althonos/pyhmmer"){.sk-src}
+  `C`{.sk-lang} `Cython`{.sk-tool}
+* [pylibmagic](https://pypi.org/project/pylibmagic) [GitHub](https://github.com/kratsg/pylibmagic/blob/HEAD/pyproject.toml "kratsg/pylibmagic"){.sk-src}
+  `C`{.sk-lang}
+* [pyopencl](https://pypi.org/project/pyopencl) [GitHub](https://github.com/inducer/pyopencl/blob/HEAD/pyproject.toml "inducer/pyopencl"){.sk-src}
+  `C++`{.sk-lang} `C`{.sk-lang} `nanobind`{.sk-tool}
+* [pyradiomics](https://pypi.org/project/pyradiomics) [GitHub](https://github.com/AIM-Harvard/pyradiomics/blob/HEAD/pyproject.toml "AIM-Harvard/pyradiomics"){.sk-src}
+  `C`{.sk-lang} `C API`{.sk-tool}
+* [pyresidfp](https://pypi.org/project/pyresidfp) [GitHub](https://github.com/pyresidfp/pyresidfp/blob/HEAD/pyproject.toml "pyresidfp/pyresidfp"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [pyslang](https://pypi.org/project/pyslang) [GitHub](https://github.com/MikePopoloski/slang/blob/HEAD/pyproject.toml "MikePopoloski/slang"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [pyzmq](https://pypi.org/project/pyzmq) [GitHub](https://github.com/zeromq/pyzmq/blob/HEAD/pyproject.toml "zeromq/pyzmq"){.sk-src}
+  `C`{.sk-lang} `Cython`{.sk-tool}
+* [rapidfuzz](https://pypi.org/project/rapidfuzz) [GitHub](https://github.com/rapidfuzz/RapidFuzz/blob/HEAD/pyproject.toml "rapidfuzz/RapidFuzz"){.sk-src}
+  `C++`{.sk-lang} `Cython`{.sk-tool}
+* [roboticstoolbox-python](https://pypi.org/project/roboticstoolbox-python) [GitHub](https://github.com/petercorke/robotics-toolbox-python/blob/HEAD/pyproject.toml "petercorke/robotics-toolbox-python"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [root](https://pypi.org/project/root) [GitHub](https://github.com/root-project/root/blob/HEAD/pyproject.toml "root-project/root"){.sk-src}
+  `C++`{.sk-lang} `cppyy`{.sk-tool}
+* [s5cmd](https://pypi.org/project/s5cmd) [GitHub](https://github.com/ImagingDataCommons/s5cmd-python-distributions/blob/HEAD/pyproject.toml "ImagingDataCommons/s5cmd-python-distributions"){.sk-src}
+  `Go`{.sk-lang}
+* [shap](https://pypi.org/project/shap) [GitHub](https://github.com/shap/shap/blob/HEAD/pyproject.toml "shap/shap"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [SimpleITK](https://pypi.org/project/SimpleITK) [GitHub](https://github.com/SimpleITK/SimpleITK/blob/HEAD/pyproject.toml "SimpleITK/SimpleITK"){.sk-src}
+  `C++`{.sk-lang} `SWIG`{.sk-tool}
+* [simsopt](https://pypi.org/project/simsopt) [GitHub](https://github.com/hiddenSymmetries/simsopt/blob/HEAD/pyproject.toml "hiddenSymmetries/simsopt"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [sparse-dot-topn](https://pypi.org/project/sparse-dot-topn) [GitHub](https://github.com/ing-bank/sparse_dot_topn/blob/HEAD/pyproject.toml "ing-bank/sparse_dot_topn"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [spglib](https://pypi.org/project/spglib) [GitHub](https://github.com/spglib/spglib/blob/HEAD/pyproject.toml "spglib/spglib"){.sk-src}
+  `C`{.sk-lang} `pybind11`{.sk-tool}
+* [spherely](https://pypi.org/project/spherely) [GitHub](https://github.com/benbovy/spherely/blob/HEAD/pyproject.toml "benbovy/spherely"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [stormpy](https://pypi.org/project/stormpy) [GitHub](https://github.com/stormchecker/stormpy/blob/HEAD/pyproject.toml "stormchecker/stormpy"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [symusic](https://pypi.org/project/symusic) [GitHub](https://github.com/Yikai-Liao/symusic/blob/HEAD/pyproject.toml "Yikai-Liao/symusic"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [tetgen](https://pypi.org/project/tetgen) [GitHub](https://github.com/pyvista/tetgen/blob/HEAD/pyproject.toml "pyvista/tetgen"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [tiledb](https://pypi.org/project/tiledb) [GitHub](https://github.com/TileDB-Inc/TileDB-Py/blob/HEAD/pyproject.toml "TileDB-Inc/TileDB-Py"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [tomotopy](https://pypi.org/project/tomotopy) [GitHub](https://github.com/bab2min/tomotopy/blob/HEAD/pyproject.toml "bab2min/tomotopy"){.sk-src}
+  `C++`{.sk-lang} `C API`{.sk-tool}
+* [viennals](https://pypi.org/project/viennals) [GitHub](https://github.com/ViennaTools/ViennaLS/blob/HEAD/pyproject.toml "ViennaTools/ViennaLS"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [viennaps](https://pypi.org/project/viennaps) [GitHub](https://github.com/ViennaTools/ViennaPS/blob/HEAD/pyproject.toml "ViennaTools/ViennaPS"){.sk-src}
+  `C++`{.sk-lang} `pybind11`{.sk-tool}
+* [voyager](https://pypi.org/project/voyager) [GitHub](https://github.com/spotify/voyager/blob/HEAD/python/pyproject.toml "spotify/voyager"){.sk-src}
+  `C++`{.sk-lang} `nanobind`{.sk-tool}
+* [xgrammar](https://pypi.org/project/xgrammar) [GitHub](https://github.com/mlc-ai/xgrammar/blob/HEAD/pyproject.toml "mlc-ai/xgrammar"){.sk-src}
+  `C++`{.sk-lang} `C API`{.sk-tool}
+* [xtgeo](https://pypi.org/project/xtgeo) [GitHub](https://github.com/equinor/xtgeo/blob/HEAD/pyproject.toml "equinor/xtgeo"){.sk-src}
+  `C`{.sk-lang} `C++`{.sk-lang} `pybind11`{.sk-tool} `SWIG`{.sk-tool}
+<!--[[[end]]] (sum: fdPMxXZJHs)-->
+
+:::
 
 <!-- prettier-ignore-end -->
 
 In addition, most of the [RAPIDSAI](https://github.com/rapidsai) projects use
 scikit-build-core, but they are not published on PyPI. A few of them are:
 
-- CuDF
-  ([source](https://github.com/rapidsai/cudf/blob/HEAD/python/cudf/pyproject.toml))
-- CuGraph
-  ([source](https://github.com/rapidsai/cugraph/blob/HEAD/python/cugraph/pyproject.toml))
-- CuML
-  ([source](https://github.com/rapidsai/cuml/blob/HEAD/python/cuml/pyproject.toml))
-- CuSpatial
-  ([source](https://github.com/rapidsai/cuspatial/blob/HEAD/python/cuspatial/pyproject.toml))
-- RMM
-  ([source](https://github.com/rapidsai/rmm/blob/HEAD/python/rmm/pyproject.toml))
-- Raft
-  ([source](https://github.com/rapidsai/raft/blob/HEAD/python/pylibraft/pyproject.toml))
+:::{container} project-grid
+
+- [CuDF](https://docs.rapids.ai/api/cudf/stable/)
+  [GitHub](https://github.com/rapidsai/cudf/blob/HEAD/python/cudf/pyproject.toml "rapidsai/cudf"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+- [CuGraph](https://docs.rapids.ai/api/cugraph/stable/)
+  [GitHub](https://github.com/rapidsai/cugraph/blob/HEAD/python/cugraph/pyproject.toml "rapidsai/cugraph"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+- [CuML](https://docs.rapids.ai/api/cuml/stable/)
+  [GitHub](https://github.com/rapidsai/cuml/blob/HEAD/python/cuml/pyproject.toml "rapidsai/cuml"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+- [CuSpatial](https://docs.rapids.ai/api/cuspatial/stable/)
+  [GitHub](https://github.com/rapidsai/cuspatial/blob/HEAD/python/cuspatial/pyproject.toml "rapidsai/cuspatial"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+- [RMM](https://docs.rapids.ai/api/rmm/stable/)
+  [GitHub](https://github.com/rapidsai/rmm/blob/HEAD/python/rmm/pyproject.toml "rapidsai/rmm"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+- [Raft](https://docs.rapids.ai/api/raft/stable/)
+  [GitHub](https://github.com/rapidsai/raft/blob/HEAD/python/pylibraft/pyproject.toml "rapidsai/raft"){.sk-src}
+  `C++`{.sk-lang} `CUDA`{.sk-lang} `Cython`{.sk-tool}
+
+:::
 
 The [Insight Toolkit (ITK)](https://docs.itk.org), the initial target project
 for scikit-build classic, has

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,7 @@ html_css_files = [
 # -- Extension configuration -------------------------------------------------
 myst_enable_extensions = [
     "alert",  # GitHub-style > [!NOTE] blockquote admonitions
+    "attrs_inline",  # {.class} on links/code, used by the projects grid
     "colon_fence",
     "substitution",
     "deflist",

--- a/docs/data/projects.toml
+++ b/docs/data/projects.toml
@@ -1,177 +1,259 @@
 [[project]]
 pypi = "adios2"
 github = "ornladios/ADIOS2"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "afdko"
 github = "adobe-type-tools/afdko"
+language = "C, C++"
+binding = "Cython"
 
 [[project]]
 pypi = "ale-py"
 github = "Farama-Foundation/Arcade-Learning-Environment"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "antspyx"
 github = "ANTsX/ANTsPy"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "astyle"
 github = "Freed-Wu/astyle-wheel"
+language = "C++"
 
 [[project]]
 pypi = "awkward-cpp"
 github = "scikit-hep/awkward"
 path = "awkward-cpp/pyproject.toml"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "bitsandbytes"
 github = "bitsandbytes-foundation/bitsandbytes"
+language = "C++, CUDA"
+binding = "ctypes"
 
 [[project]]
 pypi = "boost-histogram"
 github = "scikit-hep/boost-histogram"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "celerite2"
 github = "exoplanet-dev/celerite2"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "clang-format"
 github = "ssciwr/clang-format-wheel"
+language = "C++"
 
 [[project]]
 pypi = "cmake"
 github = "scikit-build/cmake-python-distributions"
+language = "C++"
 
 [[project]]
 pypi = "CoolProp"
 github = "CoolProp/CoolProp"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "coreforecast"
 github = "Nixtla/coreforecast"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "deflate"
 github = "dcwatson/deflate"
+language = "C"
+binding = "C API"
 
 [[project]]
 pypi = "ducc0"
 github = "mreineck/ducc"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "faiss-cpu"
 github = "facebookresearch/faiss"
+language = "C++"
+binding = "SWIG"
 
 [[project]]
 pypi = "fandango-fuzzer"
 github = "fandango-fuzzer/fandango"
+language = "C++"
+binding = "C API"
 
 [[project]]
 pypi = "freud-analysis"
 github = "glotzerlab/freud"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "gdstk"
 github = "heitzmann/gdstk"
+language = "C++"
+binding = "C API"
 
 [[project]]
 pypi = "gemmi"
 github = "project-gemmi/gemmi"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "h3"
 github = "uber/h3-py"
+language = "C"
+binding = "Cython"
 
 [[project]]
 pypi = "halide"
 github = "halide/Halide"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "highspy"
 github = "ERGO-Code/HiGHS"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "imgui-bundle"
 github = "pthom/imgui_bundle"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "iminuit"
 github = "scikit-hep/iminuit"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "implicit"
 github = "benfred/implicit"
+language = "C++, CUDA"
+binding = "Cython"
 
 [[project]]
 pypi = "islpy"
 github = "inducer/islpy"
+language = "C"
+binding = "nanobind"
 
 [[project]]
 pypi = "JPype1"
 github = "jpype-project/jpype"
+language = "C++"
+binding = "C API"
 
 [[project]]
 pypi = "kiss-icp"
 github = "PRBonn/kiss-icp"
 path = "python/pyproject.toml"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "lammps"
 github = "njzjz/lammps-wheel"
+language = "C++"
+binding = "ctypes"
 
 [[project]]
 pypi = "laszip"
 github = "tmontaigu/laszip-python"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "Levenshtein"
 github = "maxbachmann/Levenshtein"
+language = "C++"
+binding = "Cython"
 
 [[project]]
 pypi = "libigl"
 github = "libigl/libigl-python-bindings"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "librapid"
 github = "LibRapid/librapid"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "lightgbm"
 github = "lightgbm-org/LightGBM"
 path = "python-package/pyproject.toml"
+language = "C++"
+binding = "ctypes"
 
 [[project]]
 pypi = "llama-cpp-python"
 github = "abetlen/llama-cpp-python"
+language = "C++"
+binding = "ctypes"
 
 [[project]]
 pypi = "llamacpp"
 github = "thomasantony/llamacpp-python"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "manifold3d"
 github = "elalish/manifold"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "MaterialX"
 github = "AcademySoftwareFoundation/MaterialX"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "mitsuba"
 github = "mitsuba-renderer/mitsuba3"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "mqt-core"
 github = "munich-quantum-toolkit/core"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "nanobind"
 github = "wjakob/nanobind"
+language = "C++"
 
 [[project]]
 pypi = "ncrystal"
 github = "mctools/ncrystal"
+language = "C++, C"
+binding = "ctypes"
 
 #[[project]]
 #pypi = "networkx-graph"
@@ -180,100 +262,144 @@ github = "mctools/ncrystal"
 [[project]]
 pypi = "ninja"
 github = "scikit-build/ninja-python-distributions"
+language = "C++"
 
 [[project]]
 pypi = "nodejs-wheel"
 github = "njzjz/nodejs-wheel"
+language = "C++"
 
 [[project]]
 pypi = "ompl"
 github = "ompl/ompl"
 path = "py-bindings/pyproject.toml"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "onnx"
 github = "onnx/onnx"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "OpenEXR"
 github = "AcademySoftwareFoundation/OpenEXR"
+language = "C++, C"
+binding = "pybind11"
 
 [[project]]
 pypi = "OpenImageIO"
 github = "AcademySoftwareFoundation/OpenImageIO"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "osmium"
 github = "osmcode/pyosmium"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "osqp"
 github = "osqp/osqp-python"
+language = "C"
+binding = "pybind11"
 
 [[project]]
 pypi = "pedalboard"
 github = "spotify/pedalboard"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "phik"
 github = "kaveio/phik"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "phono3py"
 github = "phonopy/phono3py"
+language = "C"
+binding = "nanobind"
 
 [[project]]
 pypi = "phonopy"
 github = "phonopy/phonopy"
+language = "C"
+binding = "nanobind"
 
 [[project]]
 pypi = "pikepdf"
 github = "pikepdf/pikepdf"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "polyscope"
 github = "nmwsharp/polyscope-py"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "pyarrow"
 github = "apache/arrow"
 path = "python/pyproject.toml"
+language = "C++"
+binding = "Cython"
 
 [[project]]
 pypi = "pybind11"
 github = "pybind/pybind11"
+language = "C++"
 
 [[project]]
 pypi = "pycolmap"
 github = "colmap/colmap"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "pygram11"
 github = "douglasdavis/pygram11"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "pyhmmer"
 github = "althonos/pyhmmer"
+language = "C"
+binding = "Cython"
 
 [[project]]
 pypi = "pylibmagic"
 github = "kratsg/pylibmagic"
+language = "C"
 
 [[project]]
 pypi = "pyopencl"
 github = "inducer/pyopencl"
+language = "C++, C"
+binding = "nanobind"
 
 [[project]]
 pypi = "pyradiomics"
 github = "AIM-Harvard/pyradiomics"
+language = "C"
+binding = "C API"
 
 [[project]]
 pypi = "pyresidfp"
 github = "pyresidfp/pyresidfp"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "pyslang"
 github = "MikePopoloski/slang"
+language = "C++"
+binding = "pybind11"
 
 #[[project]]
 #pypi = "pytango"
@@ -282,84 +408,125 @@ github = "MikePopoloski/slang"
 [[project]]
 pypi = "pyzmq"
 github = "zeromq/pyzmq"
+language = "C"
+binding = "Cython"
 
 [[project]]
 pypi = "rapidfuzz"
 github = "rapidfuzz/RapidFuzz"
+language = "C++"
+binding = "Cython"
 
 [[project]]
 pypi = "roboticstoolbox-python"
 github = "petercorke/robotics-toolbox-python"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "root"
 github = "root-project/root"
+language = "C++"
+binding = "cppyy"
 
 [[project]]
 pypi = "s5cmd"
 github = "ImagingDataCommons/s5cmd-python-distributions"
+language = "Go"
 
 [[project]]
 pypi = "shap"
 github = "shap/shap"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "SimpleITK"
 github = "SimpleITK/SimpleITK"
+language = "C++"
+binding = "SWIG"
 
 [[project]]
 pypi = "simsopt"
 github = "hiddenSymmetries/simsopt"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "sparse-dot-topn"
 github = "ing-bank/sparse_dot_topn"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "spglib"
 github = "spglib/spglib"
+language = "C"
+binding = "pybind11"
 
 [[project]]
 pypi = "spherely"
 github = "benbovy/spherely"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "stormpy"
 github = "stormchecker/stormpy"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "symusic"
 github = "Yikai-Liao/symusic"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "tetgen"
 github = "pyvista/tetgen"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "tiledb"
 github = "TileDB-Inc/TileDB-Py"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "tomotopy"
 github = "bab2min/tomotopy"
+language = "C++"
+binding = "C API"
 
 [[project]]
 pypi = "viennals"
 github = "ViennaTools/ViennaLS"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "viennaps"
 github = "ViennaTools/ViennaPS"
+language = "C++"
+binding = "pybind11"
 
 [[project]]
 pypi = "voyager"
 github = "spotify/voyager"
 path = "python/pyproject.toml"
+language = "C++"
+binding = "nanobind"
 
 [[project]]
 pypi = "xgrammar"
 github = "mlc-ai/xgrammar"
+language = "C++"
+binding = "C API"
 
 [[project]]
 pypi = "xtgeo"
 github = "equinor/xtgeo"
+language = "C, C++"
+binding = "pybind11, SWIG"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Restyles the docs projects page from a flat bullet list into a responsive card grid: each card shows the project name (PyPI link), a GitHub icon linking to its `pyproject.toml` (repo slug in the tooltip), and badge pills for the native language(s) and Python binding tool.

- `docs/data/projects.toml` gains `language` and `binding` fields for all 88 projects, researched from each repo's build requirements/CMake/source. Tally: pybind11 31, nanobind 25, Cython 8, C API 7, ctypes 5, SWIG 3, cppyy 1, none 9 (executable redistributions and header-only packages).
- The cog block in `docs/about/projects.md` renders the badges; the RAPIDS section gets matching hand-written cards.
- `attrs_inline` MyST extension enabled for the badge classes; card/badge/icon styling in `custom.css` uses only furo theme variables, so dark mode works unchanged.

Verified with light/dark headless-Chrome screenshots; docs build warning-free.