### PR TITLE
docs: list choices for Literal options in the README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ print()
 
 | Option | Default | Description |
 | - | - | - |
-| `logging.level` | `"WARNING"` | The logging level to display. |
+| `logging.level` | `"WARNING"` | The logging level to display. (choices: `NOTSET`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 
 ### `sdist`
 
@@ -214,11 +214,11 @@ print()
 | - | - | - |
 | `sdist.include` | `[]` | Files to include in the SDist even if they are skipped by default. Supports gitignore syntax. |
 | `sdist.exclude` | `[]` | Files to exclude from the SDist even if they are included by default. Supports gitignore syntax. |
-| `sdist.inclusion-mode` | `"default"` ("classic") | Method to use to compute the files to include and exclude. |
+| `sdist.inclusion-mode` | `"default"` ("classic") | Method to use to compute the files to include and exclude. (choices: `classic`, `default`, `manual`, `explicit`) |
 | `sdist.reproducible` | `true` | Try to build a reproducible distribution. |
 | `sdist.cmake` | `false` | If set to True, CMake will be run before building the SDist. |
 | `sdist.force-include` | `{}` | Force-include files into the SDist. |
-| `sdist.resolve-symlinks` | `"all"` | Which symlinks to resolve in the SDist, storing the target's contents instead. |
+| `sdist.resolve-symlinks` | `"all"` | Which symlinks to resolve in the SDist, storing the target's contents instead. (choices: `all`, `external`, `none`, `classic`) |
 
 ### `wheel`
 
@@ -246,7 +246,7 @@ print()
 
 | Option | Default | Description |
 | - | - | - |
-| `editable.mode` | `"redirect"` | Select the editable mode to use. Can be "redirect" (default) or "inplace". |
+| `editable.mode` | `"redirect"` | Select the editable mode to use. (choices: `redirect`, `inplace`) |
 | `editable.verbose` | `true` | Turn on verbose output for the editable mode rebuilds. |
 | `editable.rebuild` | `false` | Rebuild the project when the package is imported. |
 | `editable.rebuild-dir` | `""` | Install rebuildable editables into this tree (a newer alternative to ``editable.rebuild``). |
@@ -275,7 +275,7 @@ print()
 | `generate[].path` | `""` | The path (relative to platlib) for the file to generate. |
 | `generate[].template` | `""` | The template string to use for the file. |
 | `generate[].template-path` | `""` | The path to the template file. If empty, a template must be set. |
-| `generate[].location` | `"install"` | The place to put the generated file. |
+| `generate[].location` | `"install"` | The place to put the generated file. (choices: `install`, `build`, `source`) |
 
 ### `messages`
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -423,7 +423,7 @@ print(mk_skbuild_docs())
   :Config-settings: ``editable.mode`` or ``skbuild.editable.mode``
   :Environment variable: ``SKBUILD_EDITABLE_MODE``
 
-  Select the editable mode to use. Can be "redirect" (default) or "inplace".
+  Select the editable mode to use.
 ```
 
 ```{eval-rst}

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -328,7 +328,7 @@
             "inplace"
           ],
           "default": "redirect",
-          "description": "Select the editable mode to use. Can be \"redirect\" (default) or \"inplace\"."
+          "description": "Select the editable mode to use."
         },
         "verbose": {
           "type": "boolean",

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -73,6 +73,7 @@ class DCDoc:
     field: dataclasses.Field[typing.Any]
     deprecated: bool = False
     override_only: bool = False
+    choices: tuple[str, ...] = ()
 
 
 def sanitize_default_field(text: str) -> str:
@@ -112,6 +113,24 @@ def get_display_type(field_type: type | str) -> str:
         return "Any"
     # Otherwise just get the formatted form of the `type` object
     return field_type.__name__
+
+
+def get_choices(field_type: type | str) -> tuple[str, ...]:
+    """
+    Return the string choices for a ``Literal`` field, unwrapping ``Annotated``
+    and ``Optional``. Empty if the field is not a string ``Literal``.
+    """
+    if isinstance(field_type, str):
+        return ()
+    if get_origin(field_type) is Annotated:
+        return get_choices(get_args(field_type)[0])
+    if is_optional(field_type):
+        return get_choices(get_args(field_type)[0])
+    if get_origin(field_type) is typing.Literal:
+        args = get_args(field_type)
+        if all(isinstance(a, str) for a in args):
+            return args
+    return ()
 
 
 def mk_docs(dc: type[object], prefix: str = "") -> Generator[DCDoc, None, None]:
@@ -157,4 +176,5 @@ def mk_docs(dc: type[object], prefix: str = "") -> Generator[DCDoc, None, None]:
             field=field,
             deprecated=field.metadata.get("deprecated", False),
             override_only=field.metadata.get("override_only", False),
+            choices=get_choices(field.type),
         )

--- a/src/scikit_build_core/settings/skbuild_docs_readme.py
+++ b/src/scikit_build_core/settings/skbuild_docs_readme.py
@@ -47,6 +47,9 @@ class Item:
 
     def format(self) -> str:
         summary = self.item.docs.split("\n", maxsplit=1)[0].replace("|", "\\|")
+        if self.item.choices:
+            choices = ", ".join(f"`{c}`" for c in self.item.choices)
+            summary = f"{summary} (choices: {choices})"
         value, _, comment = self.item.default.partition("  # ")
         default = f"`{value}`" + (f" ({comment})" if comment else "")
         return f"| `{self.item.name}` | {default} | {summary} |"

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -636,7 +636,7 @@ class BackportSettings:
 class EditableSettings:
     mode: Literal["redirect", "inplace"] = "redirect"
     """
-    Select the editable mode to use. Can be "redirect" (default) or "inplace".
+    Select the editable mode to use.
     """
 
     verbose: bool = True


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The generated README options table only listed the allowed values for `editable.mode`, since that docstring spelled them out by hand. This computes the choices from each field's `Literal` type and appends them to the description column, so the other choice-based options list their choices too:

- `logging.level`
- `sdist.inclusion-mode`
- `sdist.resolve-symlinks`
- `editable.mode`
- `generate[].location`

The redundant choice prose in the `editable.mode` docstring is dropped (the Sphinx reference already shows the choices in its `:Type:` field). Generated files (`README.md`, `docs/reference/configs.md`, schema JSON) were regenerated via `nox -t gen`.