### PR TITLE
chore: source cleanups from the review

### DIFF
--- a/src/scikit_build_core/_compat/builtins.py
+++ b/src/scikit_build_core/_compat/builtins.py
@@ -7,8 +7,20 @@ if sys.version_info < (3, 11):
 else:
     from builtins import ExceptionGroup
 
-__all__ = ["ExceptionGroup"]
+__all__ = ["ExceptionGroup", "add_note"]
 
 
 def __dir__() -> list[str]:
     return __all__
+
+
+def add_note(exc: BaseException, note: str) -> None:
+    """
+    Attach a note to an exception. ``BaseException.add_note`` is 3.11+, so set
+    ``__notes__`` by hand on older Pythons.
+    """
+    if sys.version_info < (3, 11):
+        notes = "__notes__"  # set so linters won't try to be clever
+        setattr(exc, notes, [*getattr(exc, notes, []), note])
+    else:
+        exc.add_note(note)

--- a/src/scikit_build_core/_shutil.py
+++ b/src/scikit_build_core/_shutil.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-__lazy_modules__ = {f"{__spec__.parent}._logging", "subprocess", "typing"}
+__lazy_modules__ = {f"{__spec__.parent}._logging", "shlex", "subprocess", "typing"}
 
 import dataclasses
 import os
+import shlex
 import subprocess
 from typing import ClassVar
 
@@ -67,7 +68,7 @@ class Run:
                 logger.debug("RUNENV - changes since last run only:\n  {}", msg)
                 type(self)._prev_env = self.env.copy()
 
-        logger.info("RUN: {}", " ".join(options))
+        logger.info("RUN: {}", shlex.join(options))
 
         return subprocess.run(
             options,

--- a/src/scikit_build_core/build/_scripts.py
+++ b/src/scikit_build_core/build/_scripts.py
@@ -27,7 +27,6 @@ def process_script_dir(script_dir: Path) -> None:
         with contextlib.suppress(UnicodeDecodeError), item.open(encoding="utf-8") as f:
             file_iter = iter(f)
             try:
-                # TODO: handle empty files
                 first_line = next(file_iter)
             except StopIteration:
                 first_line = ""

--- a/src/scikit_build_core/build/wheel.py
+++ b/src/scikit_build_core/build/wheel.py
@@ -512,9 +512,9 @@ def _build_wheel_impl_impl(
             return WheelImplReturn(wheel_filename=dist_info.name, settings=settings)
 
         for gen in settings.generate:
-            contents = generate_file_contents(gen, metadata)
             if gen.location == "source":
                 continue
+            contents = generate_file_contents(gen, metadata)
             if gen.location == "build":
                 path = build_dir / gen.path
             elif gen.location == "install":

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -122,10 +122,11 @@ class CMaker:
             msg = f"source directory {self.source_dir} does not exist"
             raise CMakeConfigError(msg)
 
-        self.build_dir.mkdir(parents=True, exist_ok=True)
-        if not self.build_dir.is_dir():
+        try:
+            self.build_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as err:
             msg = f"build directory {self.build_dir} must be a (creatable) directory"
-            raise CMakeConfigError(msg)
+            raise CMakeConfigError(msg) from err
 
         # TODO: This could be stateful instead
         self._file_api_query = stateless_query(self.build_dir)

--- a/src/scikit_build_core/file_api/_cattrs_converter.py
+++ b/src/scikit_build_core/file_api/_cattrs_converter.py
@@ -1,9 +1,9 @@
 # pylint: disable=duplicate-code
 
 __lazy_modules__ = {
-    "cattr",
-    "cattr.preconf",
-    "cattr.preconf.json",
+    "cattrs",
+    "cattrs.preconf",
+    "cattrs.preconf.json",
     f"{__spec__.parent}.model.cache",
     f"{__spec__.parent}.model.cmakefiles",
     f"{__spec__.parent}.model.codemodel",
@@ -18,8 +18,8 @@ import json
 from pathlib import Path
 from typing import Any, Callable, TypeVar, Union  # noqa: TID251
 
-import cattr
-import cattr.preconf.json
+import cattrs
+import cattrs.preconf.json
 
 from .model.cache import Cache
 from .model.cmakefiles import CMakeFiles
@@ -37,24 +37,24 @@ def to_path(path: str, _: type[Path]) -> Path:
     return Path(path)
 
 
-def make_converter(base_dir: Path) -> cattr.preconf.json.JsonConverter:
-    converter = cattr.preconf.json.make_converter()
+def make_converter(base_dir: Path) -> cattrs.preconf.json.JsonConverter:
+    converter = cattrs.preconf.json.make_converter()
     converter.register_structure_hook(Path, to_path)
 
-    st_hook = cattr.gen.make_dict_structure_fn(
+    st_hook = cattrs.gen.make_dict_structure_fn(
         Reply,
         converter,
-        codemodel_v2=cattr.gen.override(rename="codemodel-v2"),
-        cache_v2=cattr.gen.override(rename="cache-v2"),
-        cmakefiles_v1=cattr.gen.override(rename="cmakeFiles-v1"),
-        toolchains_v1=cattr.gen.override(rename="toolchains-v1"),
+        codemodel_v2=cattrs.gen.override(rename="codemodel-v2"),
+        cache_v2=cattrs.gen.override(rename="cache-v2"),
+        cmakefiles_v1=cattrs.gen.override(rename="cmakeFiles-v1"),
+        toolchains_v1=cattrs.gen.override(rename="toolchains-v1"),
     )
     converter.register_structure_hook(Reply, st_hook)
 
-    ip_hook = cattr.gen.make_dict_structure_fn(
+    ip_hook = cattrs.gen.make_dict_structure_fn(
         InstallPath,
         converter,
-        from_=cattr.gen.override(rename="from"),
+        from_=cattrs.gen.override(rename="from"),
     )
     converter.register_structure_hook(InstallPath, ip_hook)
     converter.register_structure_hook(

--- a/src/scikit_build_core/file_api/reply.py
+++ b/src/scikit_build_core/file_api/reply.py
@@ -16,12 +16,11 @@ import argparse
 import builtins
 import dataclasses
 import json
-import sys
 import typing
 from pathlib import Path
 from typing import Any, Callable, TypeVar, Union, get_args, get_origin  # noqa: TID251
 
-from .._compat.builtins import ExceptionGroup
+from .._compat.builtins import ExceptionGroup, add_note
 from ..utils.typing import (
     get_target_raw_type,
     is_union_type,
@@ -92,11 +91,10 @@ class Converter:
                         data[json_field], field_type
                     )
                 except TypeError as err:
-                    msg = f"Failed to convert field {field.name!r} of type {field_type}"
-                    if sys.version_info < (3, 11):
-                        err.__notes__ = [*getattr(err, "__notes__", []), msg]  # type: ignore[attr-defined]
-                    else:
-                        err.add_note(msg)  # pylint: disable=no-member
+                    add_note(
+                        err,
+                        f"Failed to convert field {field.name!r} of type {field_type}",
+                    )
                     exceptions.append(err)
                 except ExceptionGroup as err:
                     exceptions.append(err)

--- a/src/scikit_build_core/hatch/plugin.py
+++ b/src/scikit_build_core/hatch/plugin.py
@@ -37,7 +37,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from .._check_extra import warn_missing_extra
-from .._logging import logger, rich_print
+from .._logging import rich_print
 from ..build._editable import (
     editable_inplace_files,
     editable_redirect_files,
@@ -145,7 +145,6 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             msg = "wheel.exclude is not supported for hatch builds, use hatch's exclude instead"
             raise ValueError(msg)
 
-    # Requires Hatchling 1.22.0 to have an effect
     def dependencies(self) -> list[str]:
         settings = self._read_config().settings
         requires = GetRequires(settings)
@@ -337,25 +336,17 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                     path.relative_to(wheel_dirs[targetlib])
                 )
 
-        try:
-            for raw_path in wheel_dirs["data"].iterdir():
-                path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
-                build_data["shared_data"][f"{path.resolve()}"] = str(
-                    path.relative_to(wheel_dirs["data"])
-                )
-        except KeyError:
-            logger.error("SKBUILD_DATA_DIR not supported by Hatchling < 1.24.0")
-            raise
+        for raw_path in wheel_dirs["data"].iterdir():
+            path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
+            build_data["shared_data"][f"{path}"] = str(
+                path.relative_to(wheel_dirs["data"])
+            )
 
-        try:
-            for raw_path in wheel_dirs["scripts"].iterdir():
-                path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
-                build_data["shared_scripts"][f"{path.resolve()}"] = str(
-                    path.relative_to(wheel_dirs["scripts"])
-                )
-        except KeyError:
-            logger.error("SKBUILD_SCRIPTS_DIR not supported by Hatchling < 1.24.0")
-            raise
+        for raw_path in wheel_dirs["scripts"].iterdir():
+            path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
+            build_data["shared_scripts"][f"{path}"] = str(
+                path.relative_to(wheel_dirs["scripts"])
+            )
 
         for raw_path_root in wheel_dirs["metadata"].iterdir():
             path_root = (
@@ -366,12 +357,9 @@ class ScikitBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                 raise ValueError(msg)
             for raw_path in path_root.iterdir():
                 path = raw_path.resolve()  # Windows mingw64 and UCRT now requires this
-                location = path.relative_to(path_root)
-                try:
-                    build_data["extra_metadata"][f"{path.resolve()}"] = str(location)
-                except KeyError:
-                    logger.error("SKBUILD_METADATA_DIR needs a newer Hatchling")
-                    raise
+                build_data["extra_metadata"][f"{path}"] = str(
+                    path.relative_to(path_root)
+                )
 
     def finalize(
         self, version: str, build_data: dict[str, Any], artifact_path: str

--- a/src/scikit_build_core/init/__main__.py
+++ b/src/scikit_build_core/init/__main__.py
@@ -124,6 +124,11 @@ def _generate(
     return sorted(written)
 
 
+def _derive_module(project_name: str) -> str:
+    """Derive the Python module name from a normalized project name."""
+    return project_name.replace("-", "_").replace(".", "_")
+
+
 def generate_project(
     directory: Path, backend: str, name: str = "example"
 ) -> list[Path]:
@@ -138,8 +143,7 @@ def generate_project(
     files outside ``directory``.
     """
     project_name = canonicalize_name(name, validate=True)
-    module = project_name.replace("-", "_").replace(".", "_")
-    return _generate(directory, backend, project_name, module)
+    return _generate(directory, backend, project_name, _derive_module(project_name))
 
 
 def _display(path: Path) -> str:
@@ -175,7 +179,7 @@ def main_init(args: argparse.Namespace, /) -> None:
             "Could not derive a valid project name from {raw_name!r}; pass {bold}--name{normal}.",
             raw_name=raw_name,
         )
-    module = project_name.replace("-", "_").replace(".", "_")
+    module = _derive_module(project_name)
     if not module.isidentifier():
         rich_error(
             "{module!r} (derived from {raw_name!r}) is not a valid Python identifier; pass a {bold}--name{normal} that starts with a letter or underscore.",

--- a/src/scikit_build_core/settings/documentation.py
+++ b/src/scikit_build_core/settings/documentation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     "ast",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.utils.typing",
     "inspect",
     "packaging",
     "packaging.specifiers",
@@ -23,6 +24,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from .. import __version__
+from ..utils.typing import NoneType
 
 TYPE_CHECKING = False
 
@@ -38,8 +40,6 @@ def __dir__() -> list[str]:
 
 
 version_display = ".".join(__version__.split(".")[:2])
-
-NoneType = type(None)
 
 
 def _get_value(value: ast.expr) -> str:
@@ -80,7 +80,7 @@ def sanitize_default_field(text: str) -> str:
 
 
 def is_optional(field: type) -> bool:
-    return get_origin(field) is typing.Union and type(None) in get_args(field)
+    return get_origin(field) is typing.Union and NoneType in get_args(field)
 
 
 def get_display_type(field_type: type | str) -> str:
@@ -169,7 +169,7 @@ def mk_docs(dc: type[object], prefix: str = "") -> Generator[DCDoc, None, None]:
 
         yield DCDoc(
             name=f"{prefix}{field.name}".replace("_", "-"),
-            type=field.metadata.get("display_type", get_display_type(field.type)),
+            type=get_display_type(field.type),
             default=sanitize_default_field(default),
             docs=docs[field.name],
             field=field,

--- a/src/scikit_build_core/settings/json_schema.py
+++ b/src/scikit_build_core/settings/json_schema.py
@@ -3,30 +3,25 @@ from __future__ import annotations
 __lazy_modules__ = {
     "dataclasses",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._compat.builtins",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.utils.typing",
     f"{__spec__.parent}.documentation",
     "packaging",
     "packaging.specifiers",
     "packaging.version",
     "pathlib",
-    "types",
     "typing",
 }
 
 import dataclasses
-import sys
 from pathlib import Path
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from .._compat.builtins import ExceptionGroup
+from .._compat.builtins import ExceptionGroup, add_note
+from ..utils.typing import NoneType
 from .documentation import pull_docs
-
-if sys.version_info >= (3, 10):
-    from types import NoneType
-else:
-    NoneType = type(None)
 
 __all__ = ["FailedConversionError", "convert_type", "to_json_schema"]
 
@@ -103,12 +98,7 @@ def to_json_schema(dclass: type[Any], *, normalize_keys: bool) -> dict[str, Any]
         try:
             props[field.name] = convert_type(field.type, normalize_keys=normalize_keys)
         except FailedConversionError as err:
-            if sys.version_info < (3, 11):
-                notes = "__notes__"  # set so linter's won't try to be clever
-                setattr(err, notes, [*getattr(err, notes, []), f"Field: {field.name}"])
-            else:
-                # pylint: disable-next=no-member
-                err.add_note(f"Field: {field.name}")
+            add_note(err, f"Field: {field.name}")
             errs.append(err)
             continue
 

--- a/src/scikit_build_core/settings/skbuild_docs_sphinx.py
+++ b/src/scikit_build_core/settings/skbuild_docs_sphinx.py
@@ -5,7 +5,7 @@ Make documentation for the skbuild model in sphinx format.
 from __future__ import annotations
 
 __lazy_modules__ = {
-    "collections",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.utils.typing",
     f"{__spec__.parent}.skbuild_model",
     "textwrap",
     "typing",
@@ -14,9 +14,9 @@ __lazy_modules__ = {
 import dataclasses
 import textwrap
 import typing
-from collections import OrderedDict
 from typing import Annotated, get_args, get_origin
 
+from ..utils.typing import NoneType
 from .documentation import mk_docs
 from .skbuild_model import ScikitBuildSettings
 
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
     from .documentation import DCDoc
 
 __all__ = ["mk_skbuild_docs"]
-
-_NONE_TYPE = type(None)
 
 
 def __dir__() -> list[str]:
@@ -51,7 +49,7 @@ def _flat_expressible(field_type: typing.Any) -> bool:
         return all(
             _flat_expressible(arg)
             for arg in get_args(field_type)
-            if arg is not _NONE_TYPE
+            if arg is not NoneType
         )
     if origin is dict:
         return get_origin(get_args(field_type)[1]) not in (dict, list)
@@ -60,9 +58,7 @@ def _flat_expressible(field_type: typing.Any) -> bool:
 
 @dataclasses.dataclass
 class Document:
-    sections: dict[str, Section] = dataclasses.field(
-        default_factory=OrderedDict, init=False
-    )
+    sections: dict[str, Section] = dataclasses.field(default_factory=dict, init=False)
 
     def format(self) -> str:
         return "\n".join(self.sections[it].format() for it in sorted(self.sections))
@@ -76,7 +72,7 @@ class Section:
     {content}""")
     name: str
     level: int = 2
-    items: dict[str, Item] = dataclasses.field(default_factory=OrderedDict, init=False)
+    items: dict[str, Item] = dataclasses.field(default_factory=dict, init=False)
 
     def format(self) -> str:
         return self.TEMPLATE.format(

--- a/src/scikit_build_core/settings/skbuild_overrides.py
+++ b/src/scikit_build_core/settings/skbuild_overrides.py
@@ -291,7 +291,7 @@ def inherit_join(
     if isinstance(previous, list) and isinstance(value, list):
         return [*previous, *value] if mode == "append" else [*value, *previous]
     if isinstance(previous, dict) and isinstance(value, dict):
-        return {**previous, **value} if mode == "append" else {**value, **previous}
+        return previous | value if mode == "append" else value | previous
     msg = "Append/prepend modes can only be used on lists or dicts"
     raise TypeError(msg)
 

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -43,6 +43,7 @@ from ._load_entrypoint_config import load_config_providers
 from .auto_cmake_version import find_min_cmake_version
 from .auto_requires import get_min_requires
 from .skbuild_model import (
+    BuildSettings,
     CMakeSettings,
     NinjaSettings,
     ScikitBuildSettings,
@@ -231,14 +232,14 @@ def _validate_overrides(
 
     def validate_field_recursive(
         obj: Any,
-        record: OverrideRecord | None = None,
         prefix: str = "",
         path: tuple[str, ...] = (),
     ) -> None:
         """Navigate through all the keys and validate each field."""
+        # Only leaf keys are recorded by the override machinery, so a parent
+        # table never has a record to pass down.
         for field in dataclasses.fields(obj):
             conf_key = field.name.replace("_", "-")
-            closest_record = overrides.get(f"{prefix}{conf_key}", record)
             value = getattr(obj, field.name)
             # Do the validation of the current field
             validate_field(
@@ -246,12 +247,11 @@ def _validate_overrides(
                 value=value,
                 prefix=prefix,
                 path=path,
-                record=closest_record,
+                record=overrides.get(f"{prefix}{conf_key}"),
             )
             if dataclasses.is_dataclass(value):
                 validate_field_recursive(
                     obj=value,
-                    record=closest_record,
                     prefix=f"{prefix}{conf_key}.",
                     path=(*path, field.name),
                 )
@@ -424,12 +424,15 @@ class SettingsReader:
 
         validate_variant_settings(self.settings)
 
-        # Values that come *only* from static project sources (pyproject.toml
-        # and extra_settings), used by the minimum-version move gates below.
-        # Entry-point config is excluded so it behaves like env/config-settings.
-        static_settings = SourceChain(
+        # The cmake/build values that come *only* from static project sources
+        # (pyproject.toml and extra_settings), used by the minimum-version move
+        # gates below. Entry-point config is excluded so it behaves like
+        # env/config-settings.
+        static_chain = SourceChain(
             *self._static_srcs, prefixes=["tool", "scikit-build"]
-        ).convert_target(ScikitBuildSettings)
+        )
+        static_cmake = static_chain.convert_target(CMakeSettings, "cmake")
+        static_build = static_chain.convert_target(BuildSettings, "build")
 
         if self.settings.minimum_version:
             current_version = Version(__version__)
@@ -527,8 +530,8 @@ class SettingsReader:
             self.settings.build.verbose,
             self.settings.minimum_version,
             Version("0.10"),
-            static=static_settings.cmake.verbose == self.settings.cmake.verbose
-            and static_settings.build.verbose == self.settings.build.verbose,
+            static=static_cmake.verbose == self.settings.cmake.verbose
+            and static_build.verbose == self.settings.build.verbose,
         )
         self.settings.build.targets = _handle_move(
             "cmake.targets",
@@ -537,8 +540,8 @@ class SettingsReader:
             self.settings.build.targets,
             self.settings.minimum_version,
             Version("0.10"),
-            static=static_settings.cmake.targets == self.settings.cmake.targets
-            and static_settings.build.targets == self.settings.build.targets,
+            static=static_cmake.targets == self.settings.cmake.targets
+            and static_build.targets == self.settings.build.targets,
         )
 
         if self.settings.sdist.inclusion_mode is not None:

--- a/src/scikit_build_core/settings/skbuild_read_settings.py
+++ b/src/scikit_build_core/settings/skbuild_read_settings.py
@@ -236,8 +236,6 @@ def _validate_overrides(
         path: tuple[str, ...] = (),
     ) -> None:
         """Navigate through all the keys and validate each field."""
-        # Only leaf keys are recorded by the override machinery, so a parent
-        # table never has a record to pass down.
         for field in dataclasses.fields(obj):
             conf_key = field.name.replace("_", "-")
             value = getattr(obj, field.name)

--- a/src/scikit_build_core/settings/sources.py
+++ b/src/scikit_build_core/settings/sources.py
@@ -67,7 +67,7 @@ Source representations:
 When setting up your dataclasses, these types are handled:
 
 - ``str``: A string type, nothing special.
-- ``bool``: Supports bool in TOML, not handled in envvar/config (so only useful in a Union)
+- ``bool``: Supports bool in TOML; ``"0"``/``"false"``/``"off"``/``"no"``/``""`` are false in envvar/config forms.
 - Any callable (`Path`, `Version`): Passed the string input.
 - ``Optional[T]``: Treated like T. Default should be None, since no input format supports None's.
 - ``Union[str, ...]``: Supports other input types in TOML form (bool currently). Otherwise a string.
@@ -95,7 +95,7 @@ import dataclasses
 import os
 from typing import Any, Literal, Protocol, TypeVar, get_args
 
-from .._compat.builtins import ExceptionGroup
+from .._compat.builtins import ExceptionGroup, add_note
 from ..utils.typing import (
     get_inner_type,
     get_target_raw_type,
@@ -540,7 +540,7 @@ class ConfSource(Source):
         name = ".".join(names)
         if is_dict:
             d = {
-                k[len(name) + 1 :]: str(v)
+                k.removeprefix(f"{name}."): str(v)
                 for k, v in self.settings.items()
                 if k.startswith(f"{name}.")
             }
@@ -851,7 +851,7 @@ class SourceChain:
                     )
                 except Exception as e:  # noqa: BLE001
                     name = ".".join([*self.prefixes, *prefixes, field.name])
-                    e.__notes__ = [*getattr(e, "__notes__", []), f"Field: {name}"]  # type: ignore[attr-defined]
+                    add_note(e, f"Field: {name}")
                     errors.append(e)
                 continue
 
@@ -864,7 +864,7 @@ class SourceChain:
                         tmp = source.convert(simple, field.type)
                     except Exception as e:  # noqa: BLE001
                         name = ".".join([*self.prefixes, *prefixes, field.name])
-                        e.__notes__ = [*getattr(e, "__notes__", []), f"Field {name}"]  # type: ignore[attr-defined]
+                        add_note(e, f"Field {name}")
                         errors.append(e)
                         prep[field.name] = None
                         break
@@ -873,7 +873,7 @@ class SourceChain:
                         # Dict sources merge by precedence: later matching sources
                         # add missing keys without erasing higher-priority ones.
                         assert isinstance(tmp, dict), f"{field.name} must be a dict"
-                        prep[field.name] = {**tmp, **prep.get(field.name, {})}
+                        prep[field.name] = tmp | prep.get(field.name, {})
                         continue
 
                     prep[field.name] = tmp

--- a/src/scikit_build_core/utils/typing.py
+++ b/src/scikit_build_core/utils/typing.py
@@ -19,8 +19,10 @@ def __dir__() -> list[str]:
     return __all__
 
 
-# Same object as types.NoneType, which is only available on Python 3.10+
-NoneType = type(None)
+if sys.version_info >= (3, 10):
+    from types import NoneType
+else:
+    NoneType = type(None)
 
 # Runtime check for PEP 604 union syntax (A | B) support
 # types.UnionType only exists in Python 3.10+

--- a/src/scikit_build_core/utils/typing.py
+++ b/src/scikit_build_core/utils/typing.py
@@ -6,6 +6,7 @@ import sys
 from typing import Annotated, Any, Union, get_args, get_origin
 
 __all__ = [
+    "NoneType",
     "get_inner_type",
     "get_target_raw_type",
     "is_union_type",
@@ -18,13 +19,14 @@ def __dir__() -> list[str]:
     return __all__
 
 
+# Same object as types.NoneType, which is only available on Python 3.10+
+NoneType = type(None)
+
 # Runtime check for PEP 604 union syntax (A | B) support
 # types.UnionType only exists in Python 3.10+
 if sys.version_info >= (3, 10):
-    from types import NoneType
     from types import UnionType as _UnionType
 else:
-    NoneType = type(None)
 
     class _UnionType:
         pass


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1541, item 48. Source cleanups only, no user-visible behavior change.

Applied:

- `NoneType` is exported once from `utils.typing`; the four local copies (one with an unnecessary 3.10 branch) are gone.
- New `_compat.builtins.add_note` replaces the three copies of the `__notes__` compatibility code.
- The settings reader converts only `CMakeSettings` and `BuildSettings` from the static source chain, not a second full model, for the two `static=` move flags.
- Removed the dead `display_type` metadata lookup and the unused `record` parameter of `validate_field_recursive` (only leaf keys are recorded, so a parent table never has a record to pass down).
- Hatch plugin: removed the three guards for hatchling < 1.24 (the floor is 1.24), the stale "Requires 1.22" comment, and a double `.resolve()`.
- `CMaker` now raises `CMakeConfigError` when the build directory cannot be created. The check was unreachable, because `mkdir` raises first.
- `init` shares one module-name derivation.
- The file API converter uses the `cattrs` name in place of the legacy `cattr` alias.
- The wheel build skips `generate` entries with `location = "source"` before it renders the content.
- Removed a stale TODO in `_scripts` (empty files are handled).
- Idioms: `removeprefix`, `dict |`, `next(gen)`, `shlex.join`, and `dict` in place of `OrderedDict`.

Skipped:

- The three never-raised exception classes in `errors.py` (`CMakeAccessError`, `CMakeVersionError`, `NinjaVersionError`). They are in `__all__` and in the API docs, so removal needs a deprecation decision.
- The always-true `if local_matched:` in `skbuild_overrides.py`. The proof that it is always true is not complete, and the change would move an error path.
- The double write of `location = "source"` generate files when `sdist.cmake = true`. The two writes use different settings objects, so an `if.state` override can make the contents differ.
- The `isidentifier` check in `generate_project`. To add it changes what the function rejects.

Already fixed on main, no change needed: the three hand-rolled `-D VAR=value` parsers (now `iter_cmake_defines`) and the "3.9 `is_relative_to` workaround" comment.
