### PR TITLE
perf: scan entry points once for all groups

### DIFF
--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -45,7 +45,7 @@ else:
         return importlib.metadata.entry_points()
 
     def entry_points(*, group: str) -> EntryPoints:
-        return all_entry_points().get(group, [])
+        return all_entry_points().get(group, [])  # pylint: disable=no-member
 
 
 def __dir__() -> list[str]:

--- a/src/scikit_build_core/_compat/importlib/metadata.py
+++ b/src/scikit_build_core/_compat/importlib/metadata.py
@@ -11,28 +11,41 @@ if TYPE_CHECKING:
         from importlib.metadata import EntryPoint
 
         EntryPoints = list[EntryPoint]
+    elif sys.version_info < (3, 12):
+        from importlib.metadata import EntryPoints, SelectableGroups
     else:
         from importlib.metadata import EntryPoints
 
-__all__ = ["cached_entry_points", "entry_points"]
+        SelectableGroups = EntryPoints
+
+__all__ = ["all_entry_points", "entry_points"]
 
 
-def entry_points(*, group: str) -> EntryPoints:
-    if sys.version_info >= (3, 10):
-        return importlib.metadata.entry_points(group=group)
+if sys.version_info >= (3, 10):
 
-    epg = importlib.metadata.entry_points()
-    return epg.get(group, [])  # pylint: disable=no-member
+    @functools.cache
+    def all_entry_points() -> SelectableGroups:
+        """Scan the installed distributions once; every group shares the result.
 
+        Call ``all_entry_points.cache_clear()`` if the entry points change.
+        """
+        return importlib.metadata.entry_points()
 
-@functools.cache
-def cached_entry_points(*, group: str) -> EntryPoints:
-    """Like ``entry_points``, but scans the installed distributions only once.
+    def entry_points(*, group: str) -> EntryPoints:
+        """Entry points for one group, from the cached scan.
 
-    ``entry_points`` is read from the module global, so a monkeypatch of it is
-    seen. Call ``cached_entry_points.cache_clear()`` if the entry points change.
-    """
-    return entry_points(group=group)
+        Callers read this from the module global, so a monkeypatch of it is seen.
+        """
+        return all_entry_points().select(group=group)
+
+else:
+
+    @functools.cache
+    def all_entry_points() -> dict[str, EntryPoints]:
+        return importlib.metadata.entry_points()
+
+    def entry_points(*, group: str) -> EntryPoints:
+        return all_entry_points().get(group, [])
 
 
 def __dir__() -> list[str]:

--- a/src/scikit_build_core/builder/_load_provider.py
+++ b/src/scikit_build_core/builder/_load_provider.py
@@ -189,9 +189,9 @@ def load_entry_provider(provider: str | Mapping[str, Any]) -> DMProtocols:
             raise TypeError(msg)
         return load_provider(module, path)
 
-    from .._compat.importlib.metadata import cached_entry_points
+    from .._compat.importlib.metadata import entry_points
 
-    eps = cached_entry_points(group="dynamic_metadata.provider")
+    eps = entry_points(group="dynamic_metadata.provider")
     matches = [ep for ep in eps if ep.name == provider]
     if not matches:
         import difflib

--- a/src/scikit_build_core/builder/builder.py
+++ b/src/scikit_build_core/builder/builder.py
@@ -234,7 +234,7 @@ class Builder:
     def _get_entry_point_search_path(self, entry_point: str) -> dict[str, list[Path]]:
         """Get the search path dict from the entry points"""
         search_paths = {}
-        eps = metadata.cached_entry_points(group=entry_point)
+        eps = metadata.entry_points(group=entry_point)
         if eps:
             logger.debug(
                 "Loading search paths {} from entry-points: {}", entry_point, len(eps)

--- a/src/scikit_build_core/settings/_load_entrypoint_config.py
+++ b/src/scikit_build_core/settings/_load_entrypoint_config.py
@@ -81,7 +81,7 @@ def _load_group(
 ) -> list[tuple[str, str, dict[str, object]]]:
     providers: list[tuple[str, str, dict[str, object]]] = []
     by_name: dict[str, list[EntryPoint]] = {}
-    for ep in metadata.cached_entry_points(group=group):
+    for ep in metadata.entry_points(group=group):
         by_name.setdefault(ep.name, []).append(ep)
     for name in sorted(by_name):
         eps = by_name[name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,11 +504,11 @@ def pytest_report_header() -> str:
 @pytest.fixture(autouse=True)
 def _clear_caches() -> Iterable[None]:
     """Keep process-wide caches from leaking between tests that fake their input."""
-    from scikit_build_core._compat.importlib.metadata import cached_entry_points
+    from scikit_build_core._compat.importlib.metadata import all_entry_points
     from scikit_build_core.builder._known_wheels import is_known_platform
 
-    for cached in (cached_entry_points, is_known_platform):
+    for cached in (all_entry_points, is_known_platform):
         cached.cache_clear()
     yield
-    for cached in (cached_entry_points, is_known_platform):
+    for cached in (all_entry_points, is_known_platform):
         cached.cache_clear()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1545, from the review there. `cached_entry_points` cached per group, so the three CMake search-path groups (`cmake.module`, `cmake.prefix`, `cmake.root`) still scanned the installed distributions three times per configure.

The compat shim now caches the unfiltered `importlib.metadata.entry_points()` result in `all_entry_points` and selects the group from it. `entry_points(group=...)` keeps its signature and stays the module global that tests monkeypatch. The conftest fixture clears `all_entry_points` instead.
