### PR TITLE
fix: honor staged Python development environment hints

### DIFF
--- a/docs/guide/crosscompile.md
+++ b/docs/guide/crosscompile.md
@@ -119,6 +119,12 @@ also need to use `wheel.tags` to manually specify the wheel tags to use for the
 file and `cmake.python-hints = false` if the target python should be detected
 using the toolchain file instead.
 
+For a staged Python installation, set `PYTHON_INCLUDE_DIR` and the regular-build
+`PYTHON_LIBRARY` in the effective build environment. These non-empty values are
+used as Python development hints; an unset or empty value keeps the normal
+`sysconfig`/`DIST_EXTRA_CONFIG` fallback. The regular library hint is not used
+for stable-ABI (`abi3`/`abi3t`) builds.
+
 :::{note}
 
 Because most of the logic in [`FindPython`] is gated by the

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -417,7 +417,8 @@ class Builder:
                 cache_config[f"{prefix}_INCLUDE_DIR"] = python_include_dir
                 cache_config[f"{prefix}_FIND_REGISTRY"] = "NEVER"
                 # Interpreter-less FindPython rejects the free-threaded "t" ABI
-                # unless the 4-tuple (3.30+) FIND_ABI requests it.
+                # unless the 4-tuple (3.30+) FIND_ABI requests it. Written as a
+                # non-cache list so CMake does not drop the gil_disabled flag.
                 if gil_disabled and self.config.cmake.version >= Version("3.30"):
                     cache_config[f"{prefix}_FIND_ABI"] = "ANY;ANY;ANY;ON"
                 # An automatically detected Windows library is

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -395,12 +395,13 @@ class Builder:
         if self.settings.cmake.python_hints:
             # Only computed when the hints are used; get_numpy_include_dir imports NumPy.
             python_library = get_python_library(self.config.env, abi3=False)
+            python_library_from_env = self.config.env.get("PYTHON_LIBRARY")
             python_sabi_library = None
             if sabi == _SabiMode.ABI3T:
                 python_sabi_library = get_python_library(self.config.env, abi3t=True)
             elif sabi == _SabiMode.ABI3:
                 python_sabi_library = get_python_library(self.config.env, abi3=True)
-            python_include_dir = get_python_include_dir()
+            python_include_dir = get_python_include_dir(self.config.env)
             numpy_include_dir = get_numpy_include_dir()
 
             # Classic Find Python
@@ -419,18 +420,22 @@ class Builder:
                 # unless the 4-tuple (3.30+) FIND_ABI requests it.
                 if gil_disabled and self.config.cmake.version >= Version("3.30"):
                     cache_config[f"{prefix}_FIND_ABI"] = "ANY;ANY;ANY;ON"
-                # On Windows the library is constructed and existence-checked,
-                # so this is reliable. On POSIX a library hint can break
-                # FindPython (which resolves it fine on its own), so this
-                # stays Windows-only. In SABI mode the hint is skipped: CMake
-                # 4.4's FindPython ingests it even when Development.Module is
-                # not requested, disabling the SABI-only version fallback and
-                # rejecting python3.lib (Interpreter + Development.SABIModule
-                # then both report not found).
+                # An automatically detected Windows library is
+                # existence-checked, while an explicit environment hint is
+                # used on every platform. On POSIX, the automatic library can
+                # break FindPython, which resolves it fine on its own. In SABI
+                # mode the regular hint is skipped: CMake 4.4's FindPython
+                # ingests it even when Development.Module is not requested,
+                # disabling the SABI-only version fallback and rejecting
+                # python3.lib (Interpreter + Development.SABIModule then both
+                # report not found).
                 if (
                     python_library
                     and sabi == _SabiMode.NONE
-                    and sysconfig.get_platform().startswith("win")
+                    and (
+                        bool(python_library_from_env)
+                        or sysconfig.get_platform().startswith("win")
+                    )
                 ):
                     cache_config[f"{prefix}_LIBRARY"] = python_library
                 if python_sabi_library and sysconfig.get_platform().startswith("win"):

--- a/src/scikit_build_core/builder/sysconfig.py
+++ b/src/scikit_build_core/builder/sysconfig.py
@@ -111,6 +111,13 @@ def _is_dir(path: Path) -> bool:
 def get_python_library(
     env: Mapping[str, str], *, abi3: bool = False, abi3t: bool = False
 ) -> Path | None:
+    # A regular Python library supplied by the build environment is the most
+    # specific cross-compilation hint. Do not reuse it for the stable ABI:
+    # ``PYTHON_LIBRARY`` may be a versioned target library, while ``abi3`` and
+    # ``abi3t`` require their own import-library names.
+    if (python_library := env.get("PYTHON_LIBRARY")) and not (abi3 or abi3t):
+        return Path(python_library)
+
     # When cross-compiling, check DIST_EXTRA_CONFIG first
     config_file = env.get("DIST_EXTRA_CONFIG", None)
     if config_file and Path(config_file).is_file():
@@ -203,7 +210,11 @@ def get_python_library(
     return None
 
 
-def get_python_include_dir() -> Path:
+def get_python_include_dir(env: Mapping[str, str] | None = None) -> Path:
+    if env is None:
+        env = os.environ
+    if python_include_dir := env.get("PYTHON_INCLUDE_DIR"):
+        return Path(python_include_dir)
     return Path(sysconfig.get_path("include"))
 
 

--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -197,6 +197,13 @@ class CMaker:
                     # Convert to CMake's internal path format
                     str_value = str(value).replace("\\", "/")
                     f.write(f'set({key} [===[{str_value}]===] CACHE PATH "" FORCE)\n')
+                elif key.endswith("_FIND_ABI"):
+                    # FindPython reads *_FIND_ABI as a hint list. A CACHE STRING
+                    # 4-tuple is one string, so CMake 3.30+ treats gil_disabled
+                    # as omitted (OFF) and rejects free-threaded Interpreter
+                    # and Development.Module.
+                    parts = " ".join(f'"{part}"' for part in str(value).split(";"))
+                    f.write(f"set({key} {parts})\n")
                 else:
                     f.write(f'set({key} [===[{value}]===] CACHE STRING "" FORCE)\n')
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import platform
 import pprint
+import shutil
 import sys
 import sysconfig
 import typing
@@ -185,8 +186,13 @@ def test_macos_version_cmake_osx_deployment_target(
     assert str(result) == answer
 
 
-def test_get_python_include_dir():
+def test_get_python_include_dir(tmp_path):
     assert get_python_include_dir().is_dir()
+    target = tmp_path / "staged" / "include"
+    assert get_python_include_dir({"PYTHON_INCLUDE_DIR": str(target)}) == target
+    assert get_python_include_dir({"PYTHON_INCLUDE_DIR": ""}) == Path(
+        sysconfig.get_path("include")
+    )
 
 
 def test_get_python_library():
@@ -224,6 +230,36 @@ def test_get_python_library():
         # POSIX usually returns None (FindPython resolves it itself); if a real
         # library does resolve, it must be an existing file.
         assert lib is None or lib.is_file()
+
+
+def test_get_python_library_environment_hint_does_not_leak_into_sabi(tmp_path):
+    target_library = tmp_path / "staged" / "libpython-target.so"
+    env = {"PYTHON_LIBRARY": str(target_library)}
+
+    assert get_python_library(env) == target_library
+    assert get_python_library({"PYTHON_LIBRARY": ""}) == get_python_library({})
+    assert get_python_library(env, abi3=True) != target_library
+    assert get_python_library(env, abi3t=True) != target_library
+
+
+def test_get_python_library_environment_hint_preserves_dist_extra_config(tmp_path):
+    config_path = tmp_path / "tmp.cfg"
+    config_path.write_text(
+        """\
+[build_ext]
+library_dirs=staged/libs
+    """,
+        encoding="utf-8",
+    )
+    target_library = tmp_path / "target" / "python-target.lib"
+    env = {
+        "PYTHON_LIBRARY": str(target_library),
+        "DIST_EXTRA_CONFIG": str(config_path),
+    }
+
+    assert get_python_library(env) == target_library
+    assert get_python_library(env, abi3=True) == Path("staged/libs/python3.lib")
+    assert get_python_library(env, abi3t=True) == Path("staged/libs/python3t.lib")
 
 
 @pytest.mark.parametrize("free_threaded", [False, True])
@@ -576,6 +612,156 @@ def test_builder_no_python_hints_skips_lookups(tmp_path, monkeypatch):
 
     cache = config.init_cache_file.read_text(encoding="utf-8")
     assert "Python_EXECUTABLE" not in cache
+
+
+def test_builder_python_hints_use_effective_environment_in_cmake(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The environment hints must reach a real FindPython configure."""
+    cmake_path = shutil.which("cmake")
+    if cmake_path is None:
+        pytest.skip("CMake is required for the configure-level Python hint test")
+
+    host_include = Path(sysconfig.get_path("include"))
+    host_library = get_python_library({})
+    if not host_include.is_dir() or host_library is None or not host_library.is_file():
+        pytest.skip("a complete host Python development installation is required")
+
+    staged_include = tmp_path / "staged" / "include"
+    shutil.copytree(host_include, staged_include)
+    staged_library = tmp_path / "staged" / "lib" / host_library.name
+    staged_library.parent.mkdir(parents=True)
+    shutil.copy2(host_library, staged_library)
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    (source_dir / "CMakeLists.txt").write_text(
+        """\
+cmake_minimum_required(VERSION 3.15)
+project(python_hints NONE)
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+""",
+        encoding="utf-8",
+    )
+
+    config = CMaker(
+        CMake.default_search(),
+        source_dir=source_dir,
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+    config.env.update(
+        {
+            "PYTHON_INCLUDE_DIR": str(staged_include),
+            "PYTHON_LIBRARY": str(staged_library),
+        }
+    )
+    monkeypatch.setattr(Builder, "_get_entry_point_search_path", lambda *_: {})
+
+    Builder(
+        settings=ScikitBuildSettings(search=SearchSettings(site_packages=False)),
+        config=config,
+    ).configure(defines={})
+
+    cache = (config.build_dir / "CMakeCache.txt").read_text(encoding="utf-8")
+    include_value = str(staged_include).replace("\\", "/")
+    library_value = str(staged_library).replace("\\", "/")
+    assert f"Python_INCLUDE_DIR:PATH={include_value}" in cache
+    assert f"Python_LIBRARY:PATH={library_value}" in cache
+
+
+def test_builder_explicit_cmake_python_defines_override_environment_hints(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+    config.env.update(
+        {
+            "PYTHON_INCLUDE_DIR": "from-environment/include",
+            "PYTHON_LIBRARY": "from-environment/python.lib",
+        }
+    )
+    configure = unittest.mock.Mock()
+    monkeypatch.setattr(config, "configure", configure)
+    monkeypatch.setattr(Builder, "_get_entry_point_search_path", lambda *_: {})
+
+    explicit = {
+        "Python_INCLUDE_DIR": CMakeSettingsDefine("explicit/include"),
+        "Python_LIBRARY": CMakeSettingsDefine("explicit/python.lib"),
+    }
+    Builder(
+        settings=ScikitBuildSettings(
+            cmake=CMakeSettings(define=explicit),
+            search=SearchSettings(site_packages=False),
+        ),
+        config=config,
+    ).configure(defines={})
+
+    assert configure.call_args.kwargs["defines"]["Python_INCLUDE_DIR"] == str(
+        explicit["Python_INCLUDE_DIR"]
+    )
+    assert configure.call_args.kwargs["defines"]["Python_LIBRARY"] == str(
+        explicit["Python_LIBRARY"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("limited_api", "environment_library", "modern_library"),
+    [
+        (None, "target/python.lib", True),
+        (None, None, False),
+        (True, "target/python.lib", False),
+    ],
+    ids=["regular-explicit", "regular-automatic", "stable-abi-explicit"],
+)
+def test_builder_environment_library_hint_posix_modern_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    limited_api: bool | None,
+    environment_library: str | None,
+    modern_library: bool,
+) -> None:
+    """Only explicit regular hints reach modern FindPython on POSIX."""
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    config = CMaker(
+        CMake(Version("3.30"), Path("cmake")),
+        source_dir=source_dir,
+        build_dir=tmp_path / "build",
+        build_type="Release",
+    )
+    config.env["PYTHON_INCLUDE_DIR"] = "target/include"
+    if environment_library is not None:
+        config.env["PYTHON_LIBRARY"] = environment_library
+    configure = unittest.mock.Mock()
+    monkeypatch.setattr(config, "configure", configure)
+    monkeypatch.setattr(Builder, "_get_entry_point_search_path", lambda *_: {})
+    monkeypatch.setattr(sysconfig, "get_platform", lambda *_: "linux-x86_64")
+    patch_cpython_runtime(monkeypatch)
+
+    Builder(
+        settings=ScikitBuildSettings(search=SearchSettings(site_packages=False)),
+        config=config,
+    ).configure(defines={}, limited_api=limited_api)
+
+    cache = config.init_cache_file.read_text(encoding="utf-8")
+    assert ("set(PYTHON_LIBRARY [===[target/python.lib]===] CACHE PATH" in cache) == (
+        environment_library is not None
+    )
+    assert ("set(Python_LIBRARY " in cache) == modern_library
+    assert ("set(Python3_LIBRARY " in cache) == modern_library
+    assert ("set(Python_LIBRARY [===[target/python.lib]===] CACHE PATH" in cache) == (
+        modern_library
+    )
+    assert (
+        "set(Python3_LIBRARY [===[target/python.lib]===] CACHE PATH" in cache
+    ) == modern_library
 
 
 def patch_cpython_runtime(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -627,7 +627,9 @@ def test_builder_python_hints_use_effective_environment_in_cmake(
     if not host_include.is_dir() or host_library is None or not host_library.is_file():
         pytest.skip("a complete host Python development installation is required")
 
-    staged_include = tmp_path / "staged" / "include"
+    # Keep the host include directory name (e.g. python3.14t) so CMake 3.30+
+    # FindPython can recover the free-threaded ABI when pyconfig.h is a wrapper.
+    staged_include = tmp_path / "staged" / "include" / host_include.name
     shutil.copytree(host_include, staged_include)
     staged_library = tmp_path / "staged" / "lib" / host_library.name
     staged_library.parent.mkdir(parents=True)
@@ -728,6 +730,14 @@ def test_builder_environment_library_hint_posix_modern_cache(
     modern_library: bool,
 ) -> None:
     """Only explicit regular hints reach modern FindPython on POSIX."""
+    # Pin a GIL-enabled CPython so limited_api=True is honored. Free-threaded
+    # 3.14 ignores Limited API (no abi3t yet), which would write Python_LIBRARY.
+    get_config_var = sysconfig.get_config_var
+    monkeypatch.setattr(
+        sysconfig,
+        "get_config_var",
+        lambda x: None if x == "Py_GIL_DISABLED" else get_config_var(x),
+    )
     source_dir = tmp_path / "src"
     source_dir.mkdir()
     config = CMaker(
@@ -901,7 +911,7 @@ def test_builder_free_threaded_find_abi(
     )
 
     for prefix in ("Python", "Python3"):
-        line = f"set({prefix}_FIND_ABI [===[ANY;ANY;ANY;ON]===] CACHE STRING"
+        line = f'set({prefix}_FIND_ABI "ANY" "ANY" "ANY" "ON")'
         assert (line in cache) == expected
 
 


### PR DESCRIPTION
## Summary

Honor non-empty `PYTHON_INCLUDE_DIR` and `PYTHON_LIBRARY` from the effective build environment when constructing Python development hints. This addresses the staged-path selection described in #952 and the maintainer's proposed direction there.

- Pass the effective environment to include-directory lookup and prefer explicit regular-library hints over automatic detection.
- Pass an explicit regular-library hint to modern FindPython on POSIX as well as Windows, without adding automatic POSIX library hints.
- Preserve empty-value fallback, existing `DIST_EXTRA_CONFIG` handling, stable-ABI library selection, and explicit CMake define precedence.
- Document the environment hints in the manual cross-compilation guide.

## Validation

The new real-CMake configure regression failed on the base commit because the cache selected host development paths instead of distinct staged paths. It passes with this change, using copied matching host headers and a library.

- Builder tests: 123 passed, including real configure, explicit/automatic POSIX hints, regular/stable ABI, empty fallback, and CMake-define precedence.
- CMake configuration/AST tests: 65 passed, 6 skipped.
- Changed Python files: Ruff check and format passed.
- Sphinx nitpicky HTML build: succeeded, 44 source pages.
- `git diff --check`: passed.

Validation ran on Windows. The broader suite run on the initial implementation reported 1039 passed, 25 skipped, 5 xfailed, and 5 failures: four Windows symlink-privilege failures and one missing local pybind11 CMake package. The pybind11 test passed after correcting local discovery; the final POSIX cache condition was subsequently covered by the full Builder suite. Existing mypy diagnostics/toolchain limitations remain documented; a fully green repository-wide run is not claimed.

This verifies staged path selection through real CMake, not a complete Yocto/BitBake or ARM build. No dependency, toolchain, public configuration setting, or CI change is included.

Refs #952.
