### PR TITLE
fix: keep building when the CMake file-api reply is broken

### DIFF
--- a/src/scikit_build_core/cmake.py
+++ b/src/scikit_build_core/cmake.py
@@ -61,6 +61,22 @@ def __dir__() -> list[str]:
 DIR = Path(__file__).parent.resolve()
 
 
+def _load_file_api(reply_dir: Path) -> Index | None:
+    """Read a file-api reply, returning None if it cannot be parsed."""
+    try:
+        return load_reply_dir(reply_dir)
+    except (
+        ExceptionGroup,
+        IndexError,
+        OSError,
+        TypeError,
+        json.JSONDecodeError,
+    ) as exc:
+        logger.debug("Could not parse CMake file-api")
+        logger.debug(str(exc))
+    return None
+
+
 @dataclasses.dataclass(frozen=True)
 class CMake:
     version: Version
@@ -314,12 +330,8 @@ class CMaker:
             msg = "CMake configuration failed"
             raise FailedLiveProcessError(msg) from None
 
-        try:
-            if self._file_api_query.exists():
-                self.file_api = load_reply_dir(self._file_api_query)
-        except ExceptionGroup as exc:
-            logger.debug("Could not parse CMake file-api")
-            logger.debug(str(exc))
+        if self._file_api_query.exists():
+            self.file_api = _load_file_api(self._file_api_query)
 
     def _compute_build_args(
         self,

--- a/tests/test_fileapi.py
+++ b/tests/test_fileapi.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from packaging.specifiers import SpecifierSet
 
-from scikit_build_core.cmake import CMake, CMaker
+from scikit_build_core.cmake import CMake, CMaker, _load_file_api
 from scikit_build_core.file_api._cattrs_converter import (
     load_reply_dir as load_reply_dir_cattrs,
 )
@@ -217,6 +217,23 @@ def test_no_index(tmp_path):
 
     with pytest.raises(IndexError):
         load_reply_dir_cattrs(tmp_path)
+
+
+@pytest.mark.parametrize("kind", ["empty", "bad-json", "unreadable", "bad-types"])
+def test_load_file_api_degrades_on_broken_reply(kind, tmp_path):
+    # A broken file-api reply must not stop the build; the caller only loses
+    # the introspection data.
+    reply_dir = tmp_path / "reply"
+    reply_dir.mkdir()
+    index = reply_dir / "index-0.json"
+    if kind == "bad-json":
+        index.write_text("{not json", encoding="utf-8")
+    elif kind == "unreadable":
+        index.mkdir()
+    elif kind == "bad-types":
+        index.write_text('{"cmake": 5, "objects": 6}', encoding="utf-8")
+
+    assert _load_file_api(reply_dir) is None
 
 
 @pytest.mark.configure


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of item 34 of #1541.

A corrupt or unreadable CMake file-api reply raised `IndexError`, `OSError`, `JSONDecodeError`, or `TypeError` out of `configure`; only `ExceptionGroup` was caught. The reply is now read through a helper that logs and returns `None` for all of these, so the build continues without the introspection data.

Split out of #1555.