### PR TITLE
fix: don't pass Python_LIBRARY hint in SABI mode on Windows

### DIFF
--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -428,8 +428,16 @@ class Builder:
                 # On Windows the library is constructed and existence-checked,
                 # so this is reliable. On POSIX a library hint can break
                 # FindPython (which resolves it fine on its own), so this
-                # stays Windows-only.
-                if python_library and sysconfig.get_platform().startswith("win"):
+                # stays Windows-only. In SABI mode the hint is skipped: CMake
+                # 4.4's FindPython ingests it even when Development.Module is
+                # not requested, disabling the SABI-only version fallback and
+                # rejecting python3.lib (Interpreter + Development.SABIModule
+                # then both report not found).
+                if (
+                    python_library
+                    and sabi == _SabiMode.NONE
+                    and sysconfig.get_platform().startswith("win")
+                ):
                     cache_config[f"{prefix}_LIBRARY"] = python_library
                 if python_sabi_library and sysconfig.get_platform().startswith("win"):
                     cache_config[f"{prefix}_SABI_LIBRARY"] = python_sabi_library

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -501,6 +501,36 @@ def configure_builder_with_limited_api(
     return config.init_cache_file.read_text(encoding="utf-8")
 
 
+@pytest.mark.parametrize("limited_api", [False, True], ids=["classic", "abi3"])
+def test_builder_windows_library_hint_sabi(tmp_path, monkeypatch, limited_api):
+    # CMake 4.4's FindPython ingests a Python_LIBRARY hint even when
+    # Development.Module is not requested, which breaks SABI-only
+    # find_package(Python COMPONENTS Interpreter Development.SABIModule)
+    # on Windows. The hint must be dropped in SABI mode.
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: None if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    patch_cpython_runtime(monkeypatch)
+    monkeypatch.setattr(sysconfig, "get_platform", lambda *_: "win-amd64")
+
+    import scikit_build_core.builder.builder as builder_mod
+
+    def fake_library(_env, *, abi3=False, abi3t=False):
+        return Path("libs/python3.lib" if abi3 or abi3t else "libs/python313.lib")
+
+    monkeypatch.setattr(builder_mod, "get_python_library", fake_library)
+
+    cache = configure_builder_with_limited_api(
+        tmp_path, monkeypatch, limited_api=limited_api
+    )
+
+    assert ("set(Python_LIBRARY " in cache) == (not limited_api)
+    assert ("set(Python_SABI_LIBRARY " in cache) == limited_api
+
+
 def patch_cpython_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     implementation = vars(sys.implementation).copy()
     implementation["name"] = "cpython"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes the Windows CI failures in `test_setuptools_abi3.py::test_abi3_wheel` that appear with the `cmake` 4.4.x wheels (the wheelhouse cache had pinned CI to 4.3.4 until now).

CMake 4.4's FindPython ingests an absolute `Python_LIBRARY` hint even when `Development.Module` is not requested. That sets the internal library variable, which disables the SABI-only version fallback added in CMake 4.4.1 for [issue 27950](https://gitlab.kitware.com/cmake/cmake/-/issues/27950), so `find_package(Python COMPONENTS Interpreter Development.SABIModule)` rejects `python3.lib` and reports both components missing. This only affects Windows (the hint is Windows-only) and only projects that request `Development.SABIModule` without `Development.Module`.

The fix skips the `Python_LIBRARY` hint when building in SABI mode; `Python_SABI_LIBRARY` is still passed. A scenario matrix on windows-2022 against CMake 4.4.2 and 3.26.4 confirmed that dropping the hint fixes the SABI-only case and that `Development.Module`-requesting projects still resolve the normal library from the remaining hints on both versions.

The hint-ingestion behavior looks like an upstream regression worth reporting to Kitware as a follow-up to 27950; the workaround here is correct regardless.

The `cmake!=4.4.0` exclusion in `pyproject.toml` stays: 4.4.0's failure occurs even without hints and was fixed upstream in 4.4.1.