### PR TITLE
chore: avoid CMake 4.4.0's broken Windows SABI detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ dependencies = [
 
 [project.optional-dependencies]
 wheels = [
-    "cmake",
+    # 4.4.0's FindPython can't find Development.SABIModule on Windows
+    # (https://gitlab.kitware.com/cmake/cmake/-/issues/27950); remove when
+    # 4.4.1 is out
+    "cmake; sys_platform!='win32'",
+    "cmake!=4.4.0; sys_platform=='win32'",
     "ninja; sys_platform!='win32'",
 ]
 wheel-free-setuptools = [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Windows CI fails on `test_setuptools_abi3.py::test_abi3_wheel` since the `cmake==4.4.0` wheel reached PyPI. CMake 4.4.0's FindPython rejects the stable-ABI import library on Windows when `Interpreter` and `Development.SABIModule` are requested in one `find_package` call — upstream regression https://gitlab.kitware.com/cmake/cmake/-/issues/27950, milestoned for 4.4.1. The `[wheels]` extra pulls the cmake wheel into the CI test env, where its `Scripts\cmake.exe` shadows the matrix-pinned CMake.

This excludes 4.4.0 from the `wheels` extra. Drop the exclusion once 4.4.1 is out.