### PR TITLE
chore: bump CMake policy upper bound to 4.4

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -248,7 +248,7 @@ test = ["pytest>=6.0"]
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)
@@ -291,7 +291,7 @@ build-backend = "scikit_build_core.setuptools.build_meta"
 ```
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ the minimum to get started.
 An example `CMakeLists.txt`:
 
 ```cmake
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(scikit_build_simplest LANGUAGES C)
 
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)

--- a/docs/examples/downstream/nanobind_example/CMakeLists.txt
+++ b/docs/examples/downstream/nanobind_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(nanobind_example LANGUAGES CXX)
 

--- a/docs/examples/downstream/pybind11_example/CMakeLists.txt
+++ b/docs/examples/downstream/pybind11_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -437,9 +437,11 @@ every CPython 3.15+, free-threaded or not; a GIL build falls back to
 `cp315-abi3`.
 
 `USE_SABI` is set from `${SKBUILD_SABI_VERSION}` (3.15 for `abi3t`) rather than
-hardcoded. CMake before 4.4 has no `abi3t` awareness, so the SOABI suffix is
-taken from `${SKBUILD_SOABI}` and `Py_TARGET_ABI3T` is defined manually; both
-become unnecessary on CMake 4.4+.
+hardcoded. CMake 4.4 is the first release with native `abi3t` awareness; on 4.4+
+it emits the `abi3t` SOABI suffix and defines `Py_TARGET_ABI3T` on its own. The
+example keeps the manual fallback (SOABI from `${SKBUILD_SOABI}`,
+`Py_TARGET_ABI3T` defined by hand) so it still builds on CMake < 4.4. The
+fallback is a harmless no-op once you require 4.4+.
 
 ```{note}
 `abi3t` requires CPython 3.15+ and the PEP 793 module export mechanism, so the

--- a/src/scikit_build_core/resources/templates/abi3/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/abi3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/src/scikit_build_core/resources/templates/c/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/src/scikit_build_core/resources/templates/cython/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/cython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/src/scikit_build_core/resources/templates/fortran/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/fortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17...4.3)
+cmake_minimum_required(VERSION 3.17...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/src/scikit_build_core/resources/templates/nanobind/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/nanobind/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development.Module)

--- a/src/scikit_build_core/resources/templates/pybind11/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 set(PYBIND11_FINDPYTHON ON)

--- a/src/scikit_build_core/resources/templates/swig/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/swig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,10 +335,10 @@ def package_simple_pyproject_ext(
     package = PackageInfo(
         "simple_pyproject_ext",
         tmp_path_factory.mktemp("pkg"),
-        "02ddfa3e5907ef6a991d54ba4bf23d0aaafb46841d74b4327da91eaf66c95b53",
-        "8330d31d6c798455b0d8c0615dbb8b72219d0e11fb6aa34c50d7313f90facbc4",
-        "b7835a2da5732feab1bc29fde44da4e996405566922e718d8c9ad0f6f1a58903",
-        "b2d90702df52ce7b3bd1093fc5933be836b610b4d1f000857822420af4abba4a",
+        "2e38820898f524a579192aeba818663916312ec3d8bfb84a26b1701e1768540c",
+        "6d20fa5e8a8f0ecb2084abe13f3b646ea604a9a50614e18ce8cdcbefd8e365a1",
+        "9863d4c1101153174b79d1aee5d5399e7d57721389cf0cff7c195082080fea95",
+        "f71fae6a004761c7897cd55cf247af1fec69907e3d2263b4f3013469038f7261",
     )
     process_package(package, monkeypatch)
     return package

--- a/tests/packages/abi3_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/abi3_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/abi3_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/abi3_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/broken_fallback/CMakeLists.txt
+++ b/tests/packages/broken_fallback/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 if(DEFINED BROKEN_CMAKE)

--- a/tests/packages/cmake_defines/CMakeLists.txt
+++ b/tests/packages/cmake_defines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(cmake_defines LANGUAGES NONE)
 
 set(ONE_LEVEL_LIST

--- a/tests/packages/cmake_generated/CMakeLists.txt
+++ b/tests/packages/cmake_generated/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/custom_cmake/CMakeLists.txt
+++ b/tests/packages/custom_cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/cython_pxd_editable/pkg1/CMakeLists.txt
+++ b/tests/packages/cython_pxd_editable/pkg1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/cython_pxd_editable/pkg2/CMakeLists.txt
+++ b/tests/packages/cython_pxd_editable/pkg2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/dynamic_metadata/CMakeLists.txt
+++ b/tests/packages/dynamic_metadata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/filepath_pure/CMakeLists.txt
+++ b/tests/packages/filepath_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/fortran_example/CMakeLists.txt
+++ b/tests/packages/fortran_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.2...4.3)
+cmake_minimum_required(VERSION 3.17.2...4.4)
 
 project(
   fibby

--- a/tests/packages/hatchling/cpp/CMakeLists.txt
+++ b/tests/packages/hatchling/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(extensionlib_example_cmake LANGUAGES C)
 
 find_package(

--- a/tests/packages/importlib_editable/src/CMakeLists.txt
+++ b/tests/packages/importlib_editable/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/packages/mixed_setuptools/CMakeLists.txt
+++ b/tests/packages/mixed_setuptools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project("${SKBUILD_PROJECT_NAME}" LANGUAGES C)
 
 if(NOT EXAMPLE_DEFINE1 EQUAL 1)

--- a/tests/packages/multi_build_type/CMakeLists.txt
+++ b/tests/packages/multi_build_type/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/navigate_editable/CMakeLists.txt
+++ b/tests/packages/navigate_editable/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/plugin_setuptools_install_dir/CMakeLists.txt
+++ b/tests/packages/plugin_setuptools_install_dir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/sdist_config/CMakeLists.txt
+++ b/tests/packages/sdist_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   sdist_config
   LANGUAGES C

--- a/tests/packages/sdist_config/external/dummy/CMakeLists.txt
+++ b/tests/packages/sdist_config/external/dummy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(dummy LANGUAGES NONE)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/tools/dummy_helper.cmake")

--- a/tests/packages/simple_pure/CMakeLists.txt
+++ b/tests/packages/simple_pure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(simple_pure LANGUAGES C)
 

--- a/tests/packages/simple_pyproject_ext/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES CXX

--- a/tests/packages/simple_pyproject_script_with_flags/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_script_with_flags/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simple_pyproject_source_dir/src/CMakeLists.txt
+++ b/tests/packages/simple_pyproject_source_dir/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simple_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/simple_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/simplest_c/CMakeLists.txt
+++ b/tests/packages/simplest_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/tests/packages/toml_setuptools_ext/CMakeLists.txt
+++ b/tests/packages/toml_setuptools_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_classic_layout/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/wrapper_setuptools_install_dir/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_install_dir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C

--- a/tests/packages/wrapper_setuptools_install_dir_pkgdir/CMakeLists.txt
+++ b/tests/packages/wrapper_setuptools_install_dir_pkgdir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 project(
   "${SKBUILD_PROJECT_NAME}"
   LANGUAGES C


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the `cmake_minimum_required(VERSION ...4.3)` policy max to `...4.4` across the init templates, test packages, README, CONTRIBUTING, and downstream examples, so everything matches the `abi3t` template that already targets 4.4.

CMake 4.4 is the first release with native free-threaded stable ABI (`abi3t`) awareness. I verified the `abi3t` example builds and imports correctly with system CMake 4.4.0 and Python 3.15t (`uv --python=3.15t`), producing the combined `cp315-abi3.abi3t` tag and a `_core.abi3t.so`. A stripped native-only CMakeLists produces the identical suffix on 4.4, confirming CMake now handles it. The example intentionally keeps its manual `SOABI`/`Py_TARGET_ABI3T` fallback so it still builds on CMake < 4.4, and the getting-started note now spells that out.