### PR TITLE
fix: program search, build-dir info, and module detection robustness

### DIFF
--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -120,8 +120,10 @@ class GetRequires:
         cmake_verset = self.settings.cmake.version
 
         # If the module is already installed (via caching the build
-        # environment, for example), we will use that
-        if importlib.util.find_spec("cmake") is not None:
+        # environment, for example), we will use that. A namespace package
+        # (a bare "cmake" directory on sys.path) has no origin and is not it.
+        cmake_spec = importlib.util.find_spec("cmake")
+        if cmake_spec is not None and cmake_spec.origin is not None:
             yield f"cmake{cmake_verset}"
             return
 
@@ -150,8 +152,10 @@ class GetRequires:
         ninja_verset = self.settings.ninja.version
 
         # If the module is already installed (via caching the build
-        # environment, for example), we will use that
-        if importlib.util.find_spec("ninja") is not None:
+        # environment, for example), we will use that. A namespace package
+        # (a bare "ninja" directory on sys.path) has no origin and is not it.
+        ninja_spec = importlib.util.find_spec("ninja")
+        if ninja_spec is not None and ninja_spec.origin is not None:
             yield f"ninja{ninja_verset}"
             return
 

--- a/src/scikit_build_core/builder/get_requires.py
+++ b/src/scikit_build_core/builder/get_requires.py
@@ -121,7 +121,7 @@ class GetRequires:
 
         # If the module is already installed (via caching the build
         # environment, for example), we will use that. A namespace package
-        # (a bare "cmake" directory on sys.path) has no origin and is not it.
+        # (a bare "cmake" directory on sys.path) has no origin.
         cmake_spec = importlib.util.find_spec("cmake")
         if cmake_spec is not None and cmake_spec.origin is not None:
             yield f"cmake{cmake_verset}"
@@ -153,7 +153,7 @@ class GetRequires:
 
         # If the module is already installed (via caching the build
         # environment, for example), we will use that. A namespace package
-        # (a bare "ninja" directory on sys.path) has no origin and is not it.
+        # (a bare "ninja" directory on sys.path) has no origin.
         ninja_spec = importlib.util.find_spec("ninja")
         if ninja_spec is not None and ninja_spec.origin is not None:
             yield f"ninja{ninja_verset}"

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 __lazy_modules__ = {
-    "contextlib",
     f"{__spec__.parent}._compat.builtins",
     f"{__spec__.parent}._logging",
     f"{__spec__.parent}._shutil",
@@ -20,7 +19,6 @@ __lazy_modules__ = {
     "typing",
 }
 
-import contextlib
 import dataclasses
 import json
 import os
@@ -136,16 +134,25 @@ class CMaker:
             logger.info("Fresh build requested, clearing cache")
         else:
             info: dict[str, str] = {}
-            # Parenthesized context managers require the new parser (default in 3.9,
-            # guaranteed 3.10+). Keep nested until 3.9 is dropped.
-            with contextlib.suppress(FileNotFoundError):  # noqa: SIM117
+            try:
                 with skbuild_info.open("r", encoding="utf-8") as f:
                     info = json.load(f)
+            except FileNotFoundError:
+                pass
+            except (OSError, ValueError):
+                # An interrupted build can leave a truncated or empty file
+                logger.warning("Unreadable {}, clearing cache", skbuild_info)
+                stale = True
+            else:
+                if not isinstance(info, dict):
+                    logger.warning("Invalid {}, clearing cache", skbuild_info)
+                    info = {}
+                    stale = True
 
             if info:
                 # If building via SDist, this could be pre-filled
-                cached_source_dir = Path(info["source_dir"])
-                if cached_source_dir != source_dir:
+                cached_source_dir = info.get("source_dir")
+                if cached_source_dir is None or Path(cached_source_dir) != source_dir:
                     logger.warning(
                         "Original src {} != {}, clearing cache",
                         cached_source_dir,
@@ -154,8 +161,8 @@ class CMaker:
                     stale = True
 
                 # Isolated environments can cause this
-                cached_skbuild_dir = Path(info["skbuild_path"])
-                if cached_skbuild_dir != DIR:
+                cached_skbuild_dir = info.get("skbuild_path")
+                if cached_skbuild_dir is None or Path(cached_skbuild_dir) != DIR:
                     logger.info(
                         "New isolated environment {} -> {}, clearing cache",
                         cached_skbuild_dir,

--- a/src/scikit_build_core/program_search.py
+++ b/src/scikit_build_core/program_search.py
@@ -60,12 +60,23 @@ def _macos_binary_is_x86(path: Path) -> bool:
     """
     try:
         # lipo gives clean output like: "Architectures in the fat file: ... are: x86_64 arm64"
-        out = subprocess.check_output(["lipo", "-info", path], text=True)
-    except (FileNotFoundError, subprocess.CalledProcessError):
+        # stdin/stderr are silenced so shell shims cannot read input or print noise
+        out = subprocess.check_output(
+            ["lipo", "-info", path],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
         # Fallback to 'file' if lipo not available or fails
         try:
-            out = subprocess.check_output(["file", path], text=True)
-        except (FileNotFoundError, subprocess.CalledProcessError):
+            out = subprocess.check_output(
+                ["file", path],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
             return False  # unknown, assume not x86
 
     # Ignore native or fat binaries
@@ -189,8 +200,10 @@ def get_cmake_program(cmake_path: Path) -> Program:
             err.stdout,
             err.stderr,
         )
-    except PermissionError:
-        logger.warning("Permissions Error getting CMake's version")
+    except OSError as err:
+        # Covers a missing or non-executable path (FileNotFoundError,
+        # PermissionError, and friends)
+        logger.warning("Could not run CMake at {}: {}", cmake_path, err)
     except subprocess.TimeoutExpired:
         logger.warning("Accessing CMake timed out, ignoring")
 
@@ -220,7 +233,7 @@ def get_ninja_programs(*, module: bool = True) -> Generator[Program, None, None]
             )
         except (
             subprocess.CalledProcessError,
-            PermissionError,
+            OSError,
             subprocess.TimeoutExpired,
         ):
             yield Program(ninja_path, None)

--- a/tests/test_cmake_config.py
+++ b/tests/test_cmake_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sysconfig
@@ -389,3 +390,27 @@ def test_cmake_fresh_clears_cache(tmp_path: Path) -> None:
     )
     assert not cache.exists()
     assert not cmakefiles.exists()
+
+
+def test_get_cmake_via_envvar_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CMAKE_EXECUTABLE", str(DIR / "not-a-cmake"))
+    with pytest.raises(CMakeNotFoundError):
+        CMake.default_search(env=os.environ)
+
+
+@pytest.mark.parametrize("contents", ["", "{", '{"source_dir": "/nope"}', "[]"])
+def test_cmake_corrupt_info_file(tmp_path: Path, contents: str) -> None:
+    cmake = CMake(Version("3.30"), Path("cmake"))
+    source_dir = DIR / "packages" / "simple_pure"
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+
+    info = build_dir / ".skbuild-info.json"
+    info.write_text(contents, encoding="utf-8")
+    cache = build_dir / "CMakeCache.txt"
+    cache.write_text("cached", encoding="utf-8")
+
+    CMaker(cmake, source_dir=source_dir, build_dir=build_dir, build_type="Release")
+
+    assert not cache.exists()
+    assert json.loads(info.read_text(encoding="utf-8"))["source_dir"] == str(source_dir)

--- a/tests/test_get_requires.py
+++ b/tests/test_get_requires.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import sysconfig
 from pathlib import Path
 
@@ -17,6 +18,9 @@ if TYPE_CHECKING:
     from pytest_subprocess import FakeProcess
 
 ninja = [] if sysconfig.get_platform().startswith("win") else ["ninja>=1.5"]
+
+# Captured before the protect_get_requires fixture replaces it
+REAL_FIND_SPEC = importlib.util.find_spec
 
 
 @pytest.fixture(autouse=True)
@@ -272,3 +276,18 @@ def test_ninja_make_fallback_respects_forced_generator(
     )
     settings = ScikitBuildSettings(cmake=CMakeSettings(args=args))
     assert set(GetRequires(settings).ninja()) == expected
+
+
+def test_cmake_namespace_dir_is_not_a_module(
+    fp: FakeProcess, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """A bare ``cmake/`` directory on sys.path is not the PyPI cmake package."""
+    fp.register(
+        [Path("cmake/path"), "-E", "capabilities"],
+        stdout='{"version":{"string":"3.18.0"}}',
+    )
+    (tmp_path / "cmake").mkdir()
+    monkeypatch.setattr(importlib.util, "find_spec", REAL_FIND_SPEC)
+    monkeypatch.syspath_prepend(tmp_path)
+
+    assert set(GetRequires().cmake()) == set()

--- a/tests/test_program_search.py
+++ b/tests/test_program_search.py
@@ -199,3 +199,40 @@ def test_compute_timeout_ci_quadruples_base(monkeypatch: pytest.MonkeyPatch) -> 
         assert compute_timeout(Path("cmake")) == 20
     finally:
         compute_timeout.cache_clear()
+
+
+def test_get_cmake_program_missing_binary(tmp_path: Path) -> None:
+    missing = tmp_path / "not-a-cmake"
+    assert get_cmake_program(missing) == Program(missing, None)
+
+
+def test_get_ninja_programs_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    missing = tmp_path / "not-a-ninja"
+    monkeypatch.setattr(
+        "shutil.which", lambda name: str(missing) if name == "ninja" else None
+    )
+    assert list(get_ninja_programs(module=False)) == [Program(missing, None)]
+
+
+def test_macos_binary_is_x86_hides_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scikit_build_core.program_search import _macos_binary_is_x86
+
+    kwargs_seen = []
+
+    def fake_check_output(_cmd, **kwargs):
+        kwargs_seen.append(kwargs)
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    _macos_binary_is_x86.cache_clear()
+    try:
+        assert not _macos_binary_is_x86(Path("cmake"))
+    finally:
+        _macos_binary_is_x86.cache_clear()
+
+    assert len(kwargs_seen) == 2
+    for kwargs in kwargs_seen:
+        assert kwargs["stderr"] is subprocess.DEVNULL
+        assert kwargs["stdin"] is subprocess.DEVNULL


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes items 22, 26, 28, 29 of #1541.

**22 - program search catches too little.** The CMake and Ninja version probes caught `CalledProcessError`, `PermissionError` and `TimeoutExpired`, but a missing or non-executable path raises `FileNotFoundError`. That escaped the probe, so `CMakeNotFoundError` was unreachable for a bad `CMAKE_EXECUTABLE`. Both probes now catch `OSError` and yield a version-less `Program`, which gives the usual `CMakeNotFoundError`.

**26 - macOS architecture probe leaks output.** The `lipo`/`file` calls on Apple Silicon now use `stderr=subprocess.DEVNULL` and `stdin=subprocess.DEVNULL`, so a shell shim cannot print noise or read the build's input.

**28 - corrupt `.skbuild-info.json` blocks all later builds.** Reading the file suppressed only `FileNotFoundError`, so an empty or truncated file from an interrupted build raised on every later build. The read now also handles `OSError` and `ValueError` (which covers `JSONDecodeError`), rejects a non-dict payload, and uses `.get` for the keys. Any of these marks the cache stale, the same path as a source-directory change, so the build directory is wiped and rebuilt.

**29 - namespace directory read as the PyPI package.** `importlib.util.find_spec("cmake")` returns a namespace spec for a bare `cmake/` directory on `sys.path`, which happens with `python -m`, `PYTHONPATH=.` or `backend-path`. That added `cmake>=3.15` to the build requirements for no reason. The check now also requires `spec.origin is not None`; a namespace package has no origin. Same for `ninja`.

Each fix has a regression test, added first and confirmed to fail without the change.
