### PR TITLE
fix(templates): abi3 templates need CMake 3.26

### DIFF
--- a/src/scikit_build_core/resources/templates/abi3/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/abi3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.4)
+cmake_minimum_required(VERSION 3.26...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/src/scikit_build_core/resources/templates/abi3t/CMakeLists.txt
+++ b/src/scikit_build_core/resources/templates/abi3t/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.4)
+cmake_minimum_required(VERSION 3.26...4.4)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -61,6 +61,18 @@ def test_init_generates_files(backend: str, tmp_path: Path) -> None:
     assert "${SKBUILD_PROJECT_NAME}" in cmake
 
 
+@pytest.mark.parametrize("backend", ["abi3", "abi3t"])
+def test_init_sabi_requires_cmake_326(backend: str, tmp_path: Path) -> None:
+    # Development.SABIModule needs CMake 3.26+, and the declared minimum is
+    # what scikit-build-core reads to select a CMake.
+    project = tmp_path / "proj"
+    generate_project(project, backend, "my-pkg")
+
+    cmake = (project / "CMakeLists.txt").read_text()
+    assert "cmake_minimum_required(VERSION 3.26" in cmake
+    assert "Development.SABIModule" in cmake
+
+
 def test_init_default_name_from_directory(tmp_path: Path) -> None:
     project = tmp_path / "Spam.Eggs"
     main(["init", str(project), "--backend", "c"])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of item 34 of #1541.

The `abi3` and `abi3t` init templates use `Development.SABIModule`, which needs CMake 3.26, but declared 3.15 as the minimum. The declared minimum also selects the CMake to use, so it is now 3.26.

Split out of #1555.