### PR TITLE
fix: prefer cmake over cmake3 when searching

### DIFF
--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -116,7 +116,7 @@ def _get_cmake_path(*, module: bool = True) -> Generator[Path, None, None]:
 
             yield Path(CMAKE_BIN_DIR) / "cmake"
 
-    candidates = ("cmake3", "cmake")
+    candidates = ("cmake", "cmake3")
     for candidate in candidates:
         cmake_path = shutil.which(candidate)
         if cmake_path is not None:

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -53,14 +53,14 @@ def test_get_cmake_programs_all(monkeypatch, fp):
     )
     programs = list(get_cmake_programs(module=False))
     assert len(programs) == 2
-    assert programs[0].path.name == "cmake3"
-    assert programs[0].version == Version("3.19.0")
-    assert programs[1].path.name == "cmake"
-    assert programs[1].version == Version("3.20.0")
+    assert programs[0].path.name == "cmake"
+    assert programs[0].version == Version("3.20.0")
+    assert programs[1].path.name == "cmake3"
+    assert programs[1].version == Version("3.19.0")
 
     best1 = best_program(programs, version=None)
     assert best1
-    assert best1.path.name == "cmake3"
+    assert best1.path.name == "cmake"
 
     best2 = best_program(programs, version=SpecifierSet(">=3.20.0"))
     assert best2
@@ -110,7 +110,7 @@ def test_get_cmake_programs_malformed(monkeypatch, fp, caplog):
 
     best_none = best_program(programs, version=None)
     assert best_none
-    assert best_none.path.name == "cmake3"
+    assert best_none.path.name == "cmake"
 
     best_3_15 = best_program(programs, version=SpecifierSet(">=3.15"))
     assert best_3_15


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Searches for `cmake` before `cmake3`, so a current CMake install wins over a distro CMake 3. The `cmake3` name came from EPEL; Fedora has dropped the suffix.

Closes #1514