### PR TITLE
perf: cache entry-point scans and known-wheel lookups

### DIFF
--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import importlib.metadata
 import sys
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     else:
         from importlib.metadata import EntryPoints
 
-__all__ = ["entry_points"]
+__all__ = ["cached_entry_points", "entry_points"]
 
 
 def entry_points(*, group: str) -> EntryPoints:
@@ -22,6 +23,16 @@ def entry_points(*, group: str) -> EntryPoints:
 
     epg = importlib.metadata.entry_points()
     return epg.get(group, [])  # pylint: disable=no-member
+
+
+@functools.cache
+def cached_entry_points(*, group: str) -> EntryPoints:
+    """Like ``entry_points``, but scans the installed distributions only once.
+
+    ``entry_points`` is read from the module global, so a monkeypatch of it is
+    seen. Call ``cached_entry_points.cache_clear()`` if the entry points change.
+    """
+    return entry_points(group=group)
 
 
 def __dir__() -> list[str]:

--- a/src/scikit_build_core/builder/_known_wheels.py
+++ b/src/scikit_build_core/builder/_known_wheels.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.resources",
+    "packaging",
+    "packaging.tags",
+    "typing",
+}
+
+import functools
+from typing import Literal
+
+import packaging.tags
+
+from .._compat import tomllib
+from ..resources import resources
+
+__all__ = ["is_known_platform", "known_wheels"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@functools.lru_cache(maxsize=2)
+def known_wheels(name: Literal["ninja", "cmake"]) -> frozenset[str]:
+    with resources.joinpath("known_wheels.toml").open("rb") as f:
+        return frozenset(tomllib.load(f)["tool"]["scikit-build"][name]["known-wheels"])
+
+
+@functools.lru_cache(maxsize=2)
+def is_known_platform(platforms: frozenset[str]) -> bool:
+    # Called through the module so tests can monkeypatch packaging.tags.sys_tags.
+    return any(tag.platform in platforms for tag in packaging.tags.sys_tags())

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -189,9 +189,9 @@ def load_entry_provider(provider: str | Mapping[str, Any]) -> DMProtocols:
             raise TypeError(msg)
         return load_provider(module, path)
 
-    from .._compat.importlib.metadata import entry_points
+    from .._compat.importlib.metadata import cached_entry_points
 
-    eps = entry_points(group="dynamic_metadata.provider")
+    eps = cached_entry_points(group="dynamic_metadata.provider")
     matches = [ep for ep in eps if ep.name == provider]
     if not matches:
         import difflib

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -247,7 +247,7 @@ class Builder:
     def _get_entry_point_search_path(self, entry_point: str) -> dict[str, list[Path]]:
         """Get the search path dict from the entry points"""
         search_paths = {}
-        eps = metadata.entry_points(group=entry_point)
+        eps = metadata.cached_entry_points(group=entry_point)
         if eps:
             logger.debug(
                 "Loading search paths {} from entry-points: {}", entry_point, len(eps)

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -6,14 +6,12 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._variants",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.format",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.program_search",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.resources",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.settings.skbuild_read_settings",
+    f"{__spec__.parent}._known_wheels",
     f"{__spec__.parent}._load_provider",
     f"{__spec__.parent}.generator",
     "importlib",
     "importlib.util",
-    "packaging",
-    "packaging.tags",
     "pathlib",
     "shlex",
     "sysconfig",
@@ -21,15 +19,12 @@ __lazy_modules__ = {
 }
 
 import dataclasses
-import functools
 import importlib.util
 import os
 import shlex
 import sysconfig
 from pathlib import Path
 from typing import Any, Literal
-
-from packaging.tags import sys_tags
 
 from .._compat import tomllib
 from .._logging import logger
@@ -41,8 +36,8 @@ from ..program_search import (
     get_make_programs,
     get_ninja_programs,
 )
-from ..resources import resources
 from ..settings.skbuild_read_settings import SettingsReader
+from ._known_wheels import is_known_platform, known_wheels
 from ._load_provider import load_dynamic_metadata, load_provider
 from .generator import parse_generator
 
@@ -74,17 +69,6 @@ def _uses_ninja_generator(settings: ScikitBuildSettings) -> bool | None:
         return "Ninja" in os.environ["CMAKE_GENERATOR"]
 
     return None
-
-
-@functools.lru_cache(maxsize=2)
-def known_wheels(name: Literal["ninja", "cmake"]) -> frozenset[str]:
-    with resources.joinpath("known_wheels.toml").open("rb") as f:
-        return frozenset(tomllib.load(f)["tool"]["scikit-build"][name]["known-wheels"])
-
-
-@functools.lru_cache(maxsize=2)
-def is_known_platform(platforms: frozenset[str]) -> bool:
-    return any(tag.platform in platforms for tag in sys_tags())
 
 
 def _load_scikit_build_settings(

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -81,7 +81,7 @@ def _load_group(
 ) -> list[tuple[str, str, dict[str, object]]]:
     providers: list[tuple[str, str, dict[str, object]]] = []
     by_name: dict[str, list[EntryPoint]] = {}
-    for ep in metadata.entry_points(group=group):
+    for ep in metadata.cached_entry_points(group=group):
         by_name.setdefault(ep.name, []).append(ep)
     for name in sorted(by_name):
         eps = by_name[name]

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 __lazy_modules__ = {
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.builder._known_wheels",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.builder.sysconfig",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.cmake",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.resources",
     "packaging",
     "packaging.specifiers",
-    "packaging.tags",
     "pathlib",
     "platform",
     "re",
@@ -24,16 +22,14 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
-import packaging.tags
 from packaging.specifiers import SpecifierSet
 
 from .. import __version__
-from .._compat import tomllib
 from .._logging import logger
+from ..builder._known_wheels import is_known_platform, known_wheels
 from ..builder.sysconfig import get_abi_flags
 from ..cmake import CMake
 from ..errors import CMakeNotFoundError
-from ..resources import resources
 
 __all__ = ["OverrideRecord", "process_overrides", "regex_match"]
 
@@ -244,16 +240,8 @@ def override_match(
             failed_set.add("system-cmake")
 
     if cmake_wheel is not None:
-        with resources.joinpath("known_wheels.toml").open("rb") as f:
-            known_wheels_toml = tomllib.load(f)
-        known_cmake_wheels = set(
-            known_wheels_toml["tool"]["scikit-build"]["cmake"]["known-wheels"]
-        )
-        cmake_plat = known_cmake_wheels.intersection(
-            tag.platform for tag in packaging.tags.sys_tags()
-        )
-        if cmake_plat:
-            passed_dict["cmake-wheel"] = f"cmake wheel available on {cmake_plat}"
+        if is_known_platform(known_wheels("cmake")):
+            passed_dict["cmake-wheel"] = "cmake wheel available on this platform"
         else:
             failed_set.add("cmake-wheel")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,3 +475,16 @@ def pytest_report_header() -> str:
         f"sysconfig platform: {sysconfig.get_platform()}",
     ]
     return "\n".join(lines)
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterable[None]:
+    """Keep process-wide caches from leaking between tests that fake their input."""
+    from scikit_build_core._compat.importlib.metadata import cached_entry_points
+    from scikit_build_core.builder._known_wheels import is_known_platform
+
+    for cached in (cached_entry_points, is_known_platform):
+        cached.cache_clear()
+    yield
+    for cached in (cached_entry_points, is_known_platform):
+        cached.cache_clear()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1541 (items 42 and 43).

`importlib.metadata.entry_points()` scans every installed distribution. It was called once per `SettingsReader` (3-4 per build), three times per CMake configure, and once per dynamic-metadata provider. A new `cached_entry_points` helper in the `_compat` shim does the scan one time per group.

The `if.cmake-wheel` override also re-read `known_wheels.toml` and recomputed `packaging.tags.sys_tags()` for every override. The cached `known_wheels` and `is_known_platform` helpers move from `get_requires` to `builder/_known_wheels.py` (to avoid a circular import), and the override now uses them. Match semantics are unchanged; only the log message no longer lists the matched platform tags.

A conftest fixture clears both caches around each test, because some tests fake the entry points or the system tags.