### PR TITLE
perf: cut editable shim import time

### DIFF
--- a/src/scikit_build_core/resources/_editable_redirect.py
+++ b/src/scikit_build_core/resources/_editable_redirect.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-__lazy_modules__ = {"importlib.machinery", "importlib.util", "subprocess"}
-
-import importlib.abc
-import importlib.machinery
-import importlib.util
 import os
-import subprocess
 import sys
 
 # Import as little as possible, since every usage of Python imports this file.
+# A .pth file loads this module at every interpreter start, so the module level
+# holds only os and sys. Everything else is imported in the function that needs
+# it.
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import importlib.machinery
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 MARKER = "SKBUILD_EDITABLE_SKIP"
@@ -348,6 +349,8 @@ def _run_editable_rebuild(
             )
         raise RuntimeError(msg)
 
+    import subprocess
+
     env = os.environ.copy()
     # Protect against recursion
     if path in env.get(MARKER, "").split(os.pathsep):
@@ -401,7 +404,10 @@ def _run_editable_rebuild(
         lock.release()
 
 
-class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
+# The finders below are not subclasses of importlib.abc.MetaPathFinder: a meta
+# path finder only has to supply find_spec(), and importlib.abc pulls in typing
+# and more at every interpreter start.
+class ScikitBuildRedirectingFinder:
     def __init__(
         self,
         known_source_files: dict[str, str],
@@ -500,6 +506,9 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         # A tracked package directory without an importable __init__ is a
         # namespace package.
         if submodule_search_locations is not None:
+            import importlib.machinery
+            import importlib.util
+
             # A PEP 420 namespace can be shared with other distributions, so
             # merge in the portions native resolution would find on sys.path
             native = importlib.machinery.PathFinder.find_spec(fullname, path)  # type: ignore[arg-type]
@@ -524,6 +533,9 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         origin: str,
         submodule_search_locations: list[str] | None,
     ) -> importlib.machinery.ModuleSpec | None:
+        import importlib.machinery
+        import importlib.util
+
         is_pkg = origin.endswith(("__init__.py", "__init__.pyc"))
         # Resolve the loader through the standard sys.path_hooks machinery (PEP
         # 302) so instrumenting path hooks (e.g. beartype.claw) see redirected
@@ -593,7 +605,7 @@ class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder):
         )
 
 
-class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
+class ScikitBuildInplaceFinder:
     """
     Meta path finder for inplace editable installs.
 
@@ -632,6 +644,8 @@ class ScikitBuildInplaceFinder(importlib.abc.MetaPathFinder):
     ) -> importlib.machinery.ModuleSpec | None:
         if fullname.partition(".")[0] not in self.known_packages:
             return None
+
+        import importlib.machinery
 
         # Debounce to once per process, like the redirect finder: importing a
         # package resolves many submodules, but a single build covers them all.

--- a/tests/test_editable_redirect.py
+++ b/tests/test_editable_redirect.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
+from scikit_build_core.resources import _editable_redirect
 from scikit_build_core.resources._editable_redirect import (
     ScikitBuildInplaceFinder,
     ScikitBuildRedirectingFinder,
@@ -307,9 +309,7 @@ def test_rebuild_failure_surfaces_stdout_when_not_verbose(
             command, returncode=1, stdout="boom build error", stderr=""
         )
 
-    monkeypatch.setattr(
-        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
-    )
+    monkeypatch.setattr("subprocess.run", fake_run)
 
     finder = _make_finder(tmp_path, verbose=False)
     with pytest.raises(subprocess.CalledProcessError):
@@ -334,9 +334,7 @@ def test_rebuild_success_runs_build_and_install(
         calls.append(list(command))
         return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(
-        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
-    )
+    monkeypatch.setattr("subprocess.run", fake_run)
 
     finder = _make_finder(tmp_path, verbose=False)
     finder.rebuild()
@@ -660,9 +658,7 @@ def test_inplace_finder_rebuild_runs_build_only(
         calls.append(list(command))
         return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(
-        "scikit_build_core.resources._editable_redirect.subprocess.run", fake_run
-    )
+    monkeypatch.setattr("subprocess.run", fake_run)
 
     finder = ScikitBuildInplaceFinder(
         known_packages=["pkg"],
@@ -799,3 +795,17 @@ def test_install_inplace_is_idempotent():
     # A different package still registers its own finder.
     install_inplace(["pkg_b"], ["/src"])
     assert count_finders() == 2
+
+
+def test_no_expensive_module_level_imports():
+    """A .pth file loads the shim at every interpreter start, so keep it cheap."""
+    source = Path(_editable_redirect.__file__).read_text(encoding="utf-8")
+
+    imported: set[str] = set()
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module != "__future__":
+            imported.add(node.module or "")
+
+    assert imported == {"os", "sys"}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1541 (item 40).

Every editable install loads `_editable_redirect.py` at each interpreter start
through its `.pth` file. The module imported `importlib.abc` only to subclass
`MetaPathFinder` (which pulls in `typing` and more), and `subprocess` for the
optional rebuild.

The two finders are now plain classes (a meta path finder only has to supply
`find_spec`), and `importlib.machinery`, `importlib.util` and `subprocess` are
imported in the functions that use them. Only `os` and `sys` stay at module
level. Behaviour is unchanged.

Warm `python -X importtime -c "import shim"` on the shim file alone:

| Python | before | after |
| --- | --- | --- |
| 3.9 | 10.3 ms | 0.5 ms |
| 3.14 | 4.4 ms | 0.8 ms |
| 3.15 | 8.1 ms | 0.8 ms |

A new test parses the shim with `ast` and asserts that the module-level
imports stay `os` and `sys`. The shim was also smoke tested on 3.9, 3.13, 3.14
and 3.15.
