### PR TITLE
feat: add cmake.fresh to configure from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ print()
 | `cmake.define` | `{}` | A table of defines to pass to CMake when configuring the project. Additive. |
 | `cmake.build-type` | `"Release"` | The build type to use when building the project. |
 | `cmake.source-dir` | `"."` | The source directory to use when building the project. |
+| `cmake.fresh` | `false` | Discard any cached CMake configuration and configure from scratch, like ``cmake --fresh``. |
 | `cmake.python-hints` | `true` | Do not pass the current environment's python hints such as ``Python_EXECUTABLE``. |
 
 ### `ninja`

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -881,6 +881,17 @@ There are several values you can access through Python's formatting syntax. See
 every member of a uv or hatch workspace (e.g. via `SKBUILD_BUILD_DIR`) avoid
 collisions: `SKBUILD_BUILD_DIR=/path/to/cache/{name}/{cache_tag}`.
 
+If a cached configuration goes bad, you can throw it away and configure from
+scratch with {confval}`cmake.fresh`, like `cmake --fresh`.
+
+```{conftabs} cmake.fresh True
+
+```
+
+```{versionadded} 1.1
+
+```
+
 Scikit-build-core also strictly validates configuration; if you need to disable
 this, you can:
 

--- a/docs/reference/configs.md
+++ b/docs/reference/configs.md
@@ -329,6 +329,22 @@ print(mk_skbuild_docs())
 ```
 
 ```{eval-rst}
+.. confval:: cmake.fresh
+
+  :Type: ``bool``
+  :Default: false
+  :Config-settings: ``cmake.fresh`` or ``skbuild.cmake.fresh``
+  :Environment variable: ``SKBUILD_CMAKE_FRESH``
+
+  Discard any cached CMake configuration and configure from scratch, like ``cmake --fresh``.
+
+  Only affects a persistent :confval:`build-dir`. Most useful as a
+  config-setting, an environment variable, or in an override.
+
+  .. versionadded:: 1.1
+```
+
+```{eval-rst}
 .. confval:: cmake.minimum-version
 
   :Type: ``Version``

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -265,6 +265,7 @@ def configure_wheel(
     ``build_type`` to reconfigure a single-config generator into a fresh builder
     for that build type (see :func:`build_install_extra_build_types`).
     """
+    primary = build_type is None
     if build_type is None:
         build_type = normalize_build_types(settings.cmake.build_type)[0]
         rich_print("{green}***", "{bold}Configuring CMake...")
@@ -279,6 +280,9 @@ def configure_wheel(
         source_dir=settings.cmake.source_dir,
         build_dir=build_dir,
         build_type=build_type,
+        # Only clear on the primary configure; extra build types reuse the
+        # just-written cache.
+        fresh=settings.cmake.fresh and primary,
     )
     builder = Builder(settings=settings, config=config)
 

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -107,6 +107,7 @@ class CMaker:
     module_dirs: list[Path] = dataclasses.field(default_factory=list)
     prefix_dirs: list[Path] = dataclasses.field(default_factory=list)
     prefix_roots: dict[str, list[Path]] = dataclasses.field(default_factory=dict)
+    fresh: bool = False
     init_cache_file: Path = dataclasses.field(init=False, default=Path())
     env: dict[str, str] = dataclasses.field(init=False, default_factory=os.environ.copy)
     single_config: bool = not sysconfig.get_platform().startswith("win")
@@ -129,35 +130,37 @@ class CMaker:
         # TODO: This could be stateful instead
         self._file_api_query = stateless_query(self.build_dir)
         skbuild_info = self.build_dir / ".skbuild-info.json"
-        stale = False
+        stale = self.fresh
+        if self.fresh:
+            logger.info("Fresh build requested, clearing cache")
+        else:
+            info: dict[str, str] = {}
+            # Parenthesized context managers require the new parser (default in 3.9,
+            # guaranteed 3.10+). Keep nested until 3.9 is dropped.
+            with contextlib.suppress(FileNotFoundError):  # noqa: SIM117
+                with skbuild_info.open("r", encoding="utf-8") as f:
+                    info = json.load(f)
 
-        info: dict[str, str] = {}
-        # Parenthesized context managers require the new parser (default in 3.9,
-        # guaranteed 3.10+). Keep nested until 3.9 is dropped.
-        with contextlib.suppress(FileNotFoundError):  # noqa: SIM117
-            with skbuild_info.open("r", encoding="utf-8") as f:
-                info = json.load(f)
+            if info:
+                # If building via SDist, this could be pre-filled
+                cached_source_dir = Path(info["source_dir"])
+                if cached_source_dir != source_dir:
+                    logger.warning(
+                        "Original src {} != {}, clearing cache",
+                        cached_source_dir,
+                        source_dir,
+                    )
+                    stale = True
 
-        if info:
-            # If building via SDist, this could be pre-filled
-            cached_source_dir = Path(info["source_dir"])
-            if cached_source_dir != source_dir:
-                logger.warning(
-                    "Original src {} != {}, clearing cache",
-                    cached_source_dir,
-                    source_dir,
-                )
-                stale = True
-
-            # Isolated environments can cause this
-            cached_skbuild_dir = Path(info["skbuild_path"])
-            if cached_skbuild_dir != DIR:
-                logger.info(
-                    "New isolated environment {} -> {}, clearing cache",
-                    cached_skbuild_dir,
-                    DIR,
-                )
-                stale = True
+                # Isolated environments can cause this
+                cached_skbuild_dir = Path(info["skbuild_path"])
+                if cached_skbuild_dir != DIR:
+                    logger.info(
+                        "New isolated environment {} -> {}, clearing cache",
+                        cached_skbuild_dir,
+                        DIR,
+                    )
+                    stale = True
 
         # Not using --fresh here, not just due to CMake 3.24+, but also just in
         # case it triggers an extra FetchContent pull in CMake 3.30+

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -114,6 +114,11 @@
           "description": "The CMAKE_TOOLCHAIN_FILE / --toolchain used for cross-compilation.",
           "scikit-build:override-only": true
         },
+        "fresh": {
+          "type": "boolean",
+          "default": false,
+          "description": "Discard any cached CMake configuration and configure from scratch, like ``cmake --fresh``."
+        },
         "python-hints": {
           "type": "boolean",
           "default": true,

--- a/src/scikit_build_core/settings/skbuild_model.py
+++ b/src/scikit_build_core/settings/skbuild_model.py
@@ -258,6 +258,16 @@ class CMakeSettings:
     This cannot be set in the static ``[tool.scikit-build]`` table; use it in an override, config-settings, or an environment variable.
     """
 
+    fresh: bool = False
+    """
+    Discard any cached CMake configuration and configure from scratch, like ``cmake --fresh``.
+
+    Only affects a persistent :confval:`build-dir`. Most useful as a
+    config-setting, an environment variable, or in an override.
+
+    .. versionadded:: 1.1
+    """
+
     python_hints: bool = True
     """
     Do not pass the current environment's python hints such as ``Python_EXECUTABLE``.

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -339,3 +339,30 @@ def test_get_cmake_via_envvar(monkeypatch: pytest.MonkeyPatch, fp):
     result = CMake.default_search(env=os.environ)
     assert result.cmake_path == cmake_path
     assert result.version == Version("3.20.0")
+
+
+def test_cmake_fresh_clears_cache(tmp_path: Path) -> None:
+    cmake = CMake(Version("3.30"), Path("cmake"))
+    source_dir = DIR / "packages" / "simple_pure"
+    build_dir = tmp_path / "build"
+
+    CMaker(cmake, source_dir=source_dir, build_dir=build_dir, build_type="Release")
+    cache = build_dir / "CMakeCache.txt"
+    cmakefiles = build_dir / "CMakeFiles"
+    cache.write_text("cached")
+    cmakefiles.mkdir()
+    cmakefiles.joinpath("obj.txt").write_text("obj")
+
+    CMaker(cmake, source_dir=source_dir, build_dir=build_dir, build_type="Release")
+    assert cache.exists()
+    assert cmakefiles.joinpath("obj.txt").exists()
+
+    CMaker(
+        cmake,
+        source_dir=source_dir,
+        build_dir=build_dir,
+        build_type="Release",
+        fresh=True,
+    )
+    assert not cache.exists()
+    assert not cmakefiles.exists()

--- a/tests/test_simplest_c.py
+++ b/tests/test_simplest_c.py
@@ -179,3 +179,25 @@ def test_pep517_wheel_incexl(tmp_path, monkeypatch, virtualenv):
         "from simplest import square; print(square(2))",
     )
     assert version == "4.0"
+
+
+@pytest.mark.compile
+@pytest.mark.configure
+def test_pep517_wheel_fresh(tmp_path, monkeypatch):
+    dist = tmp_path / "dist"
+    build_dir = tmp_path / "build"
+    monkeypatch.chdir(SIMPLEST)
+
+    build_wheel(str(dist), config_settings={"build-dir": str(build_dir)})
+    marker = build_dir / "CMakeFiles" / "marker.txt"
+    marker.write_text("")
+
+    build_wheel(str(dist), config_settings={"build-dir": str(build_dir)})
+    assert marker.exists()
+
+    build_wheel(
+        str(dist),
+        config_settings={"build-dir": str(build_dir), "cmake.fresh": "true"},
+    )
+    assert not marker.exists()
+    assert (build_dir / "CMakeCache.txt").exists()

--- a/tests/test_skbuild_settings.py
+++ b/tests/test_skbuild_settings.py
@@ -37,6 +37,7 @@ def test_skbuild_settings_default(tmp_path: Path):
     assert not settings.build.verbose
     assert settings.cmake.build_type == "Release"
     assert settings.cmake.source_dir == Path()
+    assert not settings.cmake.fresh
     assert settings.build.targets == []
     assert settings.logging.level == "WARNING"
     assert settings.sdist.include == []
@@ -278,6 +279,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SKBUILD_CMAKE_DEFINE", "a=1;b=2")
     monkeypatch.setenv("SKBUILD_CMAKE_BUILD_TYPE", "Debug")
     monkeypatch.setenv("SKBUILD_CMAKE_SOURCE_DIR", "a/b/c")
+    monkeypatch.setenv("SKBUILD_CMAKE_FRESH", "1")
     monkeypatch.setenv("SKBUILD_LOGGING_LEVEL", "DEBUG")
     monkeypatch.setenv("SKBUILD_SDIST_INCLUDE", "a;b; c")
     monkeypatch.setenv("SKBUILD_SDIST_EXCLUDE", "d;e;f")
@@ -329,6 +331,7 @@ def test_skbuild_settings_envvar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.build_type == "Debug"
     assert settings.cmake.source_dir == Path("a/b/c")
+    assert settings.cmake.fresh
     assert not settings.ninja.make_fallback
     assert settings.logging.level == "DEBUG"
     assert settings.sdist.include == ["a", "b", "c"]
@@ -388,6 +391,7 @@ def test_skbuild_settings_config_settings(
         "cmake.define.b": "2",
         "cmake.build-type": "Debug",
         "cmake.source-dir": "a/b/c",
+        "cmake.fresh": "true",
         "env.SOME_VAR": "some-value",
         "logging.level": "INFO",
         "sdist.include": ["a", "b", "c"],
@@ -437,6 +441,7 @@ def test_skbuild_settings_config_settings(
     assert settings.build.verbose
     assert settings.cmake.build_type == "Debug"
     assert settings.cmake.source_dir == Path("a/b/c")
+    assert settings.cmake.fresh
     assert settings.env == {"SOME_VAR": EnvValue("some-value")}
     assert settings.logging.level == "INFO"
     assert settings.sdist.include == ["a", "b", "c"]
@@ -492,6 +497,7 @@ def test_skbuild_settings_pyproject_toml(
             cmake.define = {a = "1", b = "2"}
             cmake.build-type = "Debug"
             cmake.source-dir = "a/b/c"
+            cmake.fresh = true
             logging.level = "ERROR"
             sdist.include = ["a", "b", "c"]
             sdist.exclude = ["d", "e", "f"]
@@ -546,6 +552,7 @@ def test_skbuild_settings_pyproject_toml(
     assert settings.cmake.define == {"a": "1", "b": "2"}
     assert settings.cmake.build_type == "Debug"
     assert settings.cmake.source_dir == Path("a/b/c")
+    assert settings.cmake.fresh
     assert settings.logging.level == "ERROR"
     assert settings.sdist.include == ["a", "b", "c"]
     assert settings.sdist.exclude == ["d", "e", "f"]


### PR DESCRIPTION
Based on some code I saw in PyTorch, and I think this combines nicely with #1489, as then you could make your own `-Cpkg.clear` setting if you wanted to.

:robot: _AI text below_ :robot:

Adds a `cmake.fresh` setting that discards any cached CMake configuration and configures from scratch, like `cmake --fresh`. It reuses the existing stale-cache clearing in `CMaker` (removing `CMakeCache.txt` and `CMakeFiles/`) rather than passing `--fresh`, which avoids the CMake 3.24+ requirement and extra FetchContent pulls on 3.30+.

It works statically in `pyproject.toml`, as a config-setting (`-Ccmake.fresh=true`), an environment variable (`SKBUILD_CMAKE_FRESH=1`), or in an override, and only matters with a persistent `build-dir`. For multi-build-type wheels, only the primary configure clears; the per-build-type reconfigures reuse the cache they just wrote. The setuptools plugin is unaffected since it already wipes its build temp.