### PR TITLE
perf: look up nested .gitignore specs by ancestor instead of scanning all

### DIFF
--- a/src/scikit_build_core/build/_file_processor.py
+++ b/src/scikit_build_core/build/_file_processor.py
@@ -89,9 +89,7 @@ def _nested_ignore_dirs(starting_path: Path) -> Generator[Path, None, None]:
     subtree, plus the chain of directories above it, can ever match. Walking
     the whole project to collect the rest is pure cost: for a package that is
     a subdirectory it means traversing every sibling tree -- build outputs,
-    vendored dependencies, scratch directories -- once per package, and it
-    also inflates the per-path loop over ``nested_excludes`` with entries that
-    can never apply.
+    vendored dependencies, scratch directories -- once per package.
 
     The project root is omitted: its ``.gitignore`` is read separately into
     the global spec.
@@ -388,11 +386,11 @@ def match_path(
         )
         return False
 
-    # Check relative ignores (Python 3.9's is_relative_to workaround)
-    for np, nex in nested_excludes.items():
-        if (dirpath == np or np in dirpath.parents) and (
-            c := nex.check_file(p.relative_to(np))
-        ).include:
+    # Nested ignores, nearest first: only the walked directory and its
+    # ancestors can hold one that applies, so look those up directly.
+    for np in (dirpath, *dirpath.parents):
+        nex = nested_excludes.get(np)
+        if nex is not None and (c := nex.check_file(p.relative_to(np))).include:
             assert c.index is not None
             logger.debug(
                 "Excluding {} {} because it is explicitly excluded by nested ignore with {!r}.",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1542. `match_path` scanned every nested `.gitignore` spec for each path and tested whether its directory was an ancestor. Only the walked directory and its ancestors can hold an applicable spec, so this walks that chain and does dict lookups instead. Per-path cost goes from O(nested ignore files) to O(depth). File selection is unchanged; the existing nested-ignore tests cover both the walked directory and ancestor cases.
