### PR TITLE
fix: correct riscv64 manylinux tag for cmake wheels

### DIFF
--- a/src/scikit_build_core/resources/known_wheels.toml
+++ b/src/scikit_build_core/resources/known_wheels.toml
@@ -15,7 +15,7 @@ known-wheels = [
     "manylinux_2_17_ppc64le",
     "manylinux_2_17_aarch64",
     "manylinux_2_31_armv7l",
-    "manylinux_2_35_riscv64",
+    "manylinux_2_31_riscv64",
     "manylinux_2_17_x86_64",
     "manylinux_2_17_i686",
     "manylinux_2_12_x86_64",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes item 31 of #1541. Split out of #1557.

The cmake entry in `known_wheels.toml` listed `manylinux_2_35_riscv64`. PyPI
cmake wheels ship `manylinux_2_31_riscv64` (checked against the PyPI simple
index), which agrees with the ninja entry.