### PR TITLE
docs: recommend rebuilding editables via find_spec before import

### DIFF
--- a/docs/configuration/editable.md
+++ b/docs/configuration/editable.md
@@ -108,10 +108,8 @@ importlib.util.find_spec("some_package").loader.rebuild()
 import some_package
 ```
 
-(For a submodule like `"pkg.sub"`, `find_spec` still imports the parent package,
-so prefer a top-level name.) If the module is already imported and you plan to
-restart anyway to pick up the new binaries, the loader is also reachable on the
-module itself:
+If you don't import or lazily import the compiled code you are trying to load,
+you can reach the loader in Python on the outer module:
 
 ```python
 some_package.__loader__.rebuild()

--- a/docs/configuration/editable.md
+++ b/docs/configuration/editable.md
@@ -95,19 +95,32 @@ build and checking `SKBUILD` being set.
 ## Triggering a rebuild manually
 
 You don't have to enable `editable.rebuild` to rebuild on demand. Both editable
-modes install a loader that exposes a `rebuild()` method, so you can recompile
-whenever you like:
+modes install a loader that exposes a `rebuild()` method. Rebuild _before_ the
+first import: once Python loads a compiled extension it cannot unload it, so a
+rebuild after import only takes effect in a new process.
+`importlib.util.find_spec()` reaches the loader without importing the module:
 
 ```python
-import some_package
+import importlib.util
 
+importlib.util.find_spec("some_package").loader.rebuild()
+
+import some_package
+```
+
+(For a submodule like `"pkg.sub"`, `find_spec` still imports the parent package,
+so prefer a top-level name.) If the module is already imported and you plan to
+restart anyway to pick up the new binaries, the loader is also reachable on the
+module itself:
+
+```python
 some_package.__loader__.rebuild()
 ```
 
 For redirect installs this runs the same `cmake --build`/`--install` cycle used
-by the automatic rebuild, and works for any importable object the install
-provides -- a package, a plain module, or a compiled extension. A redirect
-rebuild needs a persistent build directory, so install with a `build-dir` set:
+by the automatic rebuild, and works for any importable name the install provides
+-- a package, a plain module, or a compiled extension. A redirect rebuild needs
+a persistent build directory, so install with a `build-dir` set:
 
 ```console
 $ pip install --no-build-isolation -Cbuild-dir=build -ve .
@@ -120,9 +133,9 @@ For inplace installs, `rebuild()` runs `cmake --build` in the source tree (there
 is no install step); the source directory is always the build directory, so no
 `build-dir` is required.
 
-If you don't have a handle on a redirected module, the finder itself is on
-`sys.meta_path` and carries the same method (`ScikitBuildRedirectingFinder` for
-redirect installs, `ScikitBuildInplaceFinder` for inplace):
+The finder itself is also on `sys.meta_path` and carries the same method
+(`ScikitBuildRedirectingFinder` for redirect installs,
+`ScikitBuildInplaceFinder` for inplace):
 
 ```python
 import sys

--- a/docs/guide/ctypes.md
+++ b/docs/guide/ctypes.md
@@ -69,10 +69,16 @@ a rebuild explicitly (this works whenever a persistent `build-dir` is set, with
 or without `editable.rebuild`)…
 
 ```python
-import mypackage
+import importlib.util
 
-mypackage.__loader__.rebuild()
+importlib.util.find_spec("mypackage").loader.rebuild()
+
+import mypackage
 ```
+
+Rebuild before importing `mypackage`: the module-level `ctypes.CDLL` call maps
+the library into the process, and the old binary stays loaded even after a
+rebuild.
 
 …or import a real extension module from the same project first, which does fire
 the on-import hook when `editable.rebuild` is enabled. See

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -56,7 +56,7 @@ editable.rebuild = true
 ```
 
 See [editable installs](../configuration/editable.md) for the full set of
-options (verbosity, manual `__loader__.rebuild()`, inplace mode, and the newer
+options (verbosity, manual `rebuild()`, inplace mode, and the newer
 `editable.rebuild-dir`).
 
 ## Per-member configuration

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -204,6 +204,16 @@ def test_inplace_loader_rebuild(isolated, isolate):
     assert "Running cmake --build" in out
     assert out.splitlines()[-1] == "rebuilt"
 
+    # The docs-recommended pattern: rebuild via find_spec before the first
+    # import, so the fresh extension is the one that gets loaded.
+    out = isolated.execute(
+        "import importlib.util;"
+        " importlib.util.find_spec('simplest').loader.rebuild();"
+        " import simplest; print('rebuilt')"
+    )
+    assert "Running cmake --build" in out
+    assert out.splitlines()[-1] == "rebuilt"
+
 
 @pytest.mark.compile
 @pytest.mark.configure


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The manual-rebuild docs showed `import foo; foo.__loader__.rebuild()`, but importing first loads the compiled extension, and CPython cannot unload it — the rebuild lands on disk while the process keeps the old symbols. The docs now lead with

```python
importlib.util.find_spec("foo").loader.rebuild()
```

before the first import, which works because both editable modes attach the rebuild-capable loader wrapper to the spec, keeping `__loader__.rebuild()` as the already-imported form. The ctypes guide gets the same treatment (the module-level `CDLL` call has the same problem), and the inplace integration test now also exercises the documented find_spec-before-import pattern.