### PR TITLE
feat(cli): list supported config-settings

### DIFF
--- a/docs/man.md
+++ b/docs/man.md
@@ -26,8 +26,7 @@ for inspecting the build environment:
 - **scikit-build builder sysconfig** -- show information from sysconfig.
 - **scikit-build file-api query** -- request the CMake file API.
 - **scikit-build file-api reply** -- process the CMake file API.
-- **scikit-build settings config-settings** -- list the supported
-  config-settings.
+- **scikit-build settings list** -- list the supported config-settings.
 - **scikit-build init** -- generate a starter project for a binding backend.
 
 See the CLI reference for the full set of options.

--- a/docs/man.md
+++ b/docs/man.md
@@ -26,6 +26,8 @@ for inspecting the build environment:
 - **scikit-build builder sysconfig** -- show information from sysconfig.
 - **scikit-build file-api query** -- request the CMake file API.
 - **scikit-build file-api reply** -- process the CMake file API.
+- **scikit-build settings config-settings** -- list the supported
+  config-settings.
 - **scikit-build init** -- generate a starter project for a binding backend.
 
 See the CLI reference for the full set of options.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,6 +42,16 @@ Example:
 
 ```
 
+### Config-settings
+
+Lists the config-settings the current project accepts: the built-in
+scikit-build-core settings plus any the project declares in
+`tool.scikit-build.config-setting`.
+
+```{program-output} scikit-build build config-settings --help
+
+```
+
 ## Building environment info
 
 ```{program-output} scikit-build builder --help

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -94,7 +94,7 @@ Lists the config-settings the current project accepts: the built-in
 scikit-build-core settings plus any the project declares in
 `tool.scikit-build.config-setting`.
 
-```{program-output} scikit-build settings config-settings --help
+```{program-output} scikit-build settings list --help
 
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,16 +42,6 @@ Example:
 
 ```
 
-### Config-settings
-
-Lists the config-settings the current project accepts: the built-in
-scikit-build-core settings plus any the project declares in
-`tool.scikit-build.config-setting`.
-
-```{program-output} scikit-build build config-settings --help
-
-```
-
 ## Building environment info
 
 ```{program-output} scikit-build builder --help
@@ -89,6 +79,22 @@ Example:
 ```
 
 ```{program-output} scikit-build file-api reply --help
+
+```
+
+## Settings tools
+
+```{program-output} scikit-build settings --help
+
+```
+
+### Config-settings
+
+Lists the config-settings the current project accepts: the built-in
+scikit-build-core settings plus any the project declares in
+`tool.scikit-build.config-setting`.
+
+```{program-output} scikit-build settings config-settings --help
 
 ```
 

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -23,6 +23,9 @@ def main_info(_args: argparse.Namespace | None = None, /) -> None:
     rich_print(
         "  scikit-build build project-table   {green}Get the project table (with dynamic metadata)"
     )
+    rich_print(
+        "  scikit-build build config-settings {green}List the supported config-settings"
+    )
     rich_print("  scikit-build builder               {green}Info about the system")
     rich_print(
         "  scikit-build builder wheel-tag     {green}Info about the computed wheel tag"

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -19,24 +19,20 @@ def __dir__() -> list[str]:
 
 def main_info(_args: argparse.Namespace | None = None, /) -> None:
     rich_print("{blue}The scikit-build-core CLI provides the following commands:")
+    rich_print("  scikit-build build requires      {green}Get the build requirements")
     rich_print(
-        "  scikit-build build requires           {green}Get the build requirements"
+        "  scikit-build build project-table {green}Get the project table (with dynamic metadata)"
     )
+    rich_print("  scikit-build builder             {green}Info about the system")
     rich_print(
-        "  scikit-build build project-table      {green}Get the project table (with dynamic metadata)"
+        "  scikit-build builder wheel-tag   {green}Info about the computed wheel tag"
     )
-    rich_print("  scikit-build builder                  {green}Info about the system")
+    rich_print("  scikit-build builder sysconfig   {green}Info from sysconfig")
+    rich_print("  scikit-build file-api query      {green}Request CMake file API")
+    rich_print("  scikit-build file-api reply      {green}Process CMake file API")
+    rich_print("  scikit-build init                {green}Generate a starter project")
     rich_print(
-        "  scikit-build builder wheel-tag        {green}Info about the computed wheel tag"
-    )
-    rich_print("  scikit-build builder sysconfig        {green}Info from sysconfig")
-    rich_print("  scikit-build file-api query           {green}Request CMake file API")
-    rich_print("  scikit-build file-api reply           {green}Process CMake file API")
-    rich_print(
-        "  scikit-build init                     {green}Generate a starter project"
-    )
-    rich_print(
-        "  scikit-build settings config-settings {green}List the supported config-settings"
+        "  scikit-build settings list       {green}List the supported config-settings"
     )
     rich_print()
 

--- a/src/scikit_build_core/__main__.py
+++ b/src/scikit_build_core/__main__.py
@@ -19,21 +19,25 @@ def __dir__() -> list[str]:
 
 def main_info(_args: argparse.Namespace | None = None, /) -> None:
     rich_print("{blue}The scikit-build-core CLI provides the following commands:")
-    rich_print("  scikit-build build requires        {green}Get the build requirements")
     rich_print(
-        "  scikit-build build project-table   {green}Get the project table (with dynamic metadata)"
+        "  scikit-build build requires           {green}Get the build requirements"
     )
     rich_print(
-        "  scikit-build build config-settings {green}List the supported config-settings"
+        "  scikit-build build project-table      {green}Get the project table (with dynamic metadata)"
     )
-    rich_print("  scikit-build builder               {green}Info about the system")
+    rich_print("  scikit-build builder                  {green}Info about the system")
     rich_print(
-        "  scikit-build builder wheel-tag     {green}Info about the computed wheel tag"
+        "  scikit-build builder wheel-tag        {green}Info about the computed wheel tag"
     )
-    rich_print("  scikit-build builder sysconfig     {green}Info from sysconfig")
-    rich_print("  scikit-build file-api query        {green}Request CMake file API")
-    rich_print("  scikit-build file-api reply        {green}Process CMake file API")
-    rich_print("  scikit-build init                  {green}Generate a starter project")
+    rich_print("  scikit-build builder sysconfig        {green}Info from sysconfig")
+    rich_print("  scikit-build file-api query           {green}Request CMake file API")
+    rich_print("  scikit-build file-api reply           {green}Process CMake file API")
+    rich_print(
+        "  scikit-build init                     {green}Generate a starter project"
+    )
+    rich_print(
+        "  scikit-build settings config-settings {green}List the supported config-settings"
+    )
     rich_print()
 
 
@@ -42,6 +46,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     from .builder import __main__ as builder_main
     from .file_api import __main__ as file_api_main
     from .init import __main__ as init_main
+    from .settings import __main__ as settings_main
 
     parser = argparse.ArgumentParser(
         prog="scikit-build",
@@ -82,6 +87,14 @@ def main(argv: Sequence[str] | None = None) -> None:
         allow_abbrev=False,
     )
     init_main.populate_parser(init_parser)
+
+    settings_parser = subparsers.add_parser(
+        "settings",
+        help="Settings utilities",
+        description="Settings utilities.",
+        allow_abbrev=False,
+    )
+    settings_main.populate_parser(settings_parser)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -8,6 +8,10 @@ __lazy_modules__ = {
     "scikit_build_core._logging",
     "scikit_build_core.builder",
     "scikit_build_core.builder._load_provider",
+    "scikit_build_core.settings",
+    "scikit_build_core.settings.config_settings",
+    "scikit_build_core.settings.documentation",
+    "scikit_build_core.settings.skbuild_model",
     "typing",
 }
 
@@ -17,7 +21,7 @@ from pathlib import Path
 from typing import Any, Literal, get_args
 
 from scikit_build_core._compat import tomllib
-from scikit_build_core._logging import rich_error, rich_warning
+from scikit_build_core._logging import rich_error, rich_print, rich_warning
 from scikit_build_core.build import (
     get_requires_for_build_editable,
     get_requires_for_build_sdist,
@@ -28,6 +32,9 @@ from scikit_build_core.builder._load_provider import (
     process_dynamic_metadata,
     process_legacy_dynamic_metadata,
 )
+from scikit_build_core.settings.config_settings import load_declarations
+from scikit_build_core.settings.documentation import mk_docs
+from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
 
 
 def _load_pyproject() -> dict[str, Any]:
@@ -77,6 +84,61 @@ def get_requires(mode: Literal["sdist", "wheel", "editable"]) -> None:
     print(json.dumps(sorted(set(requires)), indent=2))
 
 
+def _brace_escape(text: str) -> str:
+    """Escape braces so ``rich_print`` doesn't treat them as format fields."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
+def main_config_settings(_args: argparse.Namespace, /) -> None:
+    """List the config-settings supported when building the project."""
+    pyproject = _load_pyproject()
+    backend = pyproject.get("build-system", {}).get("build-backend", "")
+    if backend != "scikit_build_core.build":
+        rich_warning("Might not be a scikit-build-core project.")
+
+    rich_print(
+        "{blue}Config-settings supported when building this project"
+        " (pass with {bold}-C{normal}{blue}name=value):"
+    )
+    rich_print()
+
+    decls = load_declarations(
+        pyproject.get("tool", {}).get("scikit-build", {}).get("config-setting", {})
+    )
+    if decls:
+        rich_print(
+            "{bold}Project config-settings{normal} (tool.scikit-build.config-setting):"
+        )
+        width = max(len(name) for name in decls)
+        for name, decl in decls.items():
+            notes: list[str] = [decl.type]
+            if decl.env is not None:
+                notes.append(f"env: {decl.env}")
+            if decl.default is not None:
+                notes.append(f"default: {json.dumps(decl.default)}")
+            rich_print(
+                f"  {{green}}{name:{width}}{{default}}  {_brace_escape(decl.help)}"
+                f" {{yellow}}[{_brace_escape(', '.join(notes))}]"
+            )
+        rich_print()
+
+    items = [
+        item
+        for item in mk_docs(ScikitBuildSettings)
+        if not item.deprecated and item.flat_expressible()
+    ]
+    rich_print(
+        "{bold}Built-in config-settings{normal} (a 'skbuild.' prefix also works):"
+    )
+    width = max(len(item.name) for item in items)
+    for item in items:
+        summary = item.docs.split("\n", maxsplit=1)[0]
+        rich_print(
+            f"  {{green}}{item.name:{width}}{{default}}  {_brace_escape(summary)}"
+            f" {{yellow}}[{_brace_escape(item.type)}]"
+        )
+
+
 def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     """Add the ``build`` subcommands to an existing parser."""
     subparsers = parser.add_subparsers(required=True, help="Commands")
@@ -105,6 +167,13 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
         default="metadata_wheel",
         help="The build state reported to [[tool.dynamic-metadata]] providers",
     )
+
+    config_settings = subparsers.add_parser(
+        "config-settings",
+        help="List the config-settings supported when building this project",
+        description="Lists the built-in scikit-build-core settings and any config-settings the project declares in tool.scikit-build.config-setting.",
+    )
+    config_settings.set_defaults(func=main_config_settings)
 
 
 def main() -> None:

--- a/src/scikit_build_core/build/__main__.py
+++ b/src/scikit_build_core/build/__main__.py
@@ -3,25 +3,19 @@ from __future__ import annotations
 __lazy_modules__ = {
     "argparse",
     "json",
-    "pathlib",
-    "scikit_build_core._compat",
     "scikit_build_core._logging",
     "scikit_build_core.builder",
     "scikit_build_core.builder._load_provider",
     "scikit_build_core.settings",
-    "scikit_build_core.settings.config_settings",
-    "scikit_build_core.settings.documentation",
-    "scikit_build_core.settings.skbuild_model",
+    "scikit_build_core.settings.__main__",
     "typing",
 }
 
 import argparse
 import json
-from pathlib import Path
-from typing import Any, Literal, get_args
+from typing import Literal, get_args
 
-from scikit_build_core._compat import tomllib
-from scikit_build_core._logging import rich_error, rich_print, rich_warning
+from scikit_build_core._logging import rich_warning
 from scikit_build_core.build import (
     get_requires_for_build_editable,
     get_requires_for_build_sdist,
@@ -32,20 +26,7 @@ from scikit_build_core.builder._load_provider import (
     process_dynamic_metadata,
     process_legacy_dynamic_metadata,
 )
-from scikit_build_core.settings.config_settings import load_declarations
-from scikit_build_core.settings.documentation import mk_docs
-from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
-
-
-def _load_pyproject() -> dict[str, Any]:
-    """Read ``pyproject.toml`` from the current directory, erroring out clearly if missing."""
-    path = Path("pyproject.toml")
-    if not path.is_file():
-        rich_error(
-            "No {bold}pyproject.toml{normal} found in the current directory; run this from the root of a project."
-        )
-    with path.open("rb") as f:
-        return tomllib.load(f)
+from scikit_build_core.settings.__main__ import _load_pyproject
 
 
 def main_project_table(args: argparse.Namespace, /) -> None:
@@ -84,61 +65,6 @@ def get_requires(mode: Literal["sdist", "wheel", "editable"]) -> None:
     print(json.dumps(sorted(set(requires)), indent=2))
 
 
-def _brace_escape(text: str) -> str:
-    """Escape braces so ``rich_print`` doesn't treat them as format fields."""
-    return text.replace("{", "{{").replace("}", "}}")
-
-
-def main_config_settings(_args: argparse.Namespace, /) -> None:
-    """List the config-settings supported when building the project."""
-    pyproject = _load_pyproject()
-    backend = pyproject.get("build-system", {}).get("build-backend", "")
-    if backend != "scikit_build_core.build":
-        rich_warning("Might not be a scikit-build-core project.")
-
-    rich_print(
-        "{blue}Config-settings supported when building this project"
-        " (pass with {bold}-C{normal}{blue}name=value):"
-    )
-    rich_print()
-
-    decls = load_declarations(
-        pyproject.get("tool", {}).get("scikit-build", {}).get("config-setting", {})
-    )
-    if decls:
-        rich_print(
-            "{bold}Project config-settings{normal} (tool.scikit-build.config-setting):"
-        )
-        width = max(len(name) for name in decls)
-        for name, decl in decls.items():
-            notes: list[str] = [decl.type]
-            if decl.env is not None:
-                notes.append(f"env: {decl.env}")
-            if decl.default is not None:
-                notes.append(f"default: {json.dumps(decl.default)}")
-            rich_print(
-                f"  {{green}}{name:{width}}{{default}}  {_brace_escape(decl.help)}"
-                f" {{yellow}}[{_brace_escape(', '.join(notes))}]"
-            )
-        rich_print()
-
-    items = [
-        item
-        for item in mk_docs(ScikitBuildSettings)
-        if not item.deprecated and item.flat_expressible()
-    ]
-    rich_print(
-        "{bold}Built-in config-settings{normal} (a 'skbuild.' prefix also works):"
-    )
-    width = max(len(item.name) for item in items)
-    for item in items:
-        summary = item.docs.split("\n", maxsplit=1)[0]
-        rich_print(
-            f"  {{green}}{item.name:{width}}{{default}}  {_brace_escape(summary)}"
-            f" {{yellow}}[{_brace_escape(item.type)}]"
-        )
-
-
 def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     """Add the ``build`` subcommands to an existing parser."""
     subparsers = parser.add_subparsers(required=True, help="Commands")
@@ -167,13 +93,6 @@ def populate_parser(parser: argparse.ArgumentParser, /) -> None:
         default="metadata_wheel",
         help="The build state reported to [[tool.dynamic-metadata]] providers",
     )
-
-    config_settings = subparsers.add_parser(
-        "config-settings",
-        help="List the config-settings supported when building this project",
-        description="Lists the built-in scikit-build-core settings and any config-settings the project declares in tool.scikit-build.config-setting.",
-    )
-    config_settings.set_defaults(func=main_config_settings)
 
 
 def main() -> None:

--- a/src/scikit_build_core/settings/__main__.py
+++ b/src/scikit_build_core/settings/__main__.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+__lazy_modules__ = {
+    "argparse",
+    "json",
+    "pathlib",
+    "scikit_build_core._compat",
+    "scikit_build_core._logging",
+    "scikit_build_core.settings.config_settings",
+    "scikit_build_core.settings.documentation",
+    "scikit_build_core.settings.skbuild_model",
+    "typing",
+}
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scikit_build_core._compat import tomllib
+from scikit_build_core._logging import rich_error, rich_print, rich_warning
+from scikit_build_core.settings.config_settings import load_declarations
+from scikit_build_core.settings.documentation import mk_docs
+from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
+
+
+def _load_pyproject() -> dict[str, Any]:
+    """Read ``pyproject.toml`` from the current directory, erroring out clearly if missing."""
+    path = Path("pyproject.toml")
+    if not path.is_file():
+        rich_error(
+            "No {bold}pyproject.toml{normal} found in the current directory; run this from the root of a project."
+        )
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def _brace_escape(text: str) -> str:
+    """Escape braces so ``rich_print`` doesn't treat them as format fields."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
+def main_config_settings(_args: argparse.Namespace, /) -> None:
+    """List the config-settings supported when building the project."""
+    pyproject = _load_pyproject()
+    backend = pyproject.get("build-system", {}).get("build-backend", "")
+    if backend != "scikit_build_core.build":
+        rich_warning("Might not be a scikit-build-core project.")
+
+    rich_print(
+        "{blue}Config-settings supported when building this project"
+        " (pass with {bold}-C{normal}{blue}name=value):"
+    )
+    rich_print()
+
+    decls = load_declarations(
+        pyproject.get("tool", {}).get("scikit-build", {}).get("config-setting", {})
+    )
+    if decls:
+        rich_print(
+            "{bold}Project config-settings{normal} (tool.scikit-build.config-setting):"
+        )
+        width = max(len(name) for name in decls)
+        for name, decl in decls.items():
+            notes: list[str] = [decl.type]
+            if decl.env is not None:
+                notes.append(f"env: {decl.env}")
+            if decl.default is not None:
+                notes.append(f"default: {json.dumps(decl.default)}")
+            rich_print(
+                f"  {{green}}{name:{width}}{{default}}  {_brace_escape(decl.help)}"
+                f" {{yellow}}[{_brace_escape(', '.join(notes))}]"
+            )
+        rich_print()
+
+    items = [
+        item
+        for item in mk_docs(ScikitBuildSettings)
+        if not item.deprecated and item.flat_expressible()
+    ]
+    rich_print(
+        "{bold}Built-in config-settings{normal} (a 'skbuild.' prefix also works):"
+    )
+    width = max(len(item.name) for item in items)
+    for item in items:
+        summary = item.docs.split("\n", maxsplit=1)[0]
+        rich_print(
+            f"  {{green}}{item.name:{width}}{{default}}  {_brace_escape(summary)}"
+            f" {{yellow}}[{_brace_escape(item.type)}]"
+        )
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``settings`` subcommands to an existing parser."""
+    subparsers = parser.add_subparsers(required=True, help="Commands")
+    config_settings = subparsers.add_parser(
+        "config-settings",
+        help="List the config-settings supported when building this project",
+        description="Lists the built-in scikit-build-core settings and any config-settings the project declares in tool.scikit-build.config-setting.",
+    )
+    config_settings.set_defaults(func=main_config_settings)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m scikit_build_core.settings",
+        allow_abbrev=False,
+        description="Settings utilities.",
+    )
+    populate_parser(parser)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scikit_build_core/settings/__main__.py
+++ b/src/scikit_build_core/settings/__main__.py
@@ -40,7 +40,7 @@ def _brace_escape(text: str) -> str:
     return text.replace("{", "{{").replace("}", "}}")
 
 
-def main_config_settings(_args: argparse.Namespace, /) -> None:
+def main_list(_args: argparse.Namespace, /) -> None:
     """List the config-settings supported when building the project."""
     pyproject = _load_pyproject()
     backend = pyproject.get("build-system", {}).get("build-backend", "")
@@ -93,12 +93,12 @@ def main_config_settings(_args: argparse.Namespace, /) -> None:
 def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     """Add the ``settings`` subcommands to an existing parser."""
     subparsers = parser.add_subparsers(required=True, help="Commands")
-    config_settings = subparsers.add_parser(
-        "config-settings",
+    list_parser = subparsers.add_parser(
+        "list",
         help="List the config-settings supported when building this project",
         description="Lists the built-in scikit-build-core settings and any config-settings the project declares in tool.scikit-build.config-setting.",
     )
-    config_settings.set_defaults(func=main_config_settings)
+    list_parser.set_defaults(func=main_list)
 
 
 def main() -> None:

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -63,6 +63,30 @@ def pull_docs(dc: type[object]) -> dict[str, str]:
     }
 
 
+def _flat_expressible(field_type: typing.Any) -> bool:
+    """
+    Whether a field can be set through a flat source (``config-settings`` or a
+    ``SKBUILD_*`` environment variable).
+
+    Both sources reject arrays of tables (handled separately via the ``[]`` name
+    marker) and can't round-trip nested mappings (e.g. a dict of dicts), so no
+    flat key is advertised for those. Dicts of scalars (including
+    ``cmake.define``) and lists of scalars are fine.
+    """
+    origin = get_origin(field_type)
+    if origin is Annotated:
+        return _flat_expressible(get_args(field_type)[0])
+    if origin is typing.Union:
+        return all(
+            _flat_expressible(arg)
+            for arg in get_args(field_type)
+            if arg is not NoneType
+        )
+    if origin is dict:
+        return get_origin(get_args(field_type)[1]) not in (dict, list)
+    return True
+
+
 @dataclasses.dataclass(frozen=True)
 class DCDoc:
     name: str
@@ -73,6 +97,15 @@ class DCDoc:
     deprecated: bool = False
     override_only: bool = False
     choices: tuple[str, ...] = ()
+
+    def flat_expressible(self) -> bool:
+        """
+        Whether the option can be set via ``config-settings`` or an env var.
+
+        Arrays of tables (``generate[]``) and nested mappings can only be set in
+        ``pyproject.toml``, so the flat forms are skipped for them.
+        """
+        return "[]" not in self.name and _flat_expressible(self.field.type)
 
 
 def sanitize_default_field(text: str) -> str:

--- a/src/scikit_build_core/settings/skbuild_docs_sphinx.py
+++ b/src/scikit_build_core/settings/skbuild_docs_sphinx.py
@@ -15,7 +15,6 @@ import dataclasses
 import textwrap
 import typing
 from collections import OrderedDict
-from typing import Annotated, get_args, get_origin
 
 from .documentation import mk_docs
 from .skbuild_model import ScikitBuildSettings
@@ -27,35 +26,9 @@ if TYPE_CHECKING:
 
 __all__ = ["mk_skbuild_docs"]
 
-_NONE_TYPE = type(None)
-
 
 def __dir__() -> list[str]:
     return __all__
-
-
-def _flat_expressible(field_type: typing.Any) -> bool:
-    """
-    Whether a field can be set through a flat source (``config-settings`` or a
-    ``SKBUILD_*`` environment variable).
-
-    Both sources reject arrays of tables (handled separately via the ``[]`` name
-    marker) and can't round-trip nested mappings (e.g. a dict of dicts), so no
-    flat key is advertised for those. Dicts of scalars (including
-    ``cmake.define``) and lists of scalars are fine.
-    """
-    origin = get_origin(field_type)
-    if origin is Annotated:
-        return _flat_expressible(get_args(field_type)[0])
-    if origin is typing.Union:
-        return all(
-            _flat_expressible(arg)
-            for arg in get_args(field_type)
-            if arg is not _NONE_TYPE
-        )
-    if origin is dict:
-        return get_origin(get_args(field_type)[1]) not in (dict, list)
-    return True
 
 
 @dataclasses.dataclass
@@ -105,15 +78,6 @@ class Item:
         """
         return self.item.default in ('""', "[]", "{}")
 
-    def flat_expressible(self) -> bool:
-        """
-        Whether the option can be set via ``config-settings`` or an env var.
-
-        Arrays of tables (``generate[]``) and nested mappings can only be set in
-        ``pyproject.toml``, so the flat forms are skipped for them.
-        """
-        return "[]" not in self.item.name and _flat_expressible(self.item.field.type)
-
     def fields(self) -> str:
         """
         The rST field list rendered inside the confval body.
@@ -125,7 +89,7 @@ class Item:
         lines = [f":Type: ``{self.item.type}``"]
         if not self.ignore_default():
             lines.append(f":Default: {self.item.default}")
-        if self.flat_expressible():
+        if self.item.flat_expressible():
             name = self.item.name
             var = name.replace(".", "_").replace("-", "_").upper()
             lines.append(f":Config-settings: ``{name}`` or ``skbuild.{name}``")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from scikit_build_core.__main__ import main
 
 TYPE_CHECKING = False
@@ -43,6 +45,71 @@ def test_cli_file_api_query(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     query_dir = build_dir / ".cmake/api/v1/query"
     assert query_dir.joinpath("codemodel-v2").is_file()
     assert out.strip().endswith("reply")
+
+
+def _strip_ansi(text: str) -> str:
+    """Drop color codes, which CI turns on via FORCE_COLOR."""
+    return re.sub(r"\x1b\[.*?m", "", text)
+
+
+def test_cli_build_config_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = (
+        "[build-system]\n"
+        'requires = ["scikit-build-core"]\n'
+        'build-backend = "scikit_build_core.build"\n'
+        "[project]\n"
+        'name = "test"\n'
+        'version = "0.1.0"\n'
+        '[tool.scikit-build.config-setting."zmq.prefix"]\n'
+        'help = "Prefix to search for libzmq"\n'
+        'env = "ZMQ_PREFIX"\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject)
+    monkeypatch.chdir(tmp_path)
+    main(["build", "config-settings"])
+    out = _strip_ansi(capsys.readouterr().out)
+
+    names = {line.split()[0] for line in out.splitlines() if line.startswith("  ")}
+
+    # Project-declared settings
+    assert "zmq.prefix" in names
+    assert "Prefix to search for libzmq" in out
+    assert "ZMQ_PREFIX" in out
+
+    # Built-in settings come from the settings model
+    assert "cmake.version" in names
+    assert "The versions of CMake to allow" in out
+    # Override-only fields are still settable via config-settings
+    assert "wheel.tags" in names
+    # Deprecated and pyproject-only (array-of-table, nested-dict) fields are not
+    assert "cmake.minimum-version" not in names
+    assert not any(name.startswith("generate") for name in names)
+    assert "metadata" not in names
+
+
+def test_cli_build_config_settings_no_declarations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = (
+        "[build-system]\n"
+        'requires = ["scikit-build-core"]\n'
+        'build-backend = "scikit_build_core.build"\n'
+        "[project]\n"
+        'name = "test"\n'
+        'version = "0.1.0"\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject)
+    monkeypatch.chdir(tmp_path)
+    main(["build", "config-settings"])
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "Project config-settings" not in out
+    assert "Built-in config-settings" in out
 
 
 def test_cli_build_requires(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_cli_settings_config_settings(
     )
     (tmp_path / "pyproject.toml").write_text(pyproject)
     monkeypatch.chdir(tmp_path)
-    main(["settings", "config-settings"])
+    main(["settings", "list"])
     out = _strip_ansi(capsys.readouterr().out)
 
     names = {line.split()[0] for line in out.splitlines() if line.startswith("  ")}
@@ -106,7 +106,7 @@ def test_cli_settings_config_settings_no_declarations(
     )
     (tmp_path / "pyproject.toml").write_text(pyproject)
     monkeypatch.chdir(tmp_path)
-    main(["settings", "config-settings"])
+    main(["settings", "list"])
     out = _strip_ansi(capsys.readouterr().out)
     assert "Project config-settings" not in out
     assert "Built-in config-settings" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[.*?m", "", text)
 
 
-def test_cli_build_config_settings(
+def test_cli_settings_config_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -70,7 +70,7 @@ def test_cli_build_config_settings(
     )
     (tmp_path / "pyproject.toml").write_text(pyproject)
     monkeypatch.chdir(tmp_path)
-    main(["build", "config-settings"])
+    main(["settings", "config-settings"])
     out = _strip_ansi(capsys.readouterr().out)
 
     names = {line.split()[0] for line in out.splitlines() if line.startswith("  ")}
@@ -91,7 +91,7 @@ def test_cli_build_config_settings(
     assert "metadata" not in names
 
 
-def test_cli_build_config_settings_no_declarations(
+def test_cli_settings_config_settings_no_declarations(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -106,7 +106,7 @@ def test_cli_build_config_settings_no_declarations(
     )
     (tmp_path / "pyproject.toml").write_text(pyproject)
     monkeypatch.chdir(tmp_path)
-    main(["build", "config-settings"])
+    main(["settings", "config-settings"])
     out = _strip_ansi(capsys.readouterr().out)
     assert "Project config-settings" not in out
     assert "Built-in config-settings" in out


### PR DESCRIPTION
I'm going to check to see if `settings` makes more sense.

:robot: _AI text below_ :robot:

Stacked on #1489. Adds `scikit-build settings list`, which lists every config-setting a build of the current project accepts:

- **Project config-settings** declared in `tool.scikit-build.config-setting` (#1489), with help, type, env var, and default.
- **Built-in settings**, pulled from the settings model via `mk_docs` — the same single source of truth as the README table and the Sphinx config reference. Deprecated fields and fields not settable through flat sources (`generate[]`, nested tables) are skipped; override-only fields like `wheel.tags` are listed since config-settings may set them.

The flat-expressible check moved from the Sphinx generator onto `DCDoc` so both consumers share it (generated docs are unchanged).

Example output on the #1489 test package:

```
Config-settings supported when building this project (pass with -Cname=value):

Project config-settings (tool.scikit-build.config-setting):
  zmq.prefix  Prefix to search for libzmq [str, env: ZMQ_PREFIX]
  zmq.libzmq  Where libzmq comes from [str, default: "system"]

Built-in config-settings (a 'skbuild.' prefix also works):
  cmake.version                      The versions of CMake to allow as a python-compatible specifier. [SpecifierSet]
  cmake.args                         A list of args to pass to CMake when configuring the project. [list[str]]
  ...
```
