### PR TITLE
docs: add llms.txt and markdown copies of pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_inline_tabs",
+    "sphinx_llm.txt",
     "sphinx_tippy",
     "sphinxcontrib.programoutput",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ docs = [
     "sphinx-copybutton",
     "sphinx-inline-tabs",
     "sphinx-jsonschema",
+    "sphinx-llm",
     "sphinx-tippy",
     "sphinxcontrib-programoutput >=0.19",
 ]


### PR DESCRIPTION
Using https://github.com/NVIDIA/sphinx-llm.

Might help agents read the docs better (no html involved). Maybe.
