### PR TITLE
test: accept new CPython 3.15rc1 abi3 suffix in abi3 tests

### DIFF
--- a/tests/test_pyproject_abi3.py
+++ b/tests/test_pyproject_abi3.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 import sys
 import sysconfig
@@ -11,6 +12,9 @@ from scikit_build_core.build import build_wheel
 DIR = Path(__file__).parent.resolve()
 ABI_PKG = DIR / "packages/abi3_pyproject_ext"
 SYSCONFIGPLAT = sysconfig.get_platform()
+# CPython 3.15rc1+ appends the platform triplet to the abi3 suffix
+# (e.g. "abi3-x86_64-linux-gnu.so" instead of "abi3.so").
+ABI3_SO_RE = re.compile(r"abi3_example\.abi3(-[\w.-]+)?\.so")
 
 
 @pytest.mark.compile
@@ -60,9 +64,9 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv, capsys):
         else:
             assert so_file != "abi3_example.abi3.dll"
     elif abi3:
-        assert so_file == "abi3_example.abi3.so"
+        assert ABI3_SO_RE.fullmatch(so_file)
     else:
-        assert so_file != "abi3_example.abi3.so"
+        assert not ABI3_SO_RE.fullmatch(so_file)
 
     virtualenv.install(wheel)
 

--- a/tests/test_setuptools_abi3.py
+++ b/tests/test_setuptools_abi3.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 import sys
 import sysconfig
@@ -18,6 +19,9 @@ pytestmark = pytest.mark.setuptools
 DIR = Path(__file__).parent.resolve()
 ABI_PKG = DIR / "packages/abi3_setuptools_ext"
 SYSCONFIGPLAT = sysconfig.get_platform()
+# CPython 3.15rc1+ appends the platform triplet to the abi3 suffix
+# (e.g. "abi3-x86_64-linux-gnu.so" instead of "abi3.so").
+ABI3_SO_RE = re.compile(r"abi3_example\.abi3(-[\w.-]+)?\.so")
 
 
 @pytest.fixture(autouse=True)
@@ -72,7 +76,7 @@ def test_abi3_wheel(tmp_path, monkeypatch, virtualenv):
     elif sys.platform.startswith("cygwin"):
         assert "abi3_example.abi3.dll" in file_names
     else:
-        assert "abi3_example.abi3.so" in file_names
+        assert any(ABI3_SO_RE.fullmatch(name) for name in file_names)
 
     virtualenv.install(wheel)
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

CPython 3.15rc1 adds the platform triplet to the abi3 extension suffix (e.g. `abi3-x86_64-linux-gnu.so` instead of `abi3.so`). `test_pyproject_abi3.py::test_abi3_wheel` and `test_setuptools_abi3.py::test_abi3_wheel` hardcoded the old name and started failing on the 3.15 CI job (see #1527's CI). Both tests now match either form with a regex instead of an exact string.