### PR TITLE
docs: name the external dynamic-metadata plugins

### DIFF
--- a/docs/configuration/dynamic.md
+++ b/docs/configuration/dynamic.md
@@ -70,8 +70,21 @@ input = "src/mypackage/__init__.py"
 
 The
 [dynamic-metadata package provides several plugins](https://dynamic-metadata.readthedocs.io/en/latest/plugins.html)
-you can use. Remember to include dynamic-metadata in your build requirements if
-you want to use them.
+you can use, each referenced by a `dynamic_metadata.<name>` provider string:
+
+- `dynamic_metadata.ast` -- read a variable from a Python file via AST parsing.
+- `dynamic_metadata.from_file` -- read a file's contents into a field.
+- `dynamic_metadata.static` -- set fields to static values.
+- `dynamic_metadata.readme_fragment` -- assemble a readme from fragments.
+- `dynamic_metadata.pin_installed` -- pin dependencies to the versions in
+  `build-system.requires`.
+- `dynamic_metadata.substitute` -- apply a regex substitution to a field
+  produced by an earlier entry.
+
+It also ships `dynamic_metadata.regex` and `dynamic_metadata.template`, which
+mirror scikit-build-core's built-in `regex` and `template` plugins below.
+Remember to include `dynamic-metadata` in your build requirements if you want to
+use any of these.
 
 ## Built-in plugins
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The dynamic metadata page only linked out to the [dynamic-metadata package plugins](https://dynamic-metadata.readthedocs.io/en/latest/plugins.html) without naming any of them. This lists the provider strings (`dynamic_metadata.ast`, `from_file`, `static`, `readme_fragment`, `pin_installed`, `substitute`) so they are discoverable, and notes that `dynamic_metadata.regex`/`template` mirror the built-ins.

Prompted by scikit-build/SIMPLE-Py#55, which fixed the same provider names in the tutorial (the `.plugins` segment was dropped in dynamic-metadata 0.4/0.5). Our provider strings were already correct; this just fills the discoverability gap.