### PR TITLE
ci/test: test the matrix CMake version, fix pass job needs, coverage and test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,26 +206,16 @@ jobs:
         with:
           cmake-version: ${{ matrix.cmake-version }}
 
+      # No `wheels` extra: the PyPI cmake wheel would win discovery over the
+      # matrix CMake version installed above.
       - name: Install package (uv)
         run:
-          uv pip install -e.[wheels,wheel-free-setuptools] --group=dev --system
+          uv pip install -e.[wheel-free-setuptools] ninja --group=dev --system
 
       - name: Test package
-        if: "!contains(matrix.python_version, 'pypy')"
         run: >-
           pytest -ra --showlocals --cov --cov-report=xml --cov-report=term -n
           auto --durations=20
-
-      - name: Test package (two attempts)
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        if: "contains(matrix.python_version, 'pypy')"
-        with:
-          max_attempts: 2
-          retry_on: error
-          timeout_seconds: 5
-          command: >-
-            pytest -ra --showlocals --cov --cov-report=xml --cov-report=term
-            --durations=20 -n auto
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -498,7 +488,20 @@ jobs:
   pass:
     name: CI pass
     if: always()
-    needs: [changes, lint, checks, min, cygwin, dist, docs]
+    needs:
+      [
+        changes,
+        lint,
+        checks,
+        checks-32bit,
+        min,
+        manylinux,
+        cygwin,
+        msys,
+        mingw64,
+        dist,
+        docs,
+      ]
     runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
@@ -510,8 +513,12 @@ jobs:
               !fromJSON(needs.changes.outputs.run-tests)
               && '
               checks,
+              checks-32bit,
               min,
+              manylinux,
               cygwin,
+              msys,
+              mingw64,
               dist,
               '
               || ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ It is built with **hatchling** and stored under `src/scikit_build_core/`.
   auto-marked as `virtualenv` and `isolated` by `conftest.py`.
 - Important pytest markers: `compile`, `configure`, `fortran`, `integration`,
   `isolated`, `network`, `setuptools`, `upstream`, `virtualenv`.
-- `pytest -n auto` is the default parallelism. Some platforms retry on PyPy.
+- `pytest -n auto` is the default parallelism.
 
 ## Code quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,7 @@ report.exclude_also = [
     'if typing.TYPE_CHECKING:',
     'if TYPE_CHECKING:',
     'def __repr__',
-    'if __name__ == "main":',
+    'if __name__ == "__main__":',
 ]
 
 

--- a/tests/test_dynamic_metadata.py
+++ b/tests/test_dynamic_metadata.py
@@ -297,7 +297,7 @@ def test_regex(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     with Path("__init__.py").open("w") as f:
         f.write("__version__ = '0.1.0'")
 
-    regex.dynamic_metadata("version", {"input": "__init__.py"})
+    assert regex.dynamic_metadata("version", {"input": "__init__.py"}) == "0.1.0"
 
 
 def test_regex_errors() -> None:

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from scikit_build_core.program_search import (
+    Program,
     best_program,
     get_cmake_program,
     get_cmake_programs,
@@ -16,13 +19,19 @@ from scikit_build_core.program_search import (
 )
 
 
-def test_get_cmake_programs_cmake_module(monkeypatch):
-    cmake = pytest.importorskip("cmake")
+def test_get_cmake_programs_cmake_module(monkeypatch, fp, tmp_path):
+    # Fake the PyPI cmake module so this runs without the wheel installed
+    bin_dir = tmp_path / "cmake_bin"
+    monkeypatch.setitem(
+        sys.modules, "cmake", types.SimpleNamespace(CMAKE_BIN_DIR=str(bin_dir))
+    )
     monkeypatch.setattr("shutil.which", lambda _: None)
+    fp.register(
+        [bin_dir / "cmake", "-E", "capabilities"],
+        stdout='{"version":{"string":"3.20.0"}}',
+    )
     programs = list(get_cmake_programs())
-    assert len(programs) == 1
-    assert programs[0].path.name == "cmake"
-    assert programs[0].version == Version(".".join(cmake.__version__.split(".")[:3]))
+    assert programs == [Program(bin_dir / "cmake", Version("3.20.0"))]
 
 
 def test_get_ninja_programs_cmake_module(monkeypatch):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes items 35-39 of #1541.

- **35**: the `checks` job no longer installs the `wheels` extra. The PyPI cmake wheel won discovery, so every row tested cmake 4.4.x instead of its `cmake-version`. Ninja is still installed from PyPI. `test_get_cmake_programs_cmake_module` now fakes the `cmake` module so it keeps running without the wheel.
- **36**: the PyPy retry step is removed instead of fixed. It never ran (`matrix.python_version` vs `python-version`), and PyPy has been passing without it.
- **37**: `pass` now needs `checks-32bit`, `manylinux`, `msys` and `mingw64` (allowed to skip when tests are skipped).
- **38**: coverage excludes `if __name__ == "__main__":`.
- **39**: `test_regex` asserts the result.

Expect the `checks` job to be the first real run of the old CMake rows; failures there are new signal, not regressions from this PR.
