### PR TITLE
docs: put uv first in installer tabs and add it to config-settings

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -33,6 +33,14 @@ logging.level = "INFO"
 `````{tab} config-settings
 
 
+````{tab} uv
+
+```console
+$ uv pip install . -v -Cbuild.verbose=true -Clogging.level=INFO
+```
+
+````
+
 ````{tab} pip
 
 ```console
@@ -630,6 +638,14 @@ FOOD_GROUPS = ["Apple", "Lemon;Lime", "Banana"]
 
 `````{tab} config-settings
 
+
+````{tab} uv
+
+```console
+$ uv pip install . -Ccmake.define.SOME_DEFINE=ON
+```
+
+````
 
 ````{tab} pip
 

--- a/docs/ext/conftabs.py
+++ b/docs/ext/conftabs.py
@@ -38,6 +38,14 @@ class ConfTabs(SphinxDirective):
         `````{{tab}} config-settings
 
 
+        ````{{tab}} uv
+
+        ```console
+        $ uv pip install . -C{name}={joined_result}
+        ```
+
+        ````
+
         ````{{tab}} pip
 
         ```console

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -5,18 +5,18 @@
 For any backend, you can make a SDist and then build a wheel from it with one
 command (choose your favorite way to run apps):
 
-````{tab} pipx
-
-```bash
-pipx run build
-```
-
-````
-
 ````{tab} uv
 
 ```bash
 uv build
+```
+
+````
+
+````{tab} pipx
+
+```bash
+pipx run build
 ```
 
 ````

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -66,17 +66,6 @@ no longer exists when your editor looks for it.
 
 Extend the shared fix by having CMake export a compile database:
 
-````{tab} pip
-
-```bash
-pip install scikit-build-core pybind11
-pip install --no-build-isolation --check-build-dependencies -ve . \
-  -Cbuild-dir=build \
-  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
-```
-
-````
-
 ````{tab} uv
 
 ```bash
@@ -93,6 +82,17 @@ overlay:
 ```toml
 [tool.uv]
 no-build-isolation-package = ["mypackage"]
+```
+
+````
+
+````{tab} pip
+
+```bash
+pip install scikit-build-core pybind11
+pip install --no-build-isolation --check-build-dependencies -ve . \
+  -Cbuild-dir=build \
+  -Ccmake.define.CMAKE_EXPORT_COMPILE_COMMANDS=1
 ```
 
 ````

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -14,6 +14,14 @@ build.verbose = true
 
 `````{tab} config-settings
 
+````{tab} uv
+
+```console
+$ uv pip install . -Cbuild.verbose=true
+```
+
+````
+
 ````{tab} pip
 
 ```console


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Reorders the installer tabs so **uv** leads and adds a uv **config-settings** tab that was previously missing.

- Quickstart (`guide/build.md`) and debugging (`guide/debugging.md`) tabs now list uv first.
- The config-settings tab sets in `configuration/index.md`, `reference/configs.md`, and the `conftabs` Sphinx directive gain a uv tab (`uv pip install . -C…`), first in the group.

Docs build cleanly (`nox -s docs`).