### PR TITLE
chore: clean up leaked and stale config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
       - id: name-tests-test
         args: ["--pytest-test-first"]
         exclude: "^tests/packages/|^tests/utils"
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
         exclude: "^tests"
 
@@ -83,8 +82,6 @@ repos:
           - cmake
           - exceptiongroup
           - hatch-fancy-pypi-readme>=23.2
-          - importlib-resources
-          - markdown-it-py
           - ninja
           - nox
           - packaging>=24.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ It is built with **hatchling** and stored under `src/scikit_build_core/`.
 
 ## Running things
 
-- Prefer `uv run` over bare Python invocations. There is a `uv.lock` checked in.
+- Prefer `uv run` over bare Python invocations. `uv.lock` is gitignored, but CI
+  watches it to decide whether to run the test job.
 - Use `uv sync` for a local dev install. `uv run` does this for you.
 - `nox` is the task runner.
   - `nox -s tests` — run tests with xdist (`-n auto`).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "Please cite this software using the metadata from 'preferred-citation'."
 title: "Scikit-build-core"
-version: "0.10.7"
-date-released: "2024-10-20"
+version: "1.0.3"
+date-released: "2026-07-12"
 abstract: "Build compiled Python packages using CMake"
 keywords:
   - python

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,8 +37,8 @@ def lint(session: nox.Session) -> None:
     """
     Run the linter.
     """
-    session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
+    session.install("prek")
+    session.run("prek", "run", "--all-files", *session.posargs)
 
 
 @nox.session(reuse_venv=True)
@@ -142,6 +142,7 @@ def minimums(session: nox.Session) -> None:
         session,
         install_args=["--resolution=lowest-direct"],
         run_args=["-Wdefault"],
+        extras=["test-schema"],
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ test-core = [
     'setuptools >=45; python_version=="3.9"',
     'setuptools >=49; python_version>="3.10" and python_version<"3.12"',
     'setuptools >=66.1; python_version>="3.12"',
-    'typing-extensions >=3.10; python_version<"3.10"',
     "virtualenv >=20.20",
     "wheel >=0.40",
 ]
@@ -185,12 +184,11 @@ docs = [
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/scikit_build_core/_version.py"
-build.targets.sdist.exclude = [".git", ".agents/", ".distro/", ".fmf/", ".github/", ".packit.yaml", ".readthedocs.yaml"]
+build.targets.sdist.exclude = [".git", ".agents/", ".distro/", ".fmf/", ".github/", ".packit.yaml", ".readthedocs.yml"]
 
 
 [tool.uv]
 exclude-newer = "7 days"
-workspace.members = ["tmp/hello/hello"]
 
 # These provide CMake helpers used by the init templates (f2py_add_module,
 # cython helpers); allow their freshly released versions so the generated
@@ -207,10 +205,6 @@ xfail_strict = true
 filterwarnings = [
     "error",
     "ignore:Config variable '.*' is unset, Python ABI tag may be incorrect:RuntimeWarning",
-    "default:pkg_resources is deprecated as an API:DeprecationWarning:wheel",  # Caused by wheel<0.41 in tests
-    "default:The 'wheel' package is no longer the canonical location:DeprecationWarning",  # Caused by wheel also
-    "default:The 'wheel' package is no longer the canonical location:FutureWarning",  # Newer wheel/setuptools emit this as a FutureWarning
-    "default:onerror argument is deprecated, use onexc instead:DeprecationWarning:wheel", # Caused by wheel<0.41 & Python 3.12
     "default:The distutils package is deprecated and slated for removal:DeprecationWarning",  # Caused by setuptools sometimes
     "default:The distutils.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning",  # Caused by setuptools sometimes
     "default:check_home argument is deprecated and ignored.:DeprecationWarning",  # Caused by setuptools sometimes
@@ -245,7 +239,6 @@ exclude = [
     '^tests/packages/simplest_c/src/simplest/__init__.py',
     '^tests/packages/dynamic_metadata/src/dynamic/__init__.py',
     '^tests/packages/.*/setup.py',
-    '^tests/packages/extensionlib/*',
 ]
 mypy_path = ["$MYPY_CONFIG_FILE_DIR/src", "$MYPY_CONFIG_FILE_DIR/tests/utils"]
 python_version = "3.10"
@@ -278,7 +271,6 @@ messages_control.disable = [
     "invalid-name",
     "line-too-long",
     "missing-class-docstring",
-    "missing-function-docstring",
     "missing-function-docstring",
     "missing-module-docstring",
     "wrong-import-position",
@@ -325,15 +317,12 @@ ignore = [
     "CPY",     # Copyright notice at top of file
     "D",       # Too many doc requests
     "E501",    # Line too long
-    "ERA",     # Commented out code
     "FIX",     # Hacks and todos
     "PLC0415", # Import should be at top of file
-    "PLE1205", # Format check doesn't work with our custom logger
     "PLR09",   # Too many ...
     "PLR2004", # Magic value used in comparison
     "PT013",   # It's correct to import classes for typing!
     "S101",    # Use of assert detected
-    "S404",    # subprocess module is possibly insecure
     "S603",    # subprocess untrusted input
     "S607",    # subprocess call
     "SLF001",  # Private members are okay to access
@@ -374,15 +363,13 @@ docstring-code-format = true
 "tests/**" = ["T20", "ANN", "FBT001", "INP"]
 "noxfile.py" = ["T20", "TID251"]
 ".agents/skills/**/*.py" = ["T20"]
-"src/scikit_build_core/resources/*.py" = ["PTH", "ARG002", "FBT", "TID251"]
+"src/scikit_build_core/resources/*.py" = ["PTH", "ARG002", "FBT"]
 "src/scikit_build_core/_compat/**.py" = ["TID251"]
 "src/scikit_build_core/settings/**.py" = ["FBT001", "FA"]
 "src/scikit_build_core/file_api/**.py" = ["FA"]
 "tests/conftest.py" = ["TID251"]
-"tests/packages/**.py" = ["TID251"]
 "tests/test_settings.py" = ["FA"]
 "docs/**" = ["INP"]
-"docs/conf.py" = ["TID251"]
 "docs/examples/**" = ["ANN"]
 "src/scikit_build_core/file_api/model/*.py" = ["N"]
 "**/__main__.py" = ["T20"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1541, item 49.

- Remove the leaked `[tool.uv] workspace.members = ["tmp/hello/hello"]` entry.
- Remove four stale `filterwarnings` entries for old `wheel` versions (tests pass clean without them on wheel 0.48).
- Remove six no-op ruff ignores: `ERA`, `PLE1205`, `S404`, and three per-file `TID251` entries (`tests/packages/**.py`, `docs/conf.py`, `src/scikit_build_core/resources/*.py`). Confirmed with `ruff check .` that dropping each one changes nothing.
- Remove the dead mypy `exclude` entry for `tests/packages/extensionlib`; that package does not exist.
- Fix the sdist exclude list: it named `.readthedocs.yaml`, but the file is `.readthedocs.yml`.
- Remove a duplicate `missing-function-docstring` pylint disable.
- Remove unused mypy `additional_dependencies` (`importlib-resources`, `markdown-it-py`) and the no-op `requirements-txt-fixer` pre-commit hook (the repo has no `requirements*.txt` files).
- Remove the redundant `typing-extensions` pin in the `test-core` dependency group; the base package dependency already requires it for the same Python versions.
- Update `CITATION.cff` from version 0.10.7 to the latest release, v1.0.3.
- Switch `nox -s lint` from `pre-commit` to `prek`, which this repo's docs and local workflow use.
- Add the `test-schema` group to `nox -s minimums`, so it matches what CI's `min` job installs.
- Fix `AGENTS.md`: it said `uv.lock` is checked in, but it is gitignored (CI only watches it to decide whether to run tests).

Skipped:
- CI's main lint job runs `pre-commit/action` directly, not `nox -s lint`, so this change does not affect CI.
- Adding `abi3t` to the build-tested backend list (`noxfile.py` `GETTING_STARTED`) is left out. A separate review item notes `abi3t` may not build correctly on 3.13t/3.14t due to a missing version gate, so adding it here risks an unrelated CI failure. Better handled together with that fix.