### PR TITLE
fix: drop two-token CMAKE_BUILD_TYPE from CMAKE_ARGS

### DIFF
--- a/docs/api/scikit_build_core.builder.rst
+++ b/docs/api/scikit_build_core.builder.rst
@@ -17,6 +17,14 @@ scikit\_build\_core.builder.builder module
    :show-inheritance:
    :undoc-members:
 
+scikit\_build\_core.builder.cmake\_args module
+----------------------------------------------
+
+.. automodule:: scikit_build_core.builder.cmake_args
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 scikit\_build\_core.builder.generator module
 --------------------------------------------
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -6,6 +6,7 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._reproducible",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.program_search",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.resources",
+    f"{__spec__.parent}.cmake_args",
     f"{__spec__.parent}.generator",
     f"{__spec__.parent}.sysconfig",
     "importlib",
@@ -13,6 +14,7 @@ __lazy_modules__ = {
     "packaging",
     "packaging.version",
     "platform",
+    "re",
     "shlex",
     "sysconfig",
     "typing",
@@ -38,6 +40,7 @@ from .._logging import logger
 from .._reproducible import get_reproducible_epoch
 from ..program_search import _macos_binary_is_x86
 from ..resources import find_python
+from .cmake_args import iter_cmake_defines
 from .generator import set_environment_for_gen
 from .sysconfig import (
     get_numpy_include_dir,
@@ -49,7 +52,7 @@ from .sysconfig import (
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from ..cmake import CMaker
     from ..settings.skbuild_model import ScikitBuildSettings
@@ -88,26 +91,9 @@ def get_archs(env: Mapping[str, str], cmake_args: Sequence[str] = ()) -> list[st
     """
 
     if sys.platform.startswith("darwin"):
-        # Handles both the joined -DVAR=value and two-token -D VAR=value
-        # forms; a plain substring test would false-positive on any arg
-        # merely containing "CMAKE_SYSTEM_PROCESSOR" (e.g. -DFOO=CMAKE_SYSTEM_PROCESSOR).
-        expecting_value = False
-        for cmake_arg in cmake_args:
-            if expecting_value:
-                match = re.fullmatch(
-                    r"CMAKE_SYSTEM_PROCESSOR(?::[^=]*)?=(.*)", cmake_arg.strip()
-                )
-                if match:
-                    return [match.group(1)]
-                expecting_value = False
-            elif cmake_arg == "-D":
-                expecting_value = True
-            else:
-                match = re.fullmatch(
-                    r"-D\s*CMAKE_SYSTEM_PROCESSOR(?::[^=]*)?=(.*)", cmake_arg
-                )
-                if match:
-                    return [match.group(1)]
+        for define in iter_cmake_defines(cmake_args):
+            if define.name == "CMAKE_SYSTEM_PROCESSOR":
+                return [define.value]
         return re.findall(r"-arch (\S+)", env.get("ARCHFLAGS", ""))
     if sys.platform.startswith("win") and get_platform(env) == "win-arm64":
         return ["win_arm64"]
@@ -150,44 +136,20 @@ def _warn_macos_arch_mismatch(cmake_path: Path, *, explicit_arch: bool) -> None:
         )
 
 
-# Joined ``-DVAR=value`` / two-token ``-D VAR=value``, with optional CMake type
-# (``:STRING``). A prefix test on ``-DCMAKE_BUILD_TYPE`` misses the two-token
-# form and false-positives on ``-DCMAKE_BUILD_TYPE_FOO``. See get_archs (#1417).
-_UNSUPPORTED_CMAKE_DEFINE = re.compile(
-    r"CMAKE_(?:BUILD_TYPE|INSTALL_PREFIX)(?::[^=]*)?(?:=.*)?\Z"
-)
+_UNSUPPORTED_ENV_DEFINES = frozenset({"CMAKE_BUILD_TYPE", "CMAKE_INSTALL_PREFIX"})
 
 
-def _is_unsupported_cmake_define(token: str) -> bool:
-    return _UNSUPPORTED_CMAKE_DEFINE.fullmatch(token.strip()) is not None
-
-
-def _filter_env_cmake_args(env_cmake_args: list[str]) -> Generator[str, None, None]:
+def _filter_env_cmake_args(env_cmake_args: list[str]) -> list[str]:
     """
-    Filter out CMake arguments that are not supported from CMAKE_ARGS.
-
-    Handles both the joined ``-DVAR=value`` and two-token ``-D VAR=value``
-    forms, matching ``get_archs`` / ``parse_generator``.
+    Filter out CMake defines that are not supported from CMAKE_ARGS.
     """
-    expecting_value = False
-    for arg in env_cmake_args:
-        if expecting_value:
-            expecting_value = False
-            if _is_unsupported_cmake_define(arg):
-                logger.warning("Unsupported CMAKE_ARGS ignored: -D {}", arg)
-                continue
-            yield "-D"
-            yield arg
-            continue
-        if arg == "-D":
-            expecting_value = True
-            continue
-        if arg.startswith("-D") and _is_unsupported_cmake_define(arg[2:]):
-            logger.warning("Unsupported CMAKE_ARGS ignored: {}", arg)
-            continue
-        yield arg
-    if expecting_value:
-        yield "-D"
+    drop: set[int] = set()
+    for define in iter_cmake_defines(env_cmake_args):
+        if define.name in _UNSUPPORTED_ENV_DEFINES:
+            ignored = env_cmake_args[define.start : define.stop]
+            logger.warning("Unsupported CMAKE_ARGS ignored: {}", " ".join(ignored))
+            drop.update(range(define.start, define.stop))
+    return [arg for i, arg in enumerate(env_cmake_args) if i not in drop]
 
 
 def get_cmake_args_from_settings(

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -13,7 +13,6 @@ __lazy_modules__ = {
     "packaging",
     "packaging.version",
     "platform",
-    "re",
     "shlex",
     "sysconfig",
     "typing",

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -472,8 +472,8 @@ class Builder:
                 explicit_arch = (
                     "CMAKE_OSX_ARCHITECTURES" in self.settings.cmake.define
                     or any(
-                        "CMAKE_OSX_ARCHITECTURES" in arg
-                        for arg in self.get_cmake_args()
+                        define.name == "CMAKE_OSX_ARCHITECTURES"
+                        for define in iter_cmake_defines(self.get_cmake_args())
                     )
                 )
                 _warn_macos_arch_mismatch(

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -151,18 +151,44 @@ def _warn_macos_arch_mismatch(cmake_path: Path, *, explicit_arch: bool) -> None:
         )
 
 
+# Joined ``-DVAR=value`` / two-token ``-D VAR=value``, with optional CMake type
+# (``:STRING``). A prefix test on ``-DCMAKE_BUILD_TYPE`` misses the two-token
+# form and false-positives on ``-DCMAKE_BUILD_TYPE_FOO``. See get_archs (#1417).
+_UNSUPPORTED_CMAKE_DEFINE = re.compile(
+    r"CMAKE_(?:BUILD_TYPE|INSTALL_PREFIX)(?::[^=]*)?(?:=.*)?\Z"
+)
+
+
+def _is_unsupported_cmake_define(token: str) -> bool:
+    return _UNSUPPORTED_CMAKE_DEFINE.fullmatch(token.strip()) is not None
+
+
 def _filter_env_cmake_args(env_cmake_args: list[str]) -> Generator[str, None, None]:
     """
     Filter out CMake arguments that are not supported from CMAKE_ARGS.
+
+    Handles both the joined ``-DVAR=value`` and two-token ``-D VAR=value``
+    forms, matching ``get_archs`` / ``parse_generator``.
     """
-
-    unsupported_args = ("-DCMAKE_BUILD_TYPE", "-DCMAKE_INSTALL_PREFIX")
-
+    expecting_value = False
     for arg in env_cmake_args:
-        if arg.startswith(unsupported_args):
-            logger.warning("Unsupported CMAKE_ARGS ignored: {}", arg)
-        else:
+        if expecting_value:
+            expecting_value = False
+            if _is_unsupported_cmake_define(arg):
+                logger.warning("Unsupported CMAKE_ARGS ignored: -D {}", arg)
+                continue
+            yield "-D"
             yield arg
+            continue
+        if arg == "-D":
+            expecting_value = True
+            continue
+        if arg.startswith("-D") and _is_unsupported_cmake_define(arg[2:]):
+            logger.warning("Unsupported CMAKE_ARGS ignored: {}", arg)
+            continue
+        yield arg
+    if expecting_value:
+        yield "-D"
 
 
 def get_cmake_args_from_settings(

--- a/src/scikit_build_core/builder/cmake_args.py
+++ b/src/scikit_build_core/builder/cmake_args.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+__all__ = ["CMakeDefine", "iter_cmake_defines"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class CMakeDefine(NamedTuple):
+    start: int
+    stop: int
+    name: str
+    value: str
+
+
+def iter_cmake_defines(args: Sequence[str]) -> Iterator[CMakeDefine]:
+    """
+    Yield every ``-D`` define in ``args``, in both the joined ``-DVAR=value``
+    and the two-token ``-D VAR=value`` forms. An optional ``:TYPE`` is dropped
+    from the name. ``args[start:stop]`` is the token span of the define.
+    """
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "-D" and i + 1 < len(args):
+            stop, body = i + 2, args[i + 1]
+        elif arg.startswith("-D"):
+            stop, body = i + 1, arg[2:]
+        else:
+            i += 1
+            continue
+        name, sep, value = body.strip().partition("=")
+        if sep:
+            yield CMakeDefine(i, stop, name.partition(":")[0].strip(), value)
+        i = stop

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    f"{__spec__.parent}.cmake_args",
     "platform",
-    "re",
 }
 
 import os
 import platform
-import re
 from typing import NamedTuple
 
 from .._logging import logger
+from .cmake_args import iter_cmake_defines
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -56,32 +56,16 @@ def get_cmake_osx_deployment_target(
     """
     Find an explicit ``CMAKE_OSX_DEPLOYMENT_TARGET`` known before the build
     directory exists: a ``cmake.define`` entry or a ``-DCMAKE_OSX_DEPLOYMENT_TARGET=``
-    in ``cmake.args``. Handles both the joined ``-DVAR=value`` and the
-    two-token ``-D VAR=value`` forms (mirroring ``parse_generator``'s ``-G``
-    handling). The args value wins over the define, mirroring CMake's own
+    in ``cmake.args``. The args value wins over the define, mirroring CMake's own
     command-line-over-cache precedence. Settings in ``CMakeLists.txt`` or a
     toolchain file cannot be seen here and are not honored.
     """
     target: str | None = None
     if cmake_defines is not None:
         target = cmake_defines.get("CMAKE_OSX_DEPLOYMENT_TARGET", None)
-    expecting_value = False
-    for arg in cmake_args:
-        if expecting_value:
-            match = re.fullmatch(
-                r"CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg.strip()
-            )
-            if match:
-                target = match.group(1)
-            expecting_value = False
-        elif arg == "-D":
-            expecting_value = True
-        else:
-            match = re.fullmatch(
-                r"-D\s*CMAKE_OSX_DEPLOYMENT_TARGET(?::[^=]*)?=(.*)", arg
-            )
-            if match:
-                target = match.group(1)
+    for define in iter_cmake_defines(cmake_args):
+        if define.name == "CMAKE_OSX_DEPLOYMENT_TARGET":
+            target = define.value
     return target
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -398,21 +398,7 @@ def test_builder_macos_arch_extra(monkeypatch):
         (r"-DA='1 1' -DB=\'2\'", ["-DA=1 1", "-DB='2'"]),
         (r'-DA="1 1" -DB=\"2\"', ["-DA=1 1", '-DB="2"']),
         ('"-DA=1 1" -DB=2', ["-DA=1 1", "-DB=2"]),
-    ],
-)
-def test_builder_get_cmake_args(monkeypatch, cmake_args, answer):
-    monkeypatch.setenv("CMAKE_ARGS", cmake_args)
-    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
-    tmpbuilder = Builder(
-        settings=ScikitBuildSettings(wheel=WheelSettings()),
-        config=tmpcfg,
-    )
-    assert tmpbuilder.get_cmake_args() == answer
-
-
-@pytest.mark.parametrize(
-    ("cmake_args", "answer"),
-    [
+        ("-D A=1 -DB=2", ["-D", "A=1", "-DB=2"]),
         ("-DCMAKE_BUILD_TYPE=Release -DA=1", ["-DA=1"]),
         ("-D CMAKE_BUILD_TYPE=Release -DA=1", ["-DA=1"]),
         ("-DCMAKE_BUILD_TYPE:STRING=Debug -DA=1", ["-DA=1"]),
@@ -422,10 +408,7 @@ def test_builder_get_cmake_args(monkeypatch, cmake_args, answer):
         ("-DCMAKE_BUILD_TYPE_FOO=1 -DA=1", ["-DCMAKE_BUILD_TYPE_FOO=1", "-DA=1"]),
     ],
 )
-def test_builder_filter_env_cmake_args(monkeypatch, cmake_args, answer):
-    # Two-token ``-D VAR=value`` must be dropped the same way as joined
-    # ``-DVAR=value``. A prefix match would miss the two-token form and
-    # false-positive on CMAKE_BUILD_TYPE_FOO (same class as get_archs #1417).
+def test_builder_get_cmake_args(monkeypatch, cmake_args, answer):
     monkeypatch.setenv("CMAKE_ARGS", cmake_args)
     tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
     tmpbuilder = Builder(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -410,6 +410,31 @@ def test_builder_get_cmake_args(monkeypatch, cmake_args, answer):
     assert tmpbuilder.get_cmake_args() == answer
 
 
+@pytest.mark.parametrize(
+    ("cmake_args", "answer"),
+    [
+        ("-DCMAKE_BUILD_TYPE=Release -DA=1", ["-DA=1"]),
+        ("-D CMAKE_BUILD_TYPE=Release -DA=1", ["-DA=1"]),
+        ("-DCMAKE_BUILD_TYPE:STRING=Debug -DA=1", ["-DA=1"]),
+        ("-D CMAKE_INSTALL_PREFIX=/usr -DA=1", ["-DA=1"]),
+        ("-DCMAKE_INSTALL_PREFIX:PATH=/opt -DA=1", ["-DA=1"]),
+        ("-DFOO=CMAKE_BUILD_TYPE -DA=1", ["-DFOO=CMAKE_BUILD_TYPE", "-DA=1"]),
+        ("-DCMAKE_BUILD_TYPE_FOO=1 -DA=1", ["-DCMAKE_BUILD_TYPE_FOO=1", "-DA=1"]),
+    ],
+)
+def test_builder_filter_env_cmake_args(monkeypatch, cmake_args, answer):
+    # Two-token ``-D VAR=value`` must be dropped the same way as joined
+    # ``-DVAR=value``. A prefix match would miss the two-token form and
+    # false-positive on CMAKE_BUILD_TYPE_FOO (same class as get_archs #1417).
+    monkeypatch.setenv("CMAKE_ARGS", cmake_args)
+    tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))
+    tmpbuilder = Builder(
+        settings=ScikitBuildSettings(wheel=WheelSettings()),
+        config=tmpcfg,
+    )
+    assert tmpbuilder.get_cmake_args() == answer
+
+
 def test_builder_exports_source_date_epoch(monkeypatch):
     monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     tmpcfg = typing.cast("CMaker", SimpleNamespace(env=os.environ.copy()))


### PR DESCRIPTION
`CMAKE_ARGS` already drops joined `-DCMAKE_BUILD_TYPE` and `-DCMAKE_INSTALL_PREFIX` because scikit-build-core sets those itself. The two-token form (`-D CMAKE_BUILD_TYPE=Release`) still reached CMake.

Parse it the same way `get_archs` already handles two-token `-D CMAKE_SYSTEM_PROCESSOR`. A prefix match on `-DCMAKE_BUILD_TYPE` also false-positived on `-DCMAKE_BUILD_TYPE_FOO`.

## Test plan
- [x] `uv run pytest tests/test_builder.py::test_builder_get_cmake_args tests/test_builder.py::test_builder_filter_env_cmake_args` (11 passed)
- [x] `uv run ruff check` / `ruff format --check` on the two changed files
