### PR TITLE
fix(builder): gate abi3t on 3.15, unify free-threaded check, use build env for the wheel tag

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -428,10 +428,12 @@ wheel.py-api = "cp39"
 
 Scikit-build-core will only target ABI3 if the version of Python is equal to or
 newer than the one you set. `cp315t` also sets `Py_TARGET_ABI3T` (if using CMake
-4.4+). For `py3`/`py2.py3`, you still need a version of Python scikit-build-core
-supports to build the initial wheel. The `${SKBUILD_SABI_COMPONENT}` variable
-and the `USE_SABI` idiom on the CMake side is covered in
-[Limited API / Stable ABI](#limited-api).
+4.4+). The free-threaded stable ABI starts at CPython 3.15, so a `cp313t` or
+`cp314t` request, or any `cp3XXt` request on a free-threaded Python older than
+3.15, is ignored and a normal (non-`abi3t`) wheel is built. For `py3`/`py2.py3`,
+you still need a version of Python scikit-build-core supports to build the
+initial wheel. The `${SKBUILD_SABI_COMPONENT}` variable and the `USE_SABI` idiom
+on the CMake side is covered in [Limited API / Stable ABI](#limited-api).
 
 With `cp315.cp315t`, a free-threaded build emits the combined `cp315-abi3.abi3t`
 tag: `abi3t` is a subset of `abi3` (PEP 803), so the single free-threaded binary

--- a/src/scikit_build_core/build/common_wheel_helpers.py
+++ b/src/scikit_build_core/build/common_wheel_helpers.py
@@ -33,6 +33,7 @@ from ..builder.builder import (
     archs_to_tags,
     get_archs,
     get_cmake_args_from_settings,
+    set_environment_from_settings,
 )
 from ..builder.wheel_tag import WheelTag
 from ..cmake import CMaker
@@ -98,15 +99,21 @@ def get_targetlib(settings: ScikitBuildSettings) -> TargetLib:
 
 def get_wheel_tag(settings: ScikitBuildSettings, *, targetlib: TargetLib) -> WheelTag:
     """Compute the best wheel tag for the current environment."""
-    cmake_args = get_cmake_args_from_settings(settings, os.environ)
+    # Builder applies the env table to the CMake environment, so the tag must be
+    # computed against the same environment or it can describe a different
+    # platform than the one that was built (e.g. ARCHFLAGS, #1541).
+    env = os.environ.copy()
+    set_environment_from_settings(env, settings)
+    cmake_args = get_cmake_args_from_settings(settings, env)
     return WheelTag.compute_best(
-        archs_to_tags(get_archs(os.environ, cmake_args)),
+        archs_to_tags(get_archs(env, cmake_args)),
         settings.wheel.py_api,
         expand_macos=settings.wheel.expand_macos_universal_tags,
         root_is_purelib=targetlib == "purelib",
         build_tag=settings.wheel.build_tag,
         cmake_defines=settings.cmake.define,
         cmake_args=cmake_args,
+        env=env,
     )
 
 

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -43,11 +43,13 @@ from ..resources import find_python
 from .cmake_args import iter_cmake_defines
 from .generator import set_environment_for_gen
 from .sysconfig import (
+    ABI3T_MIN_MINOR,
     get_numpy_include_dir,
     get_platform,
     get_python_include_dir,
     get_python_library,
     get_soabi,
+    is_free_threaded,
 )
 
 TYPE_CHECKING = False
@@ -324,7 +326,7 @@ class Builder:
             cache_config["SKBUILD_PROJECT_VERSION_FULL"] = str(version)
 
         py_api = self.settings.wheel.py_api
-        gil_disabled = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+        gil_disabled = is_free_threaded()
 
         sabi = _SabiMode.NONE
         sabi_minor: int | None = None
@@ -336,7 +338,7 @@ class Builder:
                 # The free-threaded stable ABI (PEP 803 / abi3t) only exists on
                 # CPython 3.15+; older free-threaded builds have no abi3t, so a
                 # forced abi3t module would be unimportable. Downgrade instead.
-                if sys.version_info >= (3, 15):
+                if sys.version_info >= (3, ABI3T_MIN_MINOR):
                     sabi = _SabiMode.ABI3T
                 else:
                     logger.info(
@@ -361,7 +363,17 @@ class Builder:
                     )
                 else:
                     target_minor_version = int(ft[3:-1])
-                    if target_minor_version <= sys.version_info.minor:
+                    if target_minor_version < ABI3T_MIN_MINOR or sys.version_info < (
+                        3,
+                        ABI3T_MIN_MINOR,
+                    ):
+                        # Same gate as the forced limited_api branch above.
+                        logger.info(
+                            "py-api {} ignored, the free-threaded Stable ABI (abi3t) requires CPython >= 3.{}",
+                            ft,
+                            ABI3T_MIN_MINOR,
+                        )
+                    elif target_minor_version <= sys.version_info.minor:
                         sabi = _SabiMode.ABI3T
                         sabi_minor = target_minor_version
                     else:
@@ -386,7 +398,7 @@ class Builder:
             sys.implementation.name == "cpython"
             and sys.version_info[:3] == (3, 13, 4)
             and sys.platform.startswith("win32")
-            and not sysconfig.get_config_var("Py_GIL_DISABLED")
+            and not gil_disabled
         ):  # pragma: nocover
             logger.warning(
                 "Python 3.13.4 on Windows is broken for building, 3.13.5 was rushed out to fix it. Use an older, newer, or free-threaded version instead."

--- a/src/scikit_build_core/builder/macos.py
+++ b/src/scikit_build_core/builder/macos.py
@@ -74,6 +74,7 @@ def get_macosx_deployment_target(
     arm: bool,
     cmake_defines: Mapping[str, str] | None = None,
     cmake_args: Sequence[str] = (),
+    env: Mapping[str, str] | None = None,
 ) -> MacOSVer:
     """
     Get the deployment target used for the wheel platform tag. An explicit
@@ -82,7 +83,12 @@ def get_macosx_deployment_target(
     is the fallback default CMake itself applies). If neither is set, the current
     macOS version is used. If arm=True, then this will always return at least
     (11, 0). Versions after 11 will be normalized to 0 for minor version.
+
+    ``env`` is the build environment (``os.environ`` plus the ``env`` settings
+    table); it defaults to ``os.environ``.
     """
+    if env is None:
+        env = os.environ
     plat_ver_str, _, _ = platform.mac_ver()
     plat_target = normalize_macos_version(plat_ver_str, arm=arm)
 
@@ -97,7 +103,7 @@ def get_macosx_deployment_target(
             logger.debug("CMAKE_OSX_DEPLOYMENT_TARGET is set to {}", cmake_target)
             return norm_cmake_target
 
-    target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", None)
+    target = env.get("MACOSX_DEPLOYMENT_TARGET", None)
     if target is None:
         logger.debug("MACOSX_DEPLOYMENT_TARGET not set, using {}", plat_target)
         return plat_target

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 __all__ = [
+    "ABI3T_MIN_MINOR",
     "get_abi_flags",
     "get_cmake_platform",
     "get_numpy_include_dir",
@@ -34,7 +35,11 @@ __all__ = [
     "get_python_library",
     "get_soabi",
     "info_print",
+    "is_free_threaded",
 ]
+
+# The free-threaded Stable ABI (abi3t, PEP 803) first exists in CPython 3.15.
+ABI3T_MIN_MINOR = 15
 
 
 TARGET_TO_PLAT = {
@@ -74,7 +79,7 @@ def _is_debug_build() -> bool:
     return _config_var_is_set("Py_DEBUG")
 
 
-def _is_free_threaded() -> bool:
+def is_free_threaded() -> bool:
     """Whether the interpreter is free-threaded (the ``t`` ABI flag)."""
     return _config_var_is_set("Py_GIL_DISABLED")
 
@@ -86,7 +91,7 @@ def _windows_lib_names(*, abi3: bool, abi3t: bool) -> list[str]:
     ``Support.cmake``). Debug builds get a ``_d`` suffix (tried first), and
     free-threaded builds get a ``t`` ABI flag.
     """
-    free_threaded = _is_free_threaded()
+    free_threaded = is_free_threaded()
     if abi3 or abi3t:
         # Stable ABI: python3.lib, or python3t.lib on free-threaded abi3t.
         t = "t" if (abi3t and free_threaded) else ""
@@ -122,7 +127,7 @@ def get_python_library(
             minor = "" if (abi3 or abi3t) else sys.version_info[1]
             # Stable-ABI abi3 has no free-threaded variant of its own; only
             # abi3t (already handled) and non-SABI builds pick up the "t" flag.
-            suffix = "t" if abi3t or (not abi3 and _is_free_threaded()) else ""
+            suffix = "t" if abi3t or (not abi3 and is_free_threaded()) else ""
             return Path(result) / f"python3{minor}{suffix}.lib"
 
     # Windows CPython has no LIBDIR/LDLIBRARY/LIBRARY config vars, so construct
@@ -144,7 +149,7 @@ def get_python_library(
     ldlibrarystr = sysconfig.get_config_var("LDLIBRARY")
     librarystr = sysconfig.get_config_var("LIBRARY")
     if abi3 or abi3t:
-        if abi3t and sysconfig.get_config_var("Py_GIL_DISABLED"):
+        if abi3t and is_free_threaded():
             replacement = f"python3{sys.version_info[1]}t"
             target = "python3t"
         else:

--- a/src/scikit_build_core/builder/wheel_tag.py
+++ b/src/scikit_build_core/builder/wheel_tag.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._logging",
     f"{__spec__.parent}.macos",
+    f"{__spec__.parent}.sysconfig",
     "itertools",
     "packaging",
     "packaging.tags",
-    "sysconfig",
 }
 
 import dataclasses
 import itertools
 import os
 import sys
-import sysconfig
 
 import packaging.tags
 
 from .._logging import logger
 from .macos import get_macosx_deployment_target
+from .sysconfig import ABI3T_MIN_MINOR, is_free_threaded
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -82,7 +82,12 @@ class WheelTag:
         build_tag: str = "",
         cmake_defines: Mapping[str, str] | None = None,
         cmake_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
     ) -> Self:
+        # The build environment, which the ``env`` settings table can change;
+        # the tag must describe what CMake built, not the ambient environment.
+        if env is None:
+            env = os.environ
         if build_tag:
             if not build_tag[0].isdigit():
                 msg = f"Unexpected build-tag, must start with a digit, {build_tag!r} invalid"
@@ -103,7 +108,7 @@ class WheelTag:
         pyvers = [interp]
 
         # Check for _PYTHON_HOST_PLATFORM environment variable to override platform
-        host_platform = os.environ.get("_PYTHON_HOST_PLATFORM")
+        host_platform = env.get("_PYTHON_HOST_PLATFORM")
         if host_platform:
             # Convert sysconfig platform format to wheel platform tag format
             plats = [host_platform.replace("-", "_").replace(".", "_")]
@@ -129,6 +134,7 @@ class WheelTag:
                             arm=arm,
                             cmake_defines=cmake_defines,
                             cmake_args=cmake_args,
+                            env=env,
                         ),
                         arch,
                     )
@@ -147,7 +153,7 @@ class WheelTag:
         if py_api:
             pyvers_new = py_api.split(".")
             pytags = [_PyTag(x) for x in pyvers_new]
-            gil_disabled = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+            gil_disabled = is_free_threaded()
             if all(t.is_classic_abi3 or t.is_ft_abi3 for t in pytags):
                 if root_is_purelib:
                     msg = f"Unexpected py-api, since platlib is set to false, must be Pythonless (e.g. py2.py3), not {py_api}"
@@ -181,6 +187,16 @@ class WheelTag:
                 )
                 return None
             target = ft_tags[0]
+            if target.minor < ABI3T_MIN_MINOR or sys.version_info < (
+                3,
+                ABI3T_MIN_MINOR,
+            ):
+                # Same gate as the builder; abi3t (PEP 803) starts at 3.15.
+                logger.debug(
+                    "Ignoring py-api, the free-threaded Stable ABI (abi3t) requires CPython >= 3.{}",
+                    ABI3T_MIN_MINOR,
+                )
+                return None
             if target.minor > sys.version_info.minor:
                 logger.debug(
                     "Ignoring py-api, version (3.{}) is too high", target.minor

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -663,6 +663,52 @@ def test_builder_limited_api_auto_free_threaded(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("minor", "py_api"),
+    [
+        pytest.param(13, "cp313t", id="313t"),
+        pytest.param(14, "cp314t", id="314t"),
+        pytest.param(15, "cp313t", id="315t_asks_313t"),
+        pytest.param(15, "cp314t", id="315t_asks_314t"),
+    ],
+)
+def test_builder_py_api_abi3t_requires_315(tmp_path, monkeypatch, minor, py_api):
+    """py-api gets the same 3.15 abi3t gate as a forced limited_api."""
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: "t" if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    patch_cpython_runtime(monkeypatch)
+    monkeypatch.setattr(sys, "version_info", VersionInfo(3, minor))
+
+    cache = configure_builder_with_limited_api(
+        tmp_path, monkeypatch, limited_api=None, py_api=py_api
+    )
+
+    assert "Development.SABIModule" not in cache
+    assert "Py_TARGET_ABI3T" not in cache
+
+
+def test_builder_py_api_gil_disabled_zero(tmp_path, monkeypatch):
+    """``Py_GIL_DISABLED = 0`` is a GIL build, so classic abi3 stays available."""
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: "0" if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    patch_cpython_runtime(monkeypatch)
+
+    cache = configure_builder_with_limited_api(
+        tmp_path, monkeypatch, limited_api=None, py_api="cp39"
+    )
+
+    assert "Development.SABIModule" in cache
+    assert "Py_TARGET_ABI3T" not in cache
+
+
+@pytest.mark.parametrize(
     ("gil", "soabi", "is_ft"),
     [("t", "abi3t", True), (None, "abi3", False)],
     ids=["free_threaded", "gil"],
@@ -1011,6 +1057,75 @@ def test_wheel_tag_with_abi3t_ignored_on_classic(monkeypatch):
     default_tags = WheelTag.compute_best(["x86_64"])
     tags = WheelTag.compute_best(["x86_64"], py_api="cp315t")
     assert tags == default_tags
+
+
+@pytest.mark.parametrize(
+    ("minor", "py_api"),
+    [
+        pytest.param(13, "cp313t", id="313t"),
+        pytest.param(14, "cp314t", id="314t"),
+        pytest.param(15, "cp313t", id="315t_asks_313t"),
+        pytest.param(15, "cp314t", id="315t_asks_314t"),
+    ],
+)
+def test_wheel_tag_abi3t_requires_315(monkeypatch, minor, py_api):
+    """The free-threaded Stable ABI (abi3t) only exists on CPython 3.15+."""
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: "t" if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "implementation", SimpleNamespace(name="cpython"))
+    monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", "10.10")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9.2", "", ""))
+    monkeypatch.setattr(sys, "version_info", VersionInfo(3, minor))
+
+    default_tags = WheelTag.compute_best(["x86_64"])
+    tags = WheelTag.compute_best(["x86_64"], py_api=py_api)
+    assert tags == default_tags
+
+
+def test_wheel_tag_gil_disabled_zero(monkeypatch):
+    """``Py_GIL_DISABLED = 0`` is a GIL build; ``bool("0")`` would say otherwise."""
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: "0" if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "implementation", SimpleNamespace(name="cpython"))
+    monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", "10.10")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9.2", "", ""))
+
+    tags = WheelTag.compute_best(["x86_64"], py_api="cp39")
+    assert str(tags) == "cp39-abi3-macosx_10_10_x86_64"
+
+
+def test_wheel_tag_env_argument(monkeypatch):
+    """The tag reads the passed env, not ``os.environ``."""
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: None if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delenv("MACOSX_DEPLOYMENT_TARGET", raising=False)
+    monkeypatch.delenv("_PYTHON_HOST_PLATFORM", raising=False)
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9.2", "", ""))
+
+    tags = WheelTag.compute_best(
+        ["x86_64"], py_api="py3", env={"MACOSX_DEPLOYMENT_TARGET": "10.12"}
+    )
+    assert str(tags) == "py3-none-macosx_10_12_x86_64"
+
+    tags = WheelTag.compute_best(
+        ["x86_64"], py_api="py3", env={"_PYTHON_HOST_PLATFORM": "macosx-11.0-arm64"}
+    )
+    assert str(tags) == "py3-none-macosx_11_0_arm64"
 
 
 def test_wheel_tag_host_platform_override(monkeypatch):

--- a/tests/test_common_wheel_helpers.py
+++ b/tests/test_common_wheel_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import platform
+import sys
 from pathlib import Path
 
 import pytest
@@ -11,7 +13,7 @@ from scikit_build_core.build.common_wheel_helpers import (
     get_wheel_tag,
     prepare_wheel_dirs,
 )
-from scikit_build_core.settings.skbuild_model import ScikitBuildSettings
+from scikit_build_core.settings.skbuild_model import EnvValue, ScikitBuildSettings
 
 WHEEL_SUBDIRS = {"data", "headers", "scripts", "null", "metadata"}
 
@@ -41,6 +43,24 @@ def test_targetlib_honors_explicit_platlib() -> None:
 def test_purelib_tag_is_any() -> None:
     tags = get_wheel_tag(ScikitBuildSettings(), targetlib="purelib")
     assert tags.arch == "any"
+
+
+def test_wheel_tag_uses_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The env table is applied to the CMake environment, so the tag must see it
+    # too or the wheel is labelled for a different platform than it was built for.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9.2", "", ""))
+    monkeypatch.delenv("ARCHFLAGS", raising=False)
+    monkeypatch.delenv("MACOSX_DEPLOYMENT_TARGET", raising=False)
+
+    settings = ScikitBuildSettings()
+    settings.env = {
+        "ARCHFLAGS": EnvValue("-arch arm64 -arch x86_64"),
+        "MACOSX_DEPLOYMENT_TARGET": EnvValue("10.12"),
+    }
+
+    tags = get_wheel_tag(settings, targetlib="platlib")
+    assert tags.archs == ["macosx_10_12_universal2"]
 
 
 def test_platlib_layout_created(tmp_path: Path) -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes items 24, 27, 30 of #1541.

Three wheel-tag consistency problems.

**abi3t needs CPython 3.15 (item 24).** `wheel.py-api = "cp313t"` or `"cp314t"`
was accepted on free-threaded 3.13t/3.14t, but the free-threaded Stable ABI
(abi3t, PEP 803) only exists on CPython 3.15+. The forced `limited_api` path
already had this gate; the `py-api` path did not. Both `Builder.configure` and
`WheelTag` now apply it, and both also reject a requested minor below 3.15
(`cp314t` on a 3.15t interpreter). The build falls back to a normal, non-abi3t
wheel and logs why.

**One free-threaded check (item 27).** `Py_GIL_DISABLED` was read with raw
truthiness in four places, so the value `"0"` read as free-threaded
(`bool("0")` is `True`). `sysconfig._is_free_threaded` is now the public
`is_free_threaded()` and is used at every site.

**The tag follows the build environment (item 30).** `tool.scikit-build.env` is
applied to the CMake environment, so CMake could build for the arches in
`ARCHFLAGS` there while the tag, which read `os.environ`, described a different
platform. `WheelTag.compute_best` and `get_macosx_deployment_target` take an
`env` mapping (default `os.environ`), and `get_wheel_tag` builds that mapping
the same way `Builder` does. This covers `ARCHFLAGS`,
`MACOSX_DEPLOYMENT_TARGET`, `_PYTHON_HOST_PLATFORM` and `CMAKE_ARGS`. The
`python -m scikit_build_core.builder.wheel_tag` CLI keeps the `os.environ`
default. The setuptools plugin computes its platform name through setuptools,
not `WheelTag`, so it is unchanged.

The `py-api` documentation now states the 3.15 floor.
