### PR TITLE
ci(docs): make linkcheck retry timeouts from slow hosts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,6 +145,12 @@ linkcheck_anchors_ignore = [
     "default-versioning-scheme",
     "git-archives",
 ]
+# Retry transient failures (slow hosts like docs.rapids.ai) before giving up.
+# The retry loop only re-tries links reported as "broken", so timeouts must be
+# reported as broken for the retries to apply to them.
+linkcheck_retries = 3
+linkcheck_timeout = 30
+linkcheck_report_timeouts_as_broken = True
 linkcheck_ignore = [
     # Rate limited
     r"https://github.com/?.*",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The docs `linkcheck` job frequently fails when a slow host (notably `docs.rapids.ai`) times out. Two Sphinx behaviors combine to make a single timeout fatal:

- The linkcheck retry loop only re-tries links reported as **broken**. A timeout returns `TIMEOUT` status, which breaks out of the loop immediately — so `linkcheck_retries` never applied to timeouts.
- A timeout still sets `statuscode=1`, failing the whole job.

This sets `linkcheck_report_timeouts_as_broken = True` so timeouts become retriable, and adds `linkcheck_retries = 3` (with the existing 30s `linkcheck_timeout`). Transient slowness now gets retried instead of failing on the first hiccup.

If a host is unreachable for an entire run this won't help — the fallback there would be adding it to `linkcheck_ignore`.