### PR TITLE
fix: double CMake discovery timeout on native Apple Silicon

### DIFF
--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -96,7 +96,9 @@ def compute_timeout(executable: Path) -> int:
         return BASE_TIMEOUT * 2
 
     if sys.platform == "darwin" and platform.machine() == "arm64":
-        return BASE_TIMEOUT * 3 if _macos_binary_is_x86(executable) else BASE_TIMEOUT * 2
+        return (
+            BASE_TIMEOUT * 3 if _macos_binary_is_x86(executable) else BASE_TIMEOUT * 2
+        )
 
     return BASE_TIMEOUT
 

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -50,7 +50,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-BASE_TIMEOUT = 10
+BASE_TIMEOUT = 5
 
 
 @functools.lru_cache(None)
@@ -84,6 +84,7 @@ def compute_timeout(executable: Path) -> int:
     * Is on CI: quadruples it
     * Is windows: doubles it
     * Runs with Rosetta: triples it
+    * Native Apple Silicon: doubles it
 
     These do not stack.
     """
@@ -95,7 +96,7 @@ def compute_timeout(executable: Path) -> int:
         return BASE_TIMEOUT * 2
 
     if sys.platform == "darwin" and platform.machine() == "arm64":
-        return BASE_TIMEOUT * 3 if _macos_binary_is_x86(executable) else BASE_TIMEOUT
+        return BASE_TIMEOUT * 3 if _macos_binary_is_x86(executable) else BASE_TIMEOUT * 2
 
     return BASE_TIMEOUT
 

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -50,7 +50,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-BASE_TIMEOUT = 5
+BASE_TIMEOUT = 10
 
 
 @functools.lru_cache(None)

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -144,3 +144,28 @@ def test_get_cmake_program_fallback_exception(monkeypatch, fp, caplog, exc):
     program = get_cmake_program(cmake_path)
     assert program.path == cmake_path
     assert program.version is None
+
+
+
+def test_compute_timeout_base_is_ten_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scikit_build_core.program_search import BASE_TIMEOUT, compute_timeout
+
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr("scikit_build_core.program_search.sys.platform", "linux")
+    compute_timeout.cache_clear()
+    try:
+        assert BASE_TIMEOUT == 10
+        assert compute_timeout(Path("cmake")) == 10
+    finally:
+        compute_timeout.cache_clear()
+
+
+def test_compute_timeout_ci_quadruples_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scikit_build_core.program_search import compute_timeout
+
+    monkeypatch.setenv("CI", "true")
+    compute_timeout.cache_clear()
+    try:
+        assert compute_timeout(Path("cmake")) == 40
+    finally:
+        compute_timeout.cache_clear()

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -146,7 +146,9 @@ def test_get_cmake_program_fallback_exception(monkeypatch, fp, caplog, exc):
     assert program.version is None
 
 
-def test_compute_timeout_base_unchanged_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_compute_timeout_base_unchanged_on_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from scikit_build_core.program_search import BASE_TIMEOUT, compute_timeout
 
     monkeypatch.delenv("CI", raising=False)

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -146,14 +146,34 @@ def test_get_cmake_program_fallback_exception(monkeypatch, fp, caplog, exc):
     assert program.version is None
 
 
-def test_compute_timeout_base_is_ten_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_compute_timeout_base_unchanged_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     from scikit_build_core.program_search import BASE_TIMEOUT, compute_timeout
 
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setattr("scikit_build_core.program_search.sys.platform", "linux")
     compute_timeout.cache_clear()
     try:
-        assert BASE_TIMEOUT == 10
+        assert BASE_TIMEOUT == 5
+        assert compute_timeout(Path("cmake")) == 5
+    finally:
+        compute_timeout.cache_clear()
+
+
+def test_compute_timeout_native_apple_silicon_doubles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scikit_build_core.program_search import compute_timeout
+
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr("scikit_build_core.program_search.sys.platform", "darwin")
+    monkeypatch.setattr(
+        "scikit_build_core.program_search.platform.machine", lambda: "arm64"
+    )
+    monkeypatch.setattr(
+        "scikit_build_core.program_search._macos_binary_is_x86", lambda _path: False
+    )
+    compute_timeout.cache_clear()
+    try:
         assert compute_timeout(Path("cmake")) == 10
     finally:
         compute_timeout.cache_clear()
@@ -165,6 +185,6 @@ def test_compute_timeout_ci_quadruples_base(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("CI", "true")
     compute_timeout.cache_clear()
     try:
-        assert compute_timeout(Path("cmake")) == 40
+        assert compute_timeout(Path("cmake")) == 20
     finally:
         compute_timeout.cache_clear()

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -146,7 +146,6 @@ def test_get_cmake_program_fallback_exception(monkeypatch, fp, caplog, exc):
     assert program.version is None
 
 
-
 def test_compute_timeout_base_is_ten_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
     from scikit_build_core.program_search import BASE_TIMEOUT, compute_timeout
 


### PR DESCRIPTION
Fixes #1530.

A freshly extracted native arm64 CMake can take ~5s on the first `cmake -E capabilities` call, so the 5s base timeout dropped a working CMake. Raising `BASE_TIMEOUT` itself would double CI/Windows/Rosetta timeouts, so this only doubles the native Apple Silicon path (5s → 10s). Rosetta stays at 3×.

## Test plan
- [x] `pytest tests/test_program_search.py`