### PR TITLE
fix(fileapi): match CMake's install-rule paths and namelink spelling

### DIFF
--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -7,6 +7,7 @@ __lazy_modules__ = {
     f"{__spec__.parent}.model.cache",
     f"{__spec__.parent}.model.cmakefiles",
     f"{__spec__.parent}.model.codemodel",
+    f"{__spec__.parent}.model.directory",
     f"{__spec__.parent}.model.index",
     f"{__spec__.parent}.model.toolchains",
     "json",
@@ -15,7 +16,7 @@ __lazy_modules__ = {
 import builtins
 import json
 from pathlib import Path
-from typing import Any, Callable, Dict, Type, TypeVar  # noqa: TID251
+from typing import Any, Callable, Dict, Type, TypeVar, Union  # noqa: TID251
 
 import cattr
 import cattr.preconf.json
@@ -23,6 +24,7 @@ import cattr.preconf.json
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
 from .model.codemodel import CodeModel, Target
+from .model.directory import InstallPath
 from .model.index import Index, Reply
 from .model.toolchains import Toolchains
 
@@ -48,6 +50,19 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
         toolchains_v1=cattr.gen.override(rename="toolchains-v1"),
     )
     converter.register_structure_hook(Reply, st_hook)
+
+    ip_hook = cattr.gen.make_dict_structure_fn(
+        InstallPath,
+        converter,
+        from_=cattr.gen.override(rename="from"),
+    )
+    converter.register_structure_hook(InstallPath, ip_hook)
+    converter.register_structure_hook(
+        Union[Path, InstallPath],
+        lambda v, _: (
+            Path(v) if isinstance(v, str) else converter.structure(v, InstallPath)
+        ),
+    )
 
     def from_json_file(with_path: Dict[str, Any], t: Type[T]) -> T:
         # An error reply (e.g. an object kind unsupported by the running CMake)

--- a/src/scikit_build_core/file_api/model/directory.py
+++ b/src/scikit_build_core/file_api/model/directory.py
@@ -6,7 +6,14 @@ from typing import List, Optional, Union
 
 from .common import Paths
 
-__all__ = ["BacktraceGraph", "Directory", "InstallRule", "Node", "Target"]
+__all__ = [
+    "BacktraceGraph",
+    "Directory",
+    "InstallPath",
+    "InstallRule",
+    "Node",
+    "Target",
+]
 
 
 def __dir__() -> List[str]:
@@ -20,18 +27,24 @@ class Target:
 
 
 @dataclasses.dataclass(frozen=True)
+class InstallPath:
+    from_: Path
+    to: Path
+
+
+@dataclasses.dataclass(frozen=True)
 class InstallRule:
     component: str
     type: str
     destination: Optional[Path] = None
-    paths: List[Union[str, Paths]] = dataclasses.field(default_factory=list)
+    paths: List[Union[Path, InstallPath]] = dataclasses.field(default_factory=list)
     isExcludeFromAll: bool = False
     isForAllComponents: bool = False
     isOptional: bool = False
     targetId: Optional[str] = None
     targetIndex: Optional[int] = None
     targetIsImportLibrary: bool = False
-    targetInstallNameLink: Optional[str] = None
+    targetInstallNamelink: Optional[str] = None
     exportName: Optional[str] = None
     exportTargets: List[Target] = dataclasses.field(default_factory=list)
     runtimeDependencySetName: Optional[str] = None

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -83,8 +83,11 @@ class Converter:
 
         # We don't have DataclassInstance exposed in typing yet
         for field in dataclasses.fields(target):  # type: ignore[arg-type]
-            json_field = field.name.replace("_v", "-v").replace(
-                "cmakefiles", "cmakeFiles"
+            # A trailing underscore escapes a reserved word, like "from_"
+            json_field = (
+                field.name.rstrip("_")
+                .replace("_v", "-v")
+                .replace("cmakefiles", "cmakeFiles")
             )
             if json_field in data:
                 field_type = field.type

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import sysconfig
 from pathlib import Path
-from typing import List, Union
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -13,8 +12,11 @@ from scikit_build_core.cmake import CMake, CMaker
 from scikit_build_core.file_api._cattrs_converter import (
     load_reply_dir as load_reply_dir_cattrs,
 )
+from scikit_build_core.file_api._cattrs_converter import (
+    make_converter,
+)
 from scikit_build_core.file_api.model.codemodel import Link
-from scikit_build_core.file_api.model.common import Paths
+from scikit_build_core.file_api.model.directory import InstallPath, InstallRule
 from scikit_build_core.file_api.query import stateless_query
 from scikit_build_core.file_api.reply import Converter, load_reply_dir
 
@@ -57,19 +59,34 @@ def test_cattrs_comparison(tmp_path):
     assert index == cattrs_index
 
 
-def test_convert_union_matches_shape():
-    # ``InstallRule.paths`` is a ``List[Union[str, Paths]]``. A bare string must
-    # stay a string, while a mapping must be converted to the dataclass member
-    # (``str(<dict>)`` would otherwise succeed and shadow ``Paths``).
-    converter = Converter(Path())
-    result = converter._convert_any(
-        ["a/string", {"source": "src/dir", "build": "build/dir"}],
-        List[Union[str, Paths]],
+def test_convert_install_rule():
+    # ``InstallRule.paths`` entries are strings or ``{"from", "to"}`` objects
+    # (e.g. ``install(FILES ... RENAME)``). A bare string must become a Path,
+    # while a mapping must be converted to the dataclass member
+    # (``Path(<dict>)`` would otherwise be tried and shadow ``InstallPath``).
+    data = {
+        "component": "Unspecified",
+        "type": "file",
+        "destination": "include",
+        "paths": ["a/string", {"from": "src/file.h", "to": "renamed.h"}],
+        "targetInstallNamelink": "skip",
+    }
+    expected = InstallRule(
+        component="Unspecified",
+        type="file",
+        destination=Path("include"),
+        paths=[
+            Path("a/string"),
+            InstallPath(from_=Path("src/file.h"), to=Path("renamed.h")),
+        ],
+        targetInstallNamelink="skip",
     )
-    assert result == [
-        "a/string",
-        Paths(source=Path("src/dir"), build=Path("build/dir")),
-    ]
+
+    converter = Converter(Path())
+    assert converter._convert_any(data, InstallRule) == expected
+
+    cattrs_converter = make_converter(Path())
+    assert cattrs_converter.structure(data, InstallRule) == expected
 
 
 def test_link_without_command_fragments():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1519.

Two `InstallRule` fields in `file_api/model/directory.py` didn't match the CMake file-api spec (confirmed against `cmake-file-api(7)` and CMake's `schema_directory.json`):

- The `paths` object form is `{"from", "to"}` (emitted e.g. for `install(FILES ... RENAME)`), not the `{"source", "build"}` `Paths` pair. Such an entry previously failed to convert. Added an `InstallPath` model; the reserved word `from` is stored as `from_`, and the built-in converter now strips a trailing underscore when mapping field names.
- `targetInstallNameLink` is spelled `targetInstallNamelink` in the JSON, so it was always `None`. Renamed.

The cattrs comparison converter gets matching hooks. The old `test_convert_union_matches_shape` test encoded the wrong shape; it's replaced by a regression test that checks both converters against the spec shape (fails before the fix).

Both bugs were latent: directory objects are not auto-resolved by the reply loader, but the models are public parsing API.