### PR TITLE
fix: scope the nested .gitignore scan to the walked subtree

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -80,6 +80,32 @@ def _dir_key(dirstr: str) -> tuple[int, int] | None:
     return (st.st_dev, st.st_ino)
 
 
+def _nested_ignore_dirs(starting_path: Path) -> Generator[Path, None, None]:
+    """
+    Directories whose ``.gitignore`` can affect a walk of ``starting_path``.
+
+    ``match_path`` only consults a nested ignore whose directory is the walked
+    directory itself or one of its ancestors, so only ``starting_path``'s own
+    subtree, plus the chain of directories above it, can ever match. Walking
+    the whole project to collect the rest is pure cost: for a package that is
+    a subdirectory it means traversing every sibling tree -- build outputs,
+    vendored dependencies, scratch directories -- once per package, and it
+    also inflates the per-path loop over ``nested_excludes`` with entries that
+    can never apply.
+
+    The project root is omitted: its ``.gitignore`` is read separately into
+    the global spec.
+    """
+    root = Path()
+    for parent in starting_path.parents:
+        if parent != root:
+            yield parent
+    for dirstr, _, _ in os.walk(str(starting_path)):
+        dirpath = Path(dirstr)
+        if dirpath != root:
+            yield dirpath
+
+
 def each_unignored_file(
     starting_path: Path,
     include: Sequence[str] = (),
@@ -117,12 +143,11 @@ def each_unignored_file(
 
     nested_excludes = (
         {
-            Path(dirpath): pathspec.GitIgnoreSpec.from_lines(
-                (Path(dirpath) / filename).read_text(encoding="utf-8").splitlines()
+            dirpath: pathspec.GitIgnoreSpec.from_lines(
+                (dirpath / ".gitignore").read_text(encoding="utf-8").splitlines()
             )
-            for dirpath, _, filenames in os.walk(".")
-            for filename in filenames
-            if filename == ".gitignore" and dirpath != "."
+            for dirpath in _nested_ignore_dirs(starting_path)
+            if (dirpath / ".gitignore").is_file()
         }
         if reads_gitignore
         else {}

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -853,3 +853,58 @@ def test_nonexistent_patterns(
             Path("tests/tmp.py"),
         }
     assert exclude_result == expected
+
+
+def test_nested_gitignore_scan_scoped_to_starting_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The nested-.gitignore discovery walk must stay inside starting_path (plus
+    its ancestors). match_path only consults a nested ignore whose directory
+    is the walked directory or an ancestor of it, so sibling trees can never
+    contribute a match -- but they used to be traversed and parsed anyway,
+    once per package, which is very expensive for a project that keeps build
+    output or vendored dependencies next to its packages.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    pkg = Path("pkg")
+    (pkg / "sub").mkdir(parents=True)
+    (pkg / "keep.py").write_text("content")
+    (pkg / "sub" / "keep.py").write_text("content")
+    (pkg / "sub" / "dropped.py").write_text("content")
+    (pkg / "sub" / ".gitignore").write_text("dropped.py\n")
+
+    # A sibling tree that is irrelevant to a walk of pkg/, carrying its own
+    # .gitignore so the old code would open and parse it.
+    sibling = Path("build") / "deep" / "deeper"
+    sibling.mkdir(parents=True)
+    (sibling / ".gitignore").write_text("keep.py\n")
+    (sibling / "artifact.o").write_text("content")
+
+    visited: list[str] = []
+    real_walk = os.walk
+
+    def tracking_walk(
+        top: str, *args: object, **kwargs: object
+    ) -> Generator[tuple[str, list[str], list[str]], None, None]:
+        for dirstr, dirs, filenames in real_walk(top, *args, **kwargs):  # type: ignore[arg-type]
+            visited.append(dirstr)
+            yield dirstr, dirs, filenames
+
+    monkeypatch.setattr(os, "walk", tracking_walk)
+
+    result = set(each_unignored_file(pkg, mode="default"))
+
+    # The nested .gitignore inside the package still applies.
+    assert result == {
+        pkg / "keep.py",
+        pkg / "sub" / "keep.py",
+        pkg / "sub" / ".gitignore",
+    }
+
+    # No traversal of the sibling tree, in either walk.
+    visited_paths = {Path(d) for d in visited}
+    assert Path("build") not in visited_paths
+    assert Path("build/deep") not in visited_paths


### PR DESCRIPTION
## Problem

`each_unignored_file` collects nested `.gitignore` specs with an unpruned `os.walk(".")` over the whole project, regardless of which subtree it was asked to walk:

```python
for dirpath, _, filenames in os.walk(".")
for filename in filenames
if filename == ".gitignore" and dirpath != "."
```

`packages_to_file_mapping` calls it once per package, so a project declaring N packages traverses its entire tree N times on every wheel build, editable rebuilds included, and build output and vendored dependencies with it.

Most of what that collects can never be used. `match_path` only consults a nested ignore when `dirpath == np or np in dirpath.parents`, so only the walked subtree and its ancestor chain can ever match. Everything else is parsed, stored, and then tested against every path for the rest of the walk, since `nested_excludes` is scanned linearly per path.

## Fix

Collect from `starting_path`'s subtree plus the directories above it. The project root keeps being handled separately through `global_exclude_lines`.

SDists pass `Path()`, so that path is unchanged. This only affects callers walking a subdirectory, which is exactly the case that was paying for the whole tree.

## Numbers

PyTorch checkout, packages `torch` / `torchgen` / `functorch`, warm cache on a local SSD:

| | time | files mapped |
|---|---|---|
| `packages_to_file_mapping`, `main` | 7.17s | 4699 |
| with this patch | 1.09s | 4699 |

The pre-pass alone was visiting 1.14M directory entries across three walks. `nested_excludes` drops from 135 entries to 0, 0 and 4 for the three packages, which is where the remainder of the win comes from.

## Where it turned up

Reported downstream as pytorch/pytorch#194945, where an accumulated scratch directory on NFS pushed a rebuild past 40 minutes after compilation had already finished. It is also the "nested `.gitignore` discovery walks the whole tree" item under performance in #1541.

Worth noting for anyone triaging something similar: that directory was already in `.gitignore` and it made no difference. The pre-pass is what *collects* the ignore files, so it runs before any spec exists and cannot prune. The main walk prunes correctly.

## Verification

- File selection is unchanged: byte-identical 4699-file mapping on the PyTorch tree, before and after.
- Full suite unchanged: 979 passed, 79 skipped, and one pre-existing failure (`test_pep517_sdist_hash`, an sdist size assertion) that fails identically on `main` in the same environment.
- The added test fails on `main` at the traversal assertion; its result-set assertion passes both before and after, which is what shows this is purely a cost change.
- `ruff check`, `ruff format` and `mypy` clean on the touched files.

## Possible follow-up

The linear scan of `nested_excludes` in `match_path` is a separate cost: an SDist walk of the same tree still pays 135 spec checks per file. Keying the dict and walking a path's ancestors instead would make it O(depth). Happy to send that separately if it looks worthwhile.
