### PR TITLE
feat(fileapi): complete the file-api models and keep reference data

### DIFF
--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -23,7 +23,7 @@ import cattr.preconf.json
 
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
-from .model.codemodel import CodeModel, Target
+from .model.codemodel import CodeModel, Directory, Target
 from .model.directory import InstallPath
 from .model.index import Index, Reply
 from .model.toolchains import Toolchains
@@ -72,6 +72,9 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
             return converter.structure_attrs_fromdict(with_path, t)
         path = base_dir / Path(with_path["jsonFile"])
         raw = json.loads(path.read_text(encoding="utf-8"))
+        # Keep members only present on the reference, like directoryIndex and
+        # projectIndex on codemodel target entries
+        raw.update(with_path)
         return converter.structure_attrs_fromdict(raw, t)
 
     converter.register_structure_hook(CodeModel, from_json_file)
@@ -79,6 +82,7 @@ def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
     converter.register_structure_hook(Cache, from_json_file)
     converter.register_structure_hook(CMakeFiles, from_json_file)
     converter.register_structure_hook(Toolchains, from_json_file)
+    converter.register_structure_hook(Directory, from_json_file)
     return converter
 
 

--- a/src/scikit_build_core/file_api/model/cmakefiles.py
+++ b/src/scikit_build_core/file_api/model/cmakefiles.py
@@ -2,11 +2,11 @@ __lazy_modules__ = {f"{__spec__.parent}.common", "pathlib", "typing"}
 
 import dataclasses
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
-from .common import Paths
+from .common import APIVersion, Paths
 
-__all__ = ["CMakeFiles", "Input"]
+__all__ = ["CMakeFiles", "GlobDependent", "Input"]
 
 
 def __dir__() -> List[str]:
@@ -22,7 +22,19 @@ class Input:
 
 
 @dataclasses.dataclass(frozen=True)
+class GlobDependent:
+    expression: str
+    recurse: bool = False
+    listDirectories: bool = False
+    followSymlinks: bool = False
+    relative: Optional[str] = None
+    paths: List[Path] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
 class CMakeFiles:
     kind: str
+    version: APIVersion
     paths: Paths
     inputs: List[Input]
+    globsDependent: List[GlobDependent] = dataclasses.field(default_factory=list)

--- a/src/scikit_build_core/file_api/model/codemodel.py
+++ b/src/scikit_build_core/file_api/model/codemodel.py
@@ -1,25 +1,45 @@
-__lazy_modules__ = {f"{__spec__.parent}.common", "pathlib", "typing"}
+__lazy_modules__ = {
+    f"{__spec__.parent}.common",
+    f"{__spec__.parent}.directory",
+    "pathlib",
+    "typing",
+}
 
 import dataclasses
 from pathlib import Path
 from typing import List, Optional
 
 from .common import APIVersion, Paths
+from .directory import BacktraceGraph, InstallRule
 
 __all__ = [
     "Archive",
     "Artifact",
     "CodeModel",
     "CommandFragment",
+    "CompileCommandFragment",
+    "CompileDependency",
+    "CompileGroup",
     "Configuration",
+    "Debugger",
+    "Define",
     "Dependency",
     "Destination",
     "Directory",
+    "FileSet",
+    "Folder",
+    "FromDependency",
+    "Include",
     "Install",
+    "LanguageStandard",
+    "Launcher",
     "Link",
+    "LinkLibrary",
+    "PrecompileHeader",
     "Prefix",
     "Project",
     "Source",
+    "SourceGroup",
     "StringCMakeVersion",
     "Sysroot",
     "Target",
@@ -44,11 +64,13 @@ class Directory:
     parentIndex: Optional[int] = None
     childIndexes: List[int] = dataclasses.field(default_factory=list)
     targetIndexes: List[int] = dataclasses.field(default_factory=list)
+    abstractTargetIndexes: List[int] = dataclasses.field(default_factory=list)
     minimumCMakeVersion: Optional[StringCMakeVersion] = None
     hasInstallRule: bool = False
-
-
-# Directory is currently not resolved automatically.
+    # From the "directory" object loaded via jsonFile:
+    installers: List[InstallRule] = dataclasses.field(default_factory=list)
+    backtraceGraph: Optional[BacktraceGraph] = None
+    codemodelVersion: Optional[APIVersion] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -58,6 +80,7 @@ class Project:
     parentIndex: Optional[int] = None
     childIndexes: List[int] = dataclasses.field(default_factory=list)
     targetIndexes: List[int] = dataclasses.field(default_factory=list)
+    abstractTargetIndexes: List[int] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -118,12 +141,114 @@ class Dependency:
 
 
 @dataclasses.dataclass(frozen=True)
+class FromDependency:
+    id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class LinkLibrary:
+    # Exactly one of id or fragment is present
+    id: Optional[str] = None
+    fragment: Optional[str] = None
+    backtrace: Optional[int] = None
+    fromDependency: Optional[FromDependency] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class CompileDependency:
+    id: str
+    backtrace: Optional[int] = None
+    fromDependency: Optional[FromDependency] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Folder:
+    name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class Launcher:
+    command: Path
+    type: str
+    arguments: List[str] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class Debugger:
+    workingDirectory: Optional[Path] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class FileSet:
+    name: str
+    type: str
+    visibility: str
+    baseDirectories: List[Path] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class SourceGroup:
+    name: str
+    sourceIndexes: List[int] = dataclasses.field(default_factory=list)
+    interfaceSourceIndexes: List[int] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class LanguageStandard:
+    standard: str
+    backtraces: List[int] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class CompileCommandFragment:
+    fragment: str
+    backtrace: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Include:
+    path: Path
+    isSystem: Optional[bool] = None
+    backtrace: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class PrecompileHeader:
+    header: Path
+    backtrace: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Define:
+    define: str
+    backtrace: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class CompileGroup:
+    sourceIndexes: List[int]
+    language: str
+    languageStandard: Optional[LanguageStandard] = None
+    compileCommandFragments: List[CompileCommandFragment] = dataclasses.field(
+        default_factory=list
+    )
+    includes: List[Include] = dataclasses.field(default_factory=list)
+    frameworks: List[Include] = dataclasses.field(default_factory=list)
+    precompileHeaders: List[PrecompileHeader] = dataclasses.field(default_factory=list)
+    defines: List[Define] = dataclasses.field(default_factory=list)
+    sysroot: Optional[Sysroot] = None
+
+
+@dataclasses.dataclass(frozen=True)
 class Source:
     path: Path
     compileGroupIndex: Optional[int] = None
     sourceGroupIndex: Optional[int] = None
     isGenerated: Optional[bool] = None
+    fileSetIndex: Optional[int] = None
+    fileSetIndexes: List[int] = dataclasses.field(default_factory=list)
     backtrace: Optional[int] = None
+    backtraces: List[int] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -140,6 +265,33 @@ class Target:
     link: Optional[Link] = None
     archive: Optional[Archive] = None
     dependencies: List[Dependency] = dataclasses.field(default_factory=list)
+    backtrace: Optional[int] = None
+    folder: Optional[Folder] = None
+    launchers: List[Launcher] = dataclasses.field(default_factory=list)
+    debugger: Optional[Debugger] = None
+    imported: Optional[bool] = None
+    local: Optional[bool] = None
+    abstract: Optional[bool] = None
+    symbolic: Optional[bool] = None
+    linkLibraries: List[LinkLibrary] = dataclasses.field(default_factory=list)
+    interfaceLinkLibraries: List[LinkLibrary] = dataclasses.field(default_factory=list)
+    compileDependencies: List[CompileDependency] = dataclasses.field(
+        default_factory=list
+    )
+    interfaceCompileDependencies: List[CompileDependency] = dataclasses.field(
+        default_factory=list
+    )
+    objectDependencies: List[Dependency] = dataclasses.field(default_factory=list)
+    orderDependencies: List[Dependency] = dataclasses.field(default_factory=list)
+    fileSets: List[FileSet] = dataclasses.field(default_factory=list)
+    interfaceSources: List[Source] = dataclasses.field(default_factory=list)
+    sourceGroups: List[SourceGroup] = dataclasses.field(default_factory=list)
+    compileGroups: List[CompileGroup] = dataclasses.field(default_factory=list)
+    backtraceGraph: Optional[BacktraceGraph] = None
+    codemodelVersion: Optional[APIVersion] = None
+    # From the codemodel reference to this target:
+    directoryIndex: Optional[int] = None
+    projectIndex: Optional[int] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -148,6 +300,7 @@ class Configuration:
     projects: List[Project]
     targets: List[Target]
     directories: List[Directory]
+    abstractTargets: List[Target] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/scikit_build_core/file_api/model/directory.py
+++ b/src/scikit_build_core/file_api/model/directory.py
@@ -4,7 +4,7 @@ import dataclasses
 from pathlib import Path
 from typing import List, Optional, Union
 
-from .common import Paths
+from .common import APIVersion, Paths
 
 __all__ = [
     "BacktraceGraph",
@@ -53,6 +53,7 @@ class InstallRule:
     fileSetType: Optional[str] = None
     fileSetDirectories: List[Path] = dataclasses.field(default_factory=list)
     fileSetTarget: Optional[Target] = None
+    cxxModuleBmiTarget: Optional[Target] = None
     scriptFile: Optional[Path] = None
     backtrace: Optional[int] = None
 
@@ -77,3 +78,4 @@ class Directory:
     paths: Paths
     installers: List[InstallRule]
     backtraceGraph: BacktraceGraph
+    codemodelVersion: Optional[APIVersion] = None

--- a/src/scikit_build_core/file_api/model/toolchains.py
+++ b/src/scikit_build_core/file_api/model/toolchains.py
@@ -25,6 +25,7 @@ class Implicit:
 class Compiler:
     implicit: Implicit
     path: Optional[Path] = None
+    commandFragment: Optional[str] = None
     id: Optional[str] = None
     version: Optional[str] = None
     target: Optional[str] = None

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -31,7 +31,7 @@ from ..utils.typing import (
 )
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
-from .model.codemodel import CodeModel, Target
+from .model.codemodel import CodeModel, Directory, Target
 from .model.index import Index
 from .model.toolchains import Toolchains
 
@@ -61,22 +61,19 @@ class Converter:
 
         return self.make_class(data, Index)
 
-    def _load_from_json(self, name: Path, target: Type[T]) -> T:
-        with self.base_dir.joinpath(name).open(encoding="utf-8") as f:
-            data = json.load(f)
-
-        return self.make_class(data, target)
-
     def make_class(self, data: InputDict, target: Type[T]) -> T:
         """
         Convert a dict to a dataclass. Automatically load a few nested jsonFile classes.
         """
         if (
-            target in {CodeModel, Target, Cache, CMakeFiles, Toolchains}
-            and "jsonFile" in data
-            and data["jsonFile"] is not None
+            target in {CodeModel, Target, Cache, CMakeFiles, Toolchains, Directory}
+            and data.get("jsonFile") is not None
         ):
-            return self._load_from_json(Path(data["jsonFile"]), target)
+            with self.base_dir.joinpath(data["jsonFile"]).open(encoding="utf-8") as f:
+                file_data: InputDict = json.load(f)
+            # Keep members only present on the reference, like directoryIndex
+            # and projectIndex on codemodel target entries
+            data = {**file_data, **data}
 
         input_dict: Dict[str, Type[Any]] = {}
         exceptions: List[Exception] = []

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -15,7 +15,28 @@ from scikit_build_core.file_api._cattrs_converter import (
 from scikit_build_core.file_api._cattrs_converter import (
     make_converter,
 )
-from scikit_build_core.file_api.model.codemodel import Link
+from scikit_build_core.file_api.model.codemodel import (
+    CompileCommandFragment,
+    CompileDependency,
+    CompileGroup,
+    Debugger,
+    Define,
+    Dependency,
+    FileSet,
+    Folder,
+    FromDependency,
+    Include,
+    LanguageStandard,
+    Launcher,
+    Link,
+    LinkLibrary,
+    PrecompileHeader,
+    Source,
+    SourceGroup,
+    Sysroot,
+    Target,
+)
+from scikit_build_core.file_api.model.common import APIVersion
 from scikit_build_core.file_api.model.directory import InstallPath, InstallRule
 from scikit_build_core.file_api.query import stateless_query
 from scikit_build_core.file_api.reply import Converter, load_reply_dir
@@ -89,6 +110,97 @@ def test_convert_install_rule():
     assert cattrs_converter.structure(data, InstallRule) == expected
 
 
+def test_convert_compile_group():
+    converter = Converter(Path())
+    data = {
+        "sourceIndexes": [0],
+        "language": "CXX",
+        "languageStandard": {"backtraces": [3], "standard": "17"},
+        "compileCommandFragments": [{"fragment": "-fvisibility=hidden"}],
+        "includes": [{"path": "/usr/include/python3.13", "isSystem": True}],
+        "frameworks": [{"path": "/Library/Frameworks"}],
+        "precompileHeaders": [{"header": "pch.hpp", "backtrace": 1}],
+        "defines": [{"define": "VERSION=1", "backtrace": 2}],
+        "sysroot": {"path": "/sdk"},
+    }
+    assert converter._convert_any(data, CompileGroup) == CompileGroup(
+        sourceIndexes=[0],
+        language="CXX",
+        languageStandard=LanguageStandard(standard="17", backtraces=[3]),
+        compileCommandFragments=[
+            CompileCommandFragment(fragment="-fvisibility=hidden")
+        ],
+        includes=[Include(path=Path("/usr/include/python3.13"), isSystem=True)],
+        frameworks=[Include(path=Path("/Library/Frameworks"))],
+        precompileHeaders=[PrecompileHeader(header=Path("pch.hpp"), backtrace=1)],
+        defines=[Define(define="VERSION=1", backtrace=2)],
+        sysroot=Sysroot(path=Path("/sdk")),
+    )
+
+
+def test_convert_target_relationships():
+    converter = Converter(Path())
+    data = {
+        "name": "mylib",
+        "id": "mylib::@1",
+        "type": "SHARED_LIBRARY",
+        "paths": {"source": ".", "build": "."},
+        "folder": {"name": "libs"},
+        "launchers": [{"command": "emu", "arguments": ["-t"], "type": "emulator"}],
+        "debugger": {"workingDirectory": "/wd"},
+        "imported": True,
+        "linkLibraries": [
+            {"id": "dep::@1", "backtrace": 1},
+            {"fragment": "-lm"},
+            {"id": "extra::@2", "fromDependency": {"id": "dep::@1"}},
+        ],
+        "interfaceLinkLibraries": [{"id": "dep::@1"}],
+        "compileDependencies": [{"id": "dep::@1", "fromDependency": {"id": "x::@9"}}],
+        "orderDependencies": [{"id": "other::@3", "backtrace": 2}],
+        "objectDependencies": [{"id": "objs::@4"}],
+        "fileSets": [
+            {
+                "name": "HEADERS",
+                "type": "HEADERS",
+                "visibility": "PUBLIC",
+                "baseDirectories": ["include"],
+            }
+        ],
+        "sources": [{"path": "a.cpp", "fileSetIndexes": [0], "backtraces": [1]}],
+        "codemodelVersion": {"major": 2, "minor": 9},
+    }
+    target = converter._convert_any(data, Target)
+    assert target.folder == Folder(name="libs")
+    assert target.launchers == [
+        Launcher(command=Path("emu"), arguments=["-t"], type="emulator")
+    ]
+    assert target.debugger == Debugger(workingDirectory=Path("/wd"))
+    assert target.imported is True
+    assert target.linkLibraries == [
+        LinkLibrary(id="dep::@1", backtrace=1),
+        LinkLibrary(fragment="-lm"),
+        LinkLibrary(id="extra::@2", fromDependency=FromDependency(id="dep::@1")),
+    ]
+    assert target.interfaceLinkLibraries == [LinkLibrary(id="dep::@1")]
+    assert target.compileDependencies == [
+        CompileDependency(id="dep::@1", fromDependency=FromDependency(id="x::@9"))
+    ]
+    assert target.orderDependencies == [Dependency(id="other::@3", backtrace=2)]
+    assert target.objectDependencies == [Dependency(id="objs::@4")]
+    assert target.fileSets == [
+        FileSet(
+            name="HEADERS",
+            type="HEADERS",
+            visibility="PUBLIC",
+            baseDirectories=[Path("include")],
+        )
+    ]
+    assert target.sources == [
+        Source(path=Path("a.cpp"), fileSetIndexes=[0], backtraces=[1])
+    ]
+    assert target.codemodelVersion == APIVersion(2, 9)
+
+
 def test_link_without_command_fragments():
     # ``commandFragments`` is optional per the CMake File API spec; a link
     # object omitting it must still structure rather than failing conversion.
@@ -152,11 +264,45 @@ def test_included_dir():
     assert codemodel.version.minor == 4
     assert not codemodel.configurations[0].name
 
+    # Reference-only members must be kept when following jsonFile
+    (target,) = codemodel.configurations[0].targets
+    assert target.directoryIndex == 0
+    assert target.projectIndex == 0
+    assert target.type == "EXECUTABLE"
+    assert target.backtrace == 1
+    assert target.sourceGroups == [SourceGroup(name="Source Files", sourceIndexes=[0])]
+    (compile_group,) = target.compileGroups
+    assert compile_group.language == "CXX"
+    assert compile_group.languageStandard == LanguageStandard(
+        standard="17", backtraces=[3]
+    )
+    assert target.backtraceGraph is not None
+    assert target.backtraceGraph.commands == [
+        "add_executable",
+        "install",
+        "target_compile_features",
+    ]
+
+    # The directory object must be followed and merged with its reference
+    (directory,) = codemodel.configurations[0].directories
+    assert directory.jsonFile is not None
+    assert directory.hasInstallRule
+    (installer,) = directory.installers
+    assert installer.component == "Unspecified"
+    assert installer.type == "target"
+    assert installer.destination == Path("bin")
+    assert installer.targetIndex == 0
+    assert installer.paths == [Path("simple_pure")]
+    assert installer.backtrace == 1
+    assert directory.backtraceGraph is not None
+    assert directory.backtraceGraph.commands == ["install"]
+
     cache = index.reply.cache_v2
     assert cache is not None
 
     cmakefiles = index.reply.cmakefiles_v1
     assert cmakefiles is not None
+    assert cmakefiles.version == APIVersion(1, 0)
 
     toolchains = index.reply.toolchains_v1
     assert toolchains is not None
@@ -171,7 +317,6 @@ def test_included_dir():
     assert toolchain.sourceFileExtensions
     assert toolchain.compiler.implicit.includeDirectories
 
-    # The cattrs-based converter must load the same toolchain content.
+    # The cattrs-based converter must load the same content.
     cattrs_index = load_reply_dir_cattrs(reply_dir)
-    assert cattrs_index.reply.toolchains_v1 is not None
-    assert cattrs_index.reply.toolchains_v1.toolchains == toolchains.toolchains
+    assert cattrs_index == index


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1519. Stacked on #1520 (retargets to `main` when that merges).

Covers the "dropped information" and "missing fields" sections of the review:

**Dropped information, now kept**
- Following a `jsonFile` reference now merges the reference members into the loaded object instead of discarding them, so codemodel target entries keep `directoryIndex`/`projectIndex` (new `Target` fields).
- Codemodel directory objects are now resolved (they previously never were), so `install` rules, their backtraces, and `codemodelVersion` are reachable from the codemodel. `CMakeFiles` gains its `version`, like every other object kind.

**Missing fields added** (all documented in `cmake-file-api(7)` for the four kinds we query)
- codemodel target: `compileGroups` (includes, defines, fragments, language standard, frameworks, precompiled headers, sysroot), `sourceGroups`, `backtraceGraph`, `backtrace`, `folder`, `fileSets` (2.5), `launchers` (2.7), `debugger` (2.8), the 2.9 relationship arrays (`linkLibraries`, `interfaceLinkLibraries`, `compileDependencies`, `interfaceCompileDependencies`, `objectDependencies`, `orderDependencies`) and flags (`imported`/`local`/`abstract`/`symbolic`), `interfaceSources` (2.10), and `Source.fileSetIndex(es)`/`backtraces` (2.11)
- codemodel: `abstractTargets` and `abstractTargetIndexes` (2.9)
- install rules: `cxxModuleBmiTarget` (2.5)
- cmakeFiles: `globsDependent` (1.1)
- toolchains: `compiler.commandFragment` (1.1)

Both converters get the same merge behavior; `test_included_dir` now asserts full equality between them, and the live `test_cattrs_comparison` exercises a real CMake 4.4 (codemodel 2.11) reply. `configureLog` and the 4.1 error index are left for a possible follow-up since they are new queries, not missing fields.