### PR TITLE
fix: set Python_FIND_ABI for free-threaded builds on CMake 3.30+

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -10,6 +10,8 @@ __lazy_modules__ = {
     f"{__spec__.parent}.sysconfig",
     "importlib",
     "importlib.resources",
+    "packaging",
+    "packaging.version",
     "platform",
     "re",
     "shlex",
@@ -29,6 +31,8 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
+from packaging.version import Version
+
 from .. import __version__
 from .._compat.importlib import metadata
 from .._logging import logger
@@ -47,8 +51,6 @@ from .sysconfig import (
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Mapping, Sequence
-
-    from packaging.version import Version
 
     from ..cmake import CMaker
     from ..settings.skbuild_model import ScikitBuildSettings
@@ -425,6 +427,10 @@ class Builder:
                 cache_config[f"{prefix}_ROOT_DIR"] = Path(sys.base_exec_prefix)
                 cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
                 cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
+                # Interpreter-less FindPython rejects the free-threaded "t" ABI
+                # unless the 4-tuple (3.30+) FIND_ABI requests it.
+                if gil_disabled and self.config.cmake.version >= Version("3.30"):
+                    cache_config[f"{prefix}_FIND_ABI"] = "ANY;ANY;ANY;ON"
                 # On Windows the library is constructed and existence-checked,
                 # so this is reliable. On POSIX a library hint can break
                 # FindPython (which resolves it fine on its own), so this

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -476,12 +476,13 @@ def configure_builder_with_limited_api(
     *,
     limited_api: bool | None,
     py_api: str = "",
+    cmake_version: str = "3.30",
 ) -> str:
     source_dir = tmp_path / "src"
     source_dir.mkdir()
 
     config = CMaker(
-        CMake(Version("3.30"), Path("cmake")),
+        CMake(Version(cmake_version), Path("cmake")),
         source_dir=source_dir,
         build_dir=tmp_path / "build",
         build_type="Release",
@@ -640,6 +641,36 @@ def test_builder_combined_abi3_abi3t(tmp_path, monkeypatch, gil, soabi, is_ft):
     assert f"set(SKBUILD_SOABI [===[{expected_soabi}]===] CACHE STRING" in cache
     assert "set(SKBUILD_SABI_VERSION [===[3.15]===] CACHE STRING" in cache
     assert ("Py_TARGET_ABI3T" in cache) == is_ft
+
+
+@pytest.mark.parametrize(
+    ("gil", "cmake_version", "expected"),
+    [
+        pytest.param("t", "3.30", True, id="ft_cmake330"),
+        pytest.param("t", "3.29", False, id="ft_cmake329"),
+        pytest.param(None, "3.30", False, id="gil_cmake330"),
+    ],
+)
+def test_builder_free_threaded_find_abi(
+    tmp_path, monkeypatch, gil, cmake_version, expected
+):
+    # Interpreter-less find_package(Python COMPONENTS Development.Module) only
+    # matches the free-threaded ABI if Python_FIND_ABI requests it (#1531).
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: gil if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    patch_cpython_runtime(monkeypatch)
+
+    cache = configure_builder_with_limited_api(
+        tmp_path, monkeypatch, limited_api=None, cmake_version=cmake_version
+    )
+
+    for prefix in ("Python", "Python3"):
+        line = f"set({prefix}_FIND_ABI [===[ANY;ANY;ANY;ON]===] CACHE STRING"
+        assert (line in cache) == expected
 
 
 def configure_builder_with_version(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses the first bullet of #1531.

On free-threaded CPython, an Interpreter-less `find_package(Python COMPONENTS Development.Module REQUIRED)` fails with `Could NOT find Python (missing: Development.Module)` because FindPython does not match the free-threaded `t` ABI unless the 4-tuple `Python_FIND_ABI` requests it. This sets `Python_FIND_ABI` / `Python3_FIND_ABI` to `ANY;ANY;ANY;ON` in the init cache when the build interpreter is free-threaded, under the existing `cmake.python-hints` gate.

Gated on CMake >= 3.30: older versions read only the first 3 tuple elements and then reject the `t` ABI, so the hint must not be set there. Non-free-threaded builds are unchanged. The value satisfies the Windows constraint in the FindPython docs (`pymalloc`/`unicode` are `ANY`; `gil_disabled=ON` is supported on Windows in 3.30+).

Verified end-to-end on macOS with CPython 3.14t and CMake 4.4.2: a minimal Interpreter-less package fails on released scikit-build-core and builds a wheel with the correct `cpython-314t-darwin` suffix with this change. The SOABI-as-input part of #1531 is left open.