### PR TITLE
feat: add `if.not` overrides

### DIFF
--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -10,8 +10,9 @@ override if the `if` condition is true.
 
 At least one condition must be provided; if multiple conditions are given, all
 must be true (see [`if.any`](#any-matching-condition) to match on any one
-instead). Overrides match top to bottom, overriding previous matches. Each
-condition is one of three types:
+instead, and [`if.not`](#no-matching-condition) to match when none are true).
+Overrides match top to bottom, overriding previous matches. Each condition is
+one of three types:
 
 | Type    | Takes           | Matches when                                                                                            |
 | ------- | --------------- | ------------------------------------------------------------------------------------------------------- |
@@ -248,6 +249,37 @@ Above, either `CIBUILDWHEEL` or `BUILD_MY_LIB` being truthy will trigger a
 binary build.
 
 :::{versionadded} 0.7
+
+:::
+
+## No matching condition
+
+If you use `if.not`, then the override is true only if none of the items in it
+are true. You can combine it with `if` and `if.any`; all the `if` conditions,
+one of the `if.any` conditions, and none of the `if.not` conditions must match.
+
+Example:
+
+```toml
+[[tool.scikit-build.overrides]]
+if.not.system-cmake = ">=3.15"
+if.cmake-wheel = false
+fail = true
+messages.after-failure = "No CMake wheel is available for this platform. Install CMake with your system package manager."
+```
+
+Above, the build stops immediately with a message if there is no usable system
+CMake and no CMake wheel for this platform. Without this, scikit-build-core adds
+`cmake` to the build requirements, and the CMake sdist is built from source,
+which is slow.
+
+Use `if.not` for version and regex conditions, where there is no negated form.
+For a bool condition, set the value you want instead, as the example does;
+`if.cmake-wheel = false` is clearer than, and identical to,
+`if.not.cmake-wheel = true`. A regex condition in an `if.not` table also matches
+when the value is not set at all, such as a missing environment variable.
+
+:::{versionadded} 1.1
 
 :::
 

--- a/src/scikit_build_core/resources/scikit-build.schema.json
+++ b/src/scikit_build_core/resources/scikit-build.schema.json
@@ -613,23 +613,87 @@
         "additionalProperties": false,
         "properties": {
           "if": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/if_overrides"
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "scikit-build-version": {
+                "type": "string",
+                "description": "The version of scikit-build-version. Takes a specifier set."
               },
-              {
+              "python-version": {
+                "type": "string",
+                "description": "The two-digit Python version. Takes a specifier set."
+              },
+              "implementation-name": {
+                "type": "string",
+                "description": "The value of `sys.implementation.name`. Takes a regex"
+              },
+              "implementation-version": {
+                "type": "string",
+                "description": "Derived from `sys.implementation.version`, following PEP 508. Takes a specifier set."
+              },
+              "platform-system": {
+                "type": "string",
+                "description": "The value of `sys.platform`. Takes a regex."
+              },
+              "platform-machine": {
+                "type": "string",
+                "description": "The value of `platform.machine()`. Takes a regex."
+              },
+              "platform-node": {
+                "type": "string",
+                "description": "The value of `platform.node()`. Takes a regex."
+              },
+              "state": {
+                "type": "string",
+                "description": "The state of the build, one of `sdist`, `wheel`, `editable`, `metadata_wheel`, and `metadata_editable`. Takes a regex."
+              },
+              "from-sdist": {
+                "type": "boolean",
+                "description": "Whether the build is from an sdist."
+              },
+              "failed": {
+                "type": "boolean",
+                "description": "Matches if the build fails. A build will be retried if there is at least one matching override with this set to true."
+              },
+              "system-cmake": {
+                "type": "string",
+                "description": "The version of CMake found on the system. Takes a specifier set."
+              },
+              "cmake-wheel": {
+                "type": "boolean",
+                "description": "Whether a cmake wheel is known to be provided for this system."
+              },
+              "abi-flags": {
+                "type": "string",
+                "description": "A sorted string of the abi flags. Takes a regex."
+              },
+              "env": {
                 "type": "object",
-                "properties": {
-                  "any": {
-                    "$ref": "#/$defs/if_overrides"
+                "patternProperties": {
+                  ".*": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
                   }
                 },
-                "required": [
-                  "any"
-                ],
-                "additionalProperties": false
+                "additionalProperties": false,
+                "minProperties": 1,
+                "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0."
+              },
+              "any": {
+                "$ref": "#/$defs/if_overrides"
+              },
+              "not": {
+                "$ref": "#/$defs/if_overrides"
               }
-            ]
+            }
           },
           "inherit": {
             "type": "object",

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -74,6 +74,9 @@ class OverrideRecord:
     passed_any: dict[str, str] | None
     """All if.any statements that passed."""
 
+    passed_not: dict[str, str] | None
+    """All if.not statements that passed, that is, that did not match."""
+
 
 def strtobool(value: str) -> bool:
     """
@@ -312,6 +315,7 @@ def record_override(
     overridden_items: dict[str, OverrideRecord],
     passed_all: dict[str, str] | None,
     passed_any: dict[str, str] | None,
+    passed_not: dict[str, str] | None,
 ) -> None:
     full_key = ".".join(keys)
     # Get the original_value to construct the record
@@ -350,6 +354,7 @@ def record_override(
         value=value,
         passed_any=passed_any,
         passed_all=passed_all,
+        passed_not=passed_not,
     )
 
 
@@ -374,9 +379,12 @@ def process_overrides(
     for override in tool_skb.pop("overrides", []):
         passed_any: dict[str, str] | None = None
         passed_all: dict[str, str] | None = None
+        passed_not: dict[str, str] | None = None
         unknown: set[str] = set()
         failed_any: set[str] = set()
         failed_all: set[str] = set()
+        matched_not: dict[str, str] = {}
+        failed_not: set[str] = set()
         if_override = override.pop("if", None)
         if not if_override:
             msg = "At least one 'if' override must be provided"
@@ -395,6 +403,20 @@ def process_overrides(
                 **select,
             )
             unknown |= set(unknown_any)
+
+        if "not" in if_override:
+            not_override = if_override.pop("not")
+            select = {k.replace("-", "_"): v for k, v in not_override.items()}
+            matched_not, failed_not, unknown_not = override_match(
+                current_env=env,
+                current_state=state,
+                has_dist_info=has_dist_info,
+                retry=retry,
+                **select,
+            )
+            unknown |= set(unknown_not)
+            # An if.not passes only if none of its conditions match
+            passed_not = {k: f"{k} did not match" for k in sorted(failed_not)}
 
         inherit_override = override.pop("inherit", {})
         if not isinstance(inherit_override, dict):
@@ -416,15 +438,17 @@ def process_overrides(
         passed_or_failed = {
             *(passed_all or {}),
             *(passed_any or {}),
+            *matched_not,
             *failed_all,
             *failed_any,
+            *failed_not,
         }
         if "scikit-build-version" not in passed_or_failed and unknown:
             msg = f"Unknown overrides: {', '.join(unknown)}"
             raise TypeError(msg)
 
         # If no overrides are passed, do nothing
-        if passed_any is None and passed_all is None:
+        if passed_any is None and passed_all is None and passed_not is None:
             continue
 
         # If normal overrides are passed and one or more fails, do nothing
@@ -435,7 +459,13 @@ def process_overrides(
         if passed_any is not None and not passed_any:
             continue
 
-        local_matched = set(passed_any or []) | set(passed_all or [])
+        # If not is passed, none of the conditions are allowed to match.
+        if matched_not:
+            continue
+
+        local_matched = (
+            set(passed_any or []) | set(passed_all or []) | set(passed_not or [])
+        )
         global_matched |= local_matched
         if local_matched:
             if unknown:
@@ -446,6 +476,7 @@ def process_overrides(
                 [
                     *(passed_all or {}).values(),
                     *([" or ".join(passed_any.values())] if passed_any else []),
+                    *(passed_not or {}).values(),
                 ]
             )
             logger.info("Overrides {}", all_str)
@@ -461,6 +492,7 @@ def process_overrides(
                             overridden_items=overridden_items,
                             passed_all=passed_all,
                             passed_any=passed_any,
+                            passed_not=passed_not,
                         )
                         inherit2 = inherit1.get(key2, "none")
                         inner = tool_skb.get(key, {})
@@ -476,6 +508,7 @@ def process_overrides(
                         overridden_items=overridden_items,
                         passed_all=passed_all,
                         passed_any=passed_any,
+                        passed_not=passed_not,
                     )
                     # ``inherit`` is keyed per-table; a non-dict top-level key
                     # has no nested inherit entry, so any inherit for it must be

--- a/src/scikit_build_core/settings/skbuild_schema.py
+++ b/src/scikit_build_core/settings/skbuild_schema.py
@@ -207,15 +207,14 @@ def generate_skbuild_schema(tool_name: str = "scikit-build") -> dict[str, Any]:
             "additionalProperties": False,
             "properties": {
                 "if": {
-                    "anyOf": [
-                        {"$ref": "#/$defs/if_overrides"},
-                        {
-                            "type": "object",
-                            "properties": {"any": {"$ref": "#/$defs/if_overrides"}},
-                            "required": ["any"],
-                            "additionalProperties": False,
-                        },
-                    ]
+                    "type": "object",
+                    "minProperties": 1,
+                    "additionalProperties": False,
+                    "properties": {
+                        **schema["$defs"]["if_overrides"]["properties"],
+                        "any": {"$ref": "#/$defs/if_overrides"},
+                        "not": {"$ref": "#/$defs/if_overrides"},
+                    },
                 },
                 "inherit": {
                     "type": "object",

--- a/tests/test_settings_overrides.py
+++ b/tests/test_settings_overrides.py
@@ -343,6 +343,98 @@ def test_skbuild_overrides_any_mixed(
         assert not settings_reader.overridden_items
 
 
+@pytest.mark.parametrize("implementation_name", ["cpython", "pypy"])
+@pytest.mark.parametrize("platform_system", ["darwin", "linux"])
+def test_skbuild_overrides_not(
+    implementation_name: str,
+    platform_system: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "sys.implementation", type("Mock", (), {"name": implementation_name})
+    )
+    monkeypatch.setattr("sys.platform", platform_system)
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.not.implementation-name = "pypy"
+            if.not.platform-system = "darwin"
+            install.components = ["headers"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    settings = settings_reader.settings
+
+    if implementation_name == "cpython" and platform_system == "linux":
+        assert settings.install.components == ["headers"]
+        record = settings_reader.overridden_items["install.components"]
+        assert record.passed_all is None
+        assert record.passed_any is None
+        assert record.passed_not is not None
+        assert set(record.passed_not) == {"implementation-name", "platform-system"}
+    else:
+        assert not settings.install.components
+        assert not settings_reader.overridden_items
+
+
+@pytest.mark.parametrize("python_version", ["3.9", "3.10"])
+@pytest.mark.parametrize("platform_system", ["darwin", "linux"])
+def test_skbuild_overrides_not_mixed(
+    platform_system: str,
+    python_version: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("sys.platform", platform_system)
+    monkeypatch.setattr("sys.version_info", (*map(int, python_version.split(".")), 0))
+
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.python-version = ">=3.10"
+            if.not.platform-system = "darwin"
+            install.components = ["headers"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    settings_reader = SettingsReader.from_file(pyproject_toml)
+    settings = settings_reader.settings
+
+    if python_version == "3.10" and platform_system == "linux":
+        assert settings.install.components == ["headers"]
+    else:
+        assert not settings.install.components
+        assert not settings_reader.overridden_items
+
+
+def test_skbuild_overrides_not_unknown(tmp_path: Path):
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [[tool.scikit-build.overrides]]
+            if.not.not-real = true
+            install.components = ["headers"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="Unknown overrides: not_real"):
+        SettingsReader.from_file(pyproject_toml)
+
+
 @pytest.mark.parametrize("platform_node", ["thismatch", "matchthat"])
 def test_skbuild_overrides_platnode(
     platform_node: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds an `if.not` table to overrides. The override applies only when none of the conditions in it match, and it combines with `if` and `if.any`: all `if`, one `if.any`, and none of `if.not`.

The motivation is #1537. There is no negated form of a version condition, and `if.not.system-cmake` covers both a too-old CMake and no CMake at all, so a project can now stop the build with a useful message instead of letting pip build the CMake sdist from source on a platform with no wheel:

```toml
[[tool.scikit-build.overrides]]
if.not.system-cmake = ">=3.15"
if.cmake-wheel = false
fail = true
messages.after-failure = "No CMake wheel is available for this platform. Install CMake with your system package manager."
```

`if.not` accepts the same conditions as `if`, but the docs point bool conditions at `if.<key> = false`, which is identical and clearer. It is for the version and regex conditions that have no negated form.

The `if` schema is now one object holding the plain conditions together with `any` and `not`. This also lifts an old schema limit that rejected `if` and `if.any` in the same override, which the code and the docs always supported.

This builds on #1538, without which `if.cmake-wheel` never matched.