### PR TITLE
fix: `if.cmake-wheel` never matched a platform

### DIFF
--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -246,7 +246,9 @@ def override_match(
         known_cmake_wheels = set(
             known_wheels_toml["tool"]["scikit-build"]["cmake"]["known-wheels"]
         )
-        cmake_plat = known_cmake_wheels.intersection(packaging.tags.sys_tags())
+        cmake_plat = known_cmake_wheels.intersection(
+            tag.platform for tag in packaging.tags.sys_tags()
+        )
         if cmake_plat:
             passed_dict["cmake-wheel"] = f"cmake wheel available on {cmake_plat}"
         else:

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -6,6 +6,7 @@ import typing
 from pathlib import Path
 from textwrap import dedent
 
+import packaging.tags
 import pytest
 
 import scikit_build_core.settings.skbuild_overrides
@@ -926,7 +927,10 @@ def test_wheel_platform(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sys_tag
 
     monkeypatch.chdir(tmp_path)
 
-    monkeypatch.setattr("packaging.tags.sys_tags", lambda: [sys_tag])
+    monkeypatch.setattr(
+        "packaging.tags.sys_tags",
+        lambda: [packaging.tags.Tag("cp313", "cp313", sys_tag)],
+    )
 
     settings_reader = SettingsReader.from_file(pyproject_toml, retry=False)
     settings = settings_reader.settings


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`override_match` intersected the known-wheel platform strings with `packaging.tags.sys_tags()`, which yields `Tag` objects. The intersection was always empty, so `if.cmake-wheel = true` never matched on any platform and `if.cmake-wheel = false` always matched.

It now compares `tag.platform`, the same way `is_known_platform` in `builder/get_requires.py` does.

The existing `test_wheel_platform` hid the bug because it monkeypatched `sys_tags` to return plain strings. It now returns a real `Tag`, and fails without the fix.

Found while looking at #1537.