### PR TITLE
perf: build and builder hot paths

### DIFF
--- a/src/scikit_build_core/build/_editable.py
+++ b/src/scikit_build_core/build/_editable.py
@@ -123,10 +123,12 @@ def editable_redirect_files(
     if use_start is None:
         use_start = sys.version_info >= (3, 15)
     external_install = install_prefix is not None
-    modules = mapping_to_modules(mapping, libdir)
-    installed = libdir_to_installed(libdir, absolute=external_install)
-    directories, known_packages = collect_search_locations(
-        mapping, libdir, absolute=external_install
+    mapping_entries = _scan_mapping(mapping, libdir)
+    installed_entries = _scan_installed(libdir)
+    modules = _mapping_to_modules(mapping_entries)
+    installed = _libdir_to_installed(installed_entries, absolute=external_install)
+    directories, known_packages = _collect_search_locations(
+        mapping_entries, installed_entries, absolute=external_install
     )
     rebuild = settings.editable.rebuild_enabled
     install_dir: str | None
@@ -325,6 +327,25 @@ def package_search_dirs(packages: Mapping[str, str]) -> list[str]:
     return result
 
 
+def _scan_mapping(mapping: dict[str, str], libdir: Path) -> list[tuple[Path, Path]]:
+    """
+    Pair each mapped source file (absolute, symlinks kept) with its target path
+    relative to ``libdir``. Computed once and shared by the passes below.
+    """
+    return [
+        (Path(source).absolute(), Path(target).relative_to(libdir))
+        for source, target in mapping.items()
+    ]
+
+
+def _scan_installed(libdir: Path) -> list[tuple[Path, Path]]:
+    """
+    Pair each installed file with its path relative to ``libdir``. This is the
+    only walk of the install tree; the passes below share the result.
+    """
+    return [(v, v.relative_to(libdir)) for v in scantree(libdir)]
+
+
 def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     """
     Map importable module names to their (absolute) source files.
@@ -333,17 +354,19 @@ def mapping_to_modules(mapping: dict[str, str], libdir: Path) -> dict[str, str]:
     separately by :func:`collect_search_locations` so that ``find_spec`` never
     resolves a name to a non-importable file.
     """
+    return _mapping_to_modules(_scan_mapping(mapping, libdir))
+
+
+def _mapping_to_modules(entries: Sequence[tuple[Path, Path]]) -> dict[str, str]:
     result: dict[str, str] = {}
     selected: dict[str, Path] = {}
-    for k, v in mapping.items():
-        rel = Path(v).relative_to(libdir)
+    for source, rel in entries:
         if not is_trackable(rel) or not is_module(rel):
             continue
         module = path_to_module(rel)
         if module in result and not _prefer_module(rel, selected[module]):
             continue
-        # Make the source path absolute, but do not resolve symlinks
-        result[module] = str(Path(k).absolute())
+        result[module] = str(source)
         selected[module] = rel
     return result
 
@@ -359,10 +382,15 @@ def libdir_to_installed(libdir: Path, *, absolute: bool = False) -> dict[str, st
     ``libdir`` -- used when the install tree lives outside the wheel (a
     rebuildable editable pointing at a persistent build-dir).
     """
+    return _libdir_to_installed(_scan_installed(libdir), absolute=absolute)
+
+
+def _libdir_to_installed(
+    entries: Sequence[tuple[Path, Path]], *, absolute: bool = False
+) -> dict[str, str]:
     result: dict[str, str] = {}
     selected: dict[str, Path] = {}
-    for v in scantree(libdir):
-        pth = v.relative_to(libdir)
+    for v, pth in entries:
         if not is_trackable(pth) or not is_module(pth):
             continue
         module = path_to_module(pth)
@@ -391,16 +419,24 @@ def collect_search_locations(
     ``packages`` are the modules whose directory holds an ``__init__`` (including
     ``.pxd``/``.pyx``).
     """
+    return _collect_search_locations(
+        _scan_mapping(mapping, libdir), _scan_installed(libdir), absolute=absolute
+    )
+
+
+def _collect_search_locations(
+    mapping_entries: Sequence[tuple[Path, Path]],
+    installed_entries: Sequence[tuple[Path, Path]],
+    *,
+    absolute: bool = False,
+) -> tuple[dict[str, list[str]], list[str]]:
     # Collect (module, directory, is_init) entries. Source tree: the absolute
     # source file's parent. Install tree: the directory relative to libdir.
     entries: list[tuple[str, str, bool]] = []
-    for source, target in mapping.items():
-        rel = Path(target).relative_to(libdir)
+    for src, rel in mapping_entries:
         if is_trackable(rel):
-            src = Path(source).absolute()
             entries.append((path_to_module(rel), str(src.parent), _is_init(src.name)))
-    for v in scantree(libdir):
-        rel = v.relative_to(libdir)
+    for v, rel in installed_entries:
         if is_trackable(rel):
             directory = str(v.parent if absolute else rel.parent)
             entries.append((path_to_module(rel), directory, _is_init(rel.name)))

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -394,15 +394,6 @@ class Builder:
                     sabi = _SabiMode.ABI3
                     sabi_minor = target_minor_version
 
-        python_library = get_python_library(self.config.env, abi3=False)
-        python_sabi_library = None
-        if sabi == _SabiMode.ABI3T:
-            python_sabi_library = get_python_library(self.config.env, abi3t=True)
-        elif sabi == _SabiMode.ABI3:
-            python_sabi_library = get_python_library(self.config.env, abi3=True)
-        python_include_dir = get_python_include_dir()
-        numpy_include_dir = get_numpy_include_dir()
-
         # Warning for CPython 3.13.4 Windows bug
         if (
             sys.implementation.name == "cpython"
@@ -415,6 +406,16 @@ class Builder:
             )
 
         if self.settings.cmake.python_hints:
+            # Only computed when the hints are used; get_numpy_include_dir imports NumPy.
+            python_library = get_python_library(self.config.env, abi3=False)
+            python_sabi_library = None
+            if sabi == _SabiMode.ABI3T:
+                python_sabi_library = get_python_library(self.config.env, abi3t=True)
+            elif sabi == _SabiMode.ABI3:
+                python_sabi_library = get_python_library(self.config.env, abi3=True)
+            python_include_dir = get_python_include_dir()
+            numpy_include_dir = get_numpy_include_dir()
+
             # Classic Find Python
             cache_config["PYTHON_EXECUTABLE"] = Path(sys.executable)
             cache_config["PYTHON_INCLUDE_DIR"] = python_include_dir

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -48,7 +48,7 @@ from .generator import parse_generator
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    from collections.abc import Generator, Mapping, Sequence
 
     from .._compat.typing import Self
     from ..settings.skbuild_model import ScikitBuildSettings
@@ -114,6 +114,9 @@ class GetRequires:
     settings: ScikitBuildSettings = dataclasses.field(
         default_factory=_load_scikit_build_settings
     )
+    dynamic_metadata_entries: Sequence[dict[str, Any]] = dataclasses.field(
+        default_factory=_read_dynamic_metadata
+    )
 
     @classmethod
     def from_config_settings(
@@ -121,7 +124,10 @@ class GetRequires:
         config_settings: Mapping[str, list[str] | str] | None,
         state: Literal["sdist", "wheel", "editable"] = "sdist",
     ) -> Self:
-        return cls(_load_scikit_build_settings(config_settings, state))
+        reader = SettingsReader.from_file(
+            "pyproject.toml", config_settings, state=state
+        )
+        return cls(reader.settings, reader.dynamic_metadata)
 
     def cmake(self) -> Generator[str, None, None]:
         if self.settings.fail or os.environ.get("CMAKE_EXECUTABLE", ""):
@@ -207,7 +213,7 @@ class GetRequires:
                 )(config)
 
         # Standard top-level [[tool.dynamic-metadata]] entries (0.3).
-        for provider, settings in load_dynamic_metadata(_read_dynamic_metadata()):
+        for provider, settings in load_dynamic_metadata(self.dynamic_metadata_entries):
             get_requires = getattr(provider, "get_requires_for_dynamic_metadata", None)
             if get_requires is not None:
                 yield from get_requires(settings)

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -337,12 +337,10 @@ class CMaker:
         local_args = list(
             self._compute_build_args(verbose=verbose, build_type=build_type)
         )
-        if not targets:
-            self._build(*local_args, *build_args)
-            return
-
-        for target in targets:
-            self._build(*local_args, "--target", target, *build_args)
+        if targets:
+            # CMake 3.15+ accepts several targets in one invocation.
+            local_args += ["--target", *targets]
+        self._build(*local_args, *build_args)
 
     def _build(self, *args: str) -> None:
         try:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -305,9 +305,11 @@ class SettingsReader:
         # Human-readable names parallel to ``toml_srcs`` (used by suggestions).
         toml_src_names = ["pyproject.toml"]
 
-        # Standard top-level [[tool.dynamic-metadata]] entries (0.3); kept for
-        # validation only (cannot be combined with tool.scikit-build.metadata).
-        self._dynamic_metadata = pyproject.get("tool", {}).get("dynamic-metadata", [])
+        # Standard top-level [[tool.dynamic-metadata]] entries (0.3). Kept so
+        # callers do not have to parse pyproject.toml a second time.
+        self.dynamic_metadata: list[dict[str, Any]] = pyproject.get("tool", {}).get(
+            "dynamic-metadata", []
+        )
 
         # Support for cmake.version='CMakeLists.txt'
         # We will save the value for now since we need the CMakeLists location
@@ -631,7 +633,7 @@ class SettingsReader:
             toml_sources=self._static_srcs,
         )
 
-        if self.settings.metadata and self._dynamic_metadata:
+        if self.settings.metadata and self.dynamic_metadata:
             sys.stdout.flush()
             rich_error(
                 "tool.scikit-build.metadata cannot be combined with the standard "

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -532,6 +532,44 @@ def test_builder_windows_library_hint_sabi(tmp_path, monkeypatch, limited_api):
     assert ("set(Python_SABI_LIBRARY " in cache) == limited_api
 
 
+def test_builder_no_python_hints_skips_lookups(tmp_path, monkeypatch):
+    # The hints are the only consumer; get_numpy_include_dir imports NumPy, so
+    # neither lookup may run when the hints are off.
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+    monkeypatch.setattr(config, "configure", unittest.mock.Mock())
+
+    import scikit_build_core.builder.builder as builder_mod
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        msg = "python hints are disabled"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(builder_mod, "get_numpy_include_dir", boom)
+    monkeypatch.setattr(builder_mod, "get_python_library", boom)
+    monkeypatch.setattr(builder_mod, "get_python_include_dir", boom)
+    monkeypatch.setattr(Builder, "_get_entry_point_search_path", lambda *_: {})
+
+    builder = Builder(
+        settings=ScikitBuildSettings(
+            cmake=CMakeSettings(python_hints=False),
+            search=SearchSettings(site_packages=False),
+        ),
+        config=config,
+    )
+    builder.configure(defines={})
+
+    cache = config.init_cache_file.read_text(encoding="utf-8")
+    assert "Python_EXECUTABLE" not in cache
+
+
 def patch_cpython_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     implementation = vars(sys.implementation).copy()
     implementation["name"] = "cpython"

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -303,6 +303,29 @@ def test_install_targets(tmp_path: Path, fp):
     assert not any("--install" in c for c in fp.calls)
 
 
+def test_build_multiple_targets_one_call(tmp_path: Path, fp):
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    build_dir = tmp_path / "build"
+
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=build_dir,
+        build_type="Release",
+        single_config=True,
+    )
+
+    fp.register([fp.program("cmake"), fp.any()], occurrences=10)
+
+    config.build(targets=["one", "two"])
+
+    build_calls = [c for c in fp.calls if "--build" in c]
+    assert len(build_calls) == 1
+    call = [os.fspath(arg) for arg in build_calls[0]]
+    assert call[call.index("--target") :] == ["--target", "one", "two"]
+
+
 def test_install_targets_and_components(tmp_path: Path, fp):
     source_dir = tmp_path / "src"
     source_dir.mkdir()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1541 (items 44 and 47).

Four small performance fixes in the build/builder layer:

- Compute the Python hints only when `cmake.python-hints` is on. `get_numpy_include_dir()` imports NumPy and `get_python_library()` searches the filesystem, and both ran even when the values were thrown away.
- Reuse the `[[tool.dynamic-metadata]]` entries that `SettingsReader` already parsed, instead of reading and parsing `pyproject.toml` a second time in `GetRequires`.
- Walk the install tree once when the editable redirect files are made. `libdir_to_installed` and `collect_search_locations` each did a full `scantree`, and each also iterated the source mapping.
- Give all `build.targets` to one `cmake --build` call. CMake 3.15, the project floor, accepts more than one `--target` value.

New unit tests cover the disabled hints and the single build call.
